### PR TITLE
Close #46 - Make RefinedBase extend NewtypeBase to support unwrapping (getting value) for Refined and InlinedRefined types with Coercible

### DIFF
--- a/modules/refined4s-core/shared/src/main/scala/refined4s/InlinedRefined.scala
+++ b/modules/refined4s-core/shared/src/main/scala/refined4s/InlinedRefined.scala
@@ -7,7 +7,7 @@ import scala.compiletime.*
   */
 trait InlinedRefined[A] extends RefinedBase[A] {
 
-  inline def inlinedInvalidReason(inline a: A): String
+  inline def inlinedInvalidReason(inline a: A): String = invalidReason(a)
 
   inline def inlinedPredicate(inline a: A): Boolean
 

--- a/modules/refined4s-core/shared/src/main/scala/refined4s/RefinedBase.scala
+++ b/modules/refined4s-core/shared/src/main/scala/refined4s/RefinedBase.scala
@@ -4,12 +4,10 @@ package refined4s
   * @author Kevin Lee
   * @since 2022-03-23
   */
-trait RefinedBase[A] {
+trait RefinedBase[A] extends NewtypeBase[A] {
   import compiletime.*
 
-  opaque type Type = A
-
-  given newRefinedCanEqual: CanEqual[Type, Type] = CanEqual.derived
+  override opaque type Type = A
 
   def unapply(typ: Type): Option[A] = Some(typ)
 
@@ -29,8 +27,9 @@ trait RefinedBase[A] {
   def predicate(a: A): Boolean
 
   extension (typ: Type) {
-    inline def value: A = typ
+    override inline def value: A = typ
   }
-  def deriving[F[*]](using fa: F[A]): F[Type] = fa
+
+  override def deriving[M[*]](using fa: M[A]): M[Type] = fa
 
 }

--- a/modules/refined4s-core/shared/src/test/scala/refined4s/InlinedRefinedSpec.scala
+++ b/modules/refined4s-core/shared/src/test/scala/refined4s/InlinedRefinedSpec.scala
@@ -1,30 +1,129 @@
 package refined4s
 
-import hedgehog._
-import hedgehog.runner._
+import hedgehog.*
+import hedgehog.runner.*
+import refined4s.InlinedRefinedType.Something
 
 /** @author Kevin Lee
   * @since 2023-08-14
   */
-object InlinedRefinedSpec extends Properties {
+object InlinedInlinedRefinedSpec extends Properties {
   override def tests: List[Test] = List(
-    example("test InlinedRefined with valid value", testInlinedRefined)
+    example("test InlinedRefined.apply", testApply),
+    property("test InlinedRefined.from(valid)", testFromValid),
+    example("test InlinedRefined.from(invalid)", testFromInvalid),
+    property("test InlinedRefined.unsafeFrom(valid)", testUnsafeFromValid),
+    example("test InlinedRefined.unsafeFrom(invalid)", testUnsafeFromInvalid),
+    property("test InlinedRefined.value", testValue),
+    property("test InlinedRefined.unapply", testUnapplyWithPatternMatching),
+    property("test unwrap InlinedRefined[String] with Coercible", testCoercibleUnwrappingString),
+    property("test unwrap InlinedRefined[Int] with Coercible", testCoercibleUnwrappingInt),
   )
 
-  def testInlinedRefined: Result = {
-    import InlinedRefinedType.*
-
-    Something(1)
-    Result.success
+  def testApply: Result = {
+    /* The actual test is whether this compiles or not actual ==== expected is meaningless here */
+    val expected = MyType("blah")
+    val actual   = MyType("blah")
+    actual ==== expected
   }
 
-//  def testInlinedRefined2: Result = {
-//    import InlinedRefinedType.*
-//
-//    val a = 1
-//    // This should not compile.
-//    Something(a)
-//    Result.failure
-//  }
+  def testFromValid: Property =
+    for {
+      s <- Gen.string(Gen.unicode, Range.linear(1, 10)).log("s")
+    } yield {
+      val expected = MyType.unsafeFrom(s)
+      val actual   = MyType.from(s)
+      actual ==== Right(expected)
+    }
+
+  def testFromInvalid: Result = {
+    val expected = "Invalid value: []. It has to be a non-empty String but got []"
+    val actual   = MyType.from("")
+    actual ==== Left(expected)
+  }
+
+  def testUnsafeFromValid: Property =
+    for {
+      s <- Gen.string(Gen.unicode, Range.linear(1, 10)).log("s")
+    } yield {
+      val expected = MyType.unsafeFrom(s)
+      val actual   = MyType.unsafeFrom(s)
+      actual ==== expected
+    }
+
+  def testUnsafeFromInvalid: Result = {
+    val expected = "Invalid value: []. It has to be a non-empty String but got []"
+    try {
+      MyType.unsafeFrom("")
+      Result.failure.log("""IllegalArgumentException was expected from MyType.unsafeFrom(""), but it was not thrown.""")
+    } catch {
+      case ex: IllegalArgumentException =>
+        ex.getMessage ==== expected
+
+    }
+  }
+
+  def testValue: Property =
+    for {
+      s <- Gen.string(Gen.unicode, Range.linear(1, 10)).log("s")
+    } yield {
+      val expected = s
+      val actual   = MyType.unsafeFrom(s)
+      actual.value ==== expected
+    }
+
+  def testUnapplyWithPatternMatching: Property =
+    for {
+      s <- Gen.string(Gen.unicode, Range.linear(1, 10)).log("s")
+    } yield {
+      val expected = s
+      val myType   = MyType.unsafeFrom(s)
+      myType match {
+        case MyType(actual) =>
+          actual ==== expected
+      }
+    }
+
+  def testCoercibleUnwrappingString: Property =
+    for {
+      s <- Gen.string(Gen.unicode, Range.linear(1, 10)).log("s")
+    } yield {
+
+      def unwrap[A, B](a: A)(using coercible: Coercible[A, B]): B =
+        coercible(a)
+
+      val expected = s
+      val myType   = MyType.unsafeFrom(s)
+
+      val actual: String = unwrap(myType)
+      actual ==== expected
+    }
+
+  def testCoercibleUnwrappingInt: Property =
+    for {
+      n <- Gen.int(Range.linear(1, Int.MaxValue)).log("n")
+    } yield {
+
+      def unwrap[A, B](a: A)(using coercible: Coercible[A, B]): B =
+        coercible(a)
+
+      val expected = n
+      val myType   = Something.unsafeFrom(n)
+
+      val actual: Int = unwrap(myType)
+      actual ==== expected
+    }
+
+  type MyType = MyType.Type
+  @SuppressWarnings(Array("org.wartremover.warts.Equals"))
+  object MyType extends InlinedRefined[String] {
+
+    override inline def invalidReason(a: String): String =
+      "It has to be a non-empty String but got [" + a + "]"
+
+    override inline def predicate(a: String): Boolean = a != ""
+
+    override inline def inlinedPredicate(inline a: String): Boolean = a != ""
+  }
 
 }

--- a/modules/refined4s-core/shared/src/test/scala/refined4s/RefinedSpec.scala
+++ b/modules/refined4s-core/shared/src/test/scala/refined4s/RefinedSpec.scala
@@ -15,6 +15,7 @@ object RefinedSpec extends Properties {
     example("test Refined.unsafeFrom(invalid)", testUnsafeFromInvalid),
     property("test Refined.value", testValue),
     property("test Refined.unapply", testUnapplyWithPatternMatching),
+    property("test unwrap Refined with Coercible", testCoercibleUnwrapping),
   )
 
   def testApply: Result = {
@@ -79,6 +80,21 @@ object RefinedSpec extends Properties {
         case MyType(actual) =>
           actual ==== expected
       }
+    }
+
+  def testCoercibleUnwrapping: Property =
+    for {
+      s <- Gen.string(Gen.unicode, Range.linear(1, 10)).log("s")
+    } yield {
+
+      def unwrap[A, B](a: A)(using coercible: Coercible[A, B]): B =
+        coercible(a)
+
+      val expected = s
+      val myType   = MyType.unsafeFrom(s)
+
+      val actual: String = unwrap(myType)
+      actual ==== expected
     }
 
   type MyType = MyType.Type


### PR DESCRIPTION
Close #46 - Make `RefinedBase` extend `NewtypeBase` to support unwrapping (getting value) for `Refined` and `InlinedRefined` types with `Coercible`