### PR TITLE
Close #42 - Add `Coercible` to type-safely cast refined type to the actual type

### DIFF
--- a/modules/refined4s-core/shared/src/main/scala/refined4s/Coercible.scala
+++ b/modules/refined4s-core/shared/src/main/scala/refined4s/Coercible.scala
@@ -1,0 +1,34 @@
+package refined4s
+
+/** The idea of Coercible is from scala-newtype
+  * https://github.com/estatico/scala-newtype/blob/201dad6b0c628caa9a80141e304ca70716d601a8/shared/src/main/scala/io/estatico/newtype/Coercible.scala
+  * It does exactly the same thing as scala-newtype's.
+  *
+  * @author Kevin Lee
+  * @since 2023-12-02
+  */
+trait Coercible[A, B] {
+  @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
+  final inline def apply(a: A): B = a.asInstanceOf[B] // scalafix:ok DisableSyntax.asInstanceOf
+}
+object Coercible {
+
+  def apply[A, B](using ev: Coercible[A, B]): Coercible[A, B] = ev
+
+  // scalafix:off DisableSyntax.asInstanceOf
+  @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
+  def instance[A, B]: Coercible[A, B] = coercible.asInstanceOf[Coercible[A, B]]
+  // scalafix:on
+
+  private object coercible extends Coercible[Any, Any]
+
+  /* For type constructors */
+  given unsafeWrapM[M[*], A, B](
+    using Coercible[A, B]
+  ): Coercible[M[A], M[B]] = Coercible.instance
+
+  /* For nested type constructors */
+  given unsafeWrapMOfM[M1[*], M2[*], A, B](
+    using Coercible[M2[A], M2[B]]
+  ): Coercible[M1[M2[A]], M1[M2[B]]] = Coercible.instance
+}

--- a/modules/refined4s-core/shared/src/test/scala/refined4s/CoercibleSpec.scala
+++ b/modules/refined4s-core/shared/src/test/scala/refined4s/CoercibleSpec.scala
@@ -1,0 +1,75 @@
+package refined4s
+
+import cats.syntax.all.*
+
+import hedgehog.*
+import hedgehog.runner.*
+
+/** @author Kevin Lee
+  * @since 2023-12-02
+  */
+object CoercibleSpec extends Properties {
+  override def tests: List[Test] = List(
+    property("test Coercible[A, B].apply", testApply),
+    property("test Coercible[A, B].instance.apply", testApply),
+    property("Coercible.unsafeWrapM[M[*], A, B](M[A]) should return M[B]", testUnsafeWrapM),
+    property("Coercible.unsafeWrapMOfM[M1[*], M2[*], A, B](M1[M2[A]]) should return M1[M2[B]]", testUnsafeWrapMOfM),
+  )
+
+  def testApply: Property =
+    for {
+      s        <- Gen.string(Gen.unicode, Range.linear(1, 10)).log("s")
+      testType <- Gen.constant(TestType(s)).log("testType")
+    } yield {
+      val expected = s
+      val actual   = Coercible[TestType, String](testType)
+      actual ==== expected
+    }
+
+  def testInstanceApply: Property =
+    for {
+      s        <- Gen.string(Gen.unicode, Range.linear(1, 10)).log("s")
+      testType <- Gen.constant(TestType(s)).log("testType")
+    } yield {
+      val expected  = s
+      val coercible = Coercible.instance[TestType, String]
+
+      val actual = coercible(testType)
+      actual ==== expected
+    }
+
+  def testUnsafeWrapM: Property =
+    for {
+      s        <- Gen.string(Gen.unicode, Range.linear(1, 10)).log("s")
+      testType <- Gen.constant(TestType(s).some).log("testType")
+    } yield {
+      val expected  = s.some
+      val coercible = Coercible.unsafeWrapM[Option, TestType, String]
+      val actual    = coercible(testType)
+      actual ==== expected
+    }
+
+  def testUnsafeWrapMOfM: Property =
+    for {
+      s        <- Gen.string(Gen.unicode, Range.linear(1, 10)).log("s")
+      testType <- Gen.constant(List(TestType(s).some)).log("testType")
+    } yield {
+      val expected  = List(s.some)
+      val coercible = Coercible.unsafeWrapMOfM[List, Option, TestType, String]
+      val actual    = coercible(testType)
+      actual ==== expected
+    }
+
+  trait TestNewtype[A] {
+    type Type
+
+    inline given unwrap: Coercible[Type, A] = Coercible.instance
+  }
+  type TestType = TestType.Type
+  object TestType extends TestNewtype[String] {
+    override opaque type Type = String
+
+    def apply(s: String): Type = s
+
+  }
+}


### PR DESCRIPTION
Close #42 - Add `Coercible` to type-safely cast refined type to the actual type