### PR TITLE
Close #49 - Add `RefinedCtor[T, A]` to provide a way to create a validated type `T` from an actual type `A` with validation

### DIFF
--- a/modules/refined4s-core/shared/src/main/scala/refined4s/RefinedCtor.scala
+++ b/modules/refined4s-core/shared/src/main/scala/refined4s/RefinedCtor.scala
@@ -1,0 +1,11 @@
+package refined4s
+
+/** @author Kevin Lee
+  * @since 2023-12-05
+  */
+trait RefinedCtor[T, A] {
+  def create(a: A): Either[String, T]
+}
+object RefinedCtor {
+  def apply[T, A](using refinedCtor: RefinedCtor[T, A]): RefinedCtor[T, A] = refinedCtor
+}

--- a/modules/refined4s-core/shared/src/test/scala/refined4s/RefinedCtorSpec.scala
+++ b/modules/refined4s-core/shared/src/test/scala/refined4s/RefinedCtorSpec.scala
@@ -1,0 +1,51 @@
+package refined4s
+
+import cats.syntax.all.*
+import hedgehog.*
+import hedgehog.runner.*
+
+/** @author Kevin Lee
+  * @since 2023-12-05
+  */
+object RefinedCtorSpec extends Properties {
+  override def tests: List[Test] = List(
+    property(
+      "RefinedCtor[T].create with a valid input should return Either[String, T] = Right(T)",
+      testRefinedCtorCreate,
+    ),
+    example(
+      "RefinedCtor[T].create with an invalid input should return Either[String, T] = Left(String)",
+      testRefinedCtorCreateInvalid,
+    ),
+  )
+
+  def testRefinedCtorCreate: Property =
+    for {
+      s <- Gen.string(Gen.unicode, Range.linear(1, 10)).log("s")
+    } yield {
+      val expected = s.asRight[String]
+      val actual   = RefinedCtor[MyType, String].create(s)
+      actual ==== expected
+    }
+
+  def testRefinedCtorCreateInvalid: Result = {
+    val expected = "Invalid value: []. It has to be non-empty String but got \"\"".asLeft[MyType]
+    val actual   = RefinedCtor[MyType, String].create("")
+    actual ==== expected
+  }
+
+  type MyType = MyType.Type
+  @SuppressWarnings(Array("org.wartremover.warts.Equals"))
+  object MyType extends Refined[String] {
+
+    override inline def invalidReason(a: String): String =
+      "It has to be non-empty String but got \"" + a + "\""
+
+    override inline def predicate(a: String): Boolean = a != ""
+
+    given refinedCtor: RefinedCtor[Type, String] with {
+      override def create(a: String): Either[String, MyType] = from(a)
+    }
+  }
+
+}


### PR DESCRIPTION
Close #49 - Add `RefinedCtor[T, A]` to provide a way to create a validated type `T` from an actual type `A` with validation