### PR TITLE
Close #53 - Add `A.refinedTo[T]` syntax to create `Refined[A]` and `InlinedRefined[A]`

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -55,14 +55,15 @@ lazy val refined4s = (project in file("."))
   .settings(noPublish)
   .aggregate(coreJvm, coreJs)
 
-lazy val core = module("core", crossProject(JVMPlatform, JSPlatform))
+lazy val core    = module("core", crossProject(JVMPlatform, JSPlatform))
   .settings(
     libraryDependencies ++= List(
-      libs.cats % Test
+      libs.extrasTypeInfo % Test,
+      libs.cats           % Test,
     )
   )
 lazy val coreJvm = core.jvm
-lazy val coreJs = core.js.settings(jsSettingsForFuture)
+lazy val coreJs  = core.js.settings(jsSettingsForFuture)
 
 lazy val props =
   new {
@@ -94,10 +95,14 @@ lazy val props =
 
     val HedgehogVersion = "0.10.1"
 
+    val ExtrasVersion = "0.44.0"
+
     val CatsVersion = "2.8.0"
   }
 
 lazy val libs = new {
+
+  lazy val extrasTypeInfo = "io.kevinlee" %% "extras-type-info" % props.ExtrasVersion
 
   lazy val cats = "org.typelevel" %% "cats-core" % props.CatsVersion
 
@@ -181,7 +186,7 @@ def module(projectName: String, crossProject: CrossProject.Builder): CrossProjec
 lazy val jsSettingsForFuture: SettingsDefinition = List(
   Test / fork := false,
   Test / scalacOptions ++= (if (scalaVersion.value.startsWith("3")) List.empty
-  else List("-P:scalajs:nowarnGlobalExecutionContext")),
+                            else List("-P:scalajs:nowarnGlobalExecutionContext")),
   Test / compile / scalacOptions ++= (if (scalaVersion.value.startsWith("3")) List.empty
-  else List("-P:scalajs:nowarnGlobalExecutionContext")),
+                                      else List("-P:scalajs:nowarnGlobalExecutionContext")),
 )

--- a/modules/refined4s-core/shared/src/main/scala/refined4s/syntax.scala
+++ b/modules/refined4s-core/shared/src/main/scala/refined4s/syntax.scala
@@ -1,0 +1,13 @@
+package refined4s
+
+/** @author Kevin Lee
+  * @since 2023-12-02
+  */
+object syntax {
+
+  extension [A](a: A) {
+    inline def refinedTo[T](using refinedCtor: RefinedCtor[T, A]): Either[String, T] =
+      refinedCtor.create(a)
+  }
+
+}

--- a/modules/refined4s-core/shared/src/test/scala/refined4s/syntaxSpec.scala
+++ b/modules/refined4s-core/shared/src/test/scala/refined4s/syntaxSpec.scala
@@ -1,0 +1,148 @@
+package refined4s
+
+import cats.*
+import cats.syntax.all.*
+import extras.core.syntax.all.*
+import hedgehog.*
+import hedgehog.runner.*
+import refined4s.syntax.*
+
+/** @author Kevin Lee
+  * @since 2023-12-05
+  */
+object syntaxSpec extends Properties {
+
+  override def tests: List[Test] = List(
+    property(
+      "For type T = Refined[A], a.refinedTo[T] with a valid `a` should return Either[String, T] = Right(T)",
+      testARefinedT,
+    ),
+    example(
+      "For type T = Refined[A], a.refinedTo[T] with an invalid `a` should return Either[String, T] = Left(String)",
+      testARefinedTVInvalid,
+    ),
+    property(
+      "For type T = Refined[A], refinedTo(a)[T] with a valid `a` should return Either[String, T] = Right(T)",
+      testRefinedTA,
+    ),
+    example(
+      "For type T = Refined[A], refinedTo(a)[T] with an invalid `a` should return Either[String, T] = Left(String)",
+      testRefinedTAInvalid,
+    ),
+    property(
+      "For type T = InlinedRefined[A], a.refinedTo[T] with a valid `a` should return Either[String, T] = Right(T)",
+      testInlinedRefined_ARefinedT,
+    ),
+    property(
+      "For type T = InlinedRefined[A], a.refinedTo[T] with an invalid `a` should return Either[String, T] = Left(String)",
+      testInlinedRefined_ARefinedTVInvalid,
+    ),
+    property(
+      "For type T = InlinedRefined[A], refinedTo(a)[T] with a valid `a` should return Either[String, T] = Right(T)",
+      testInlinedRefined_RefinedTA,
+    ),
+    property(
+      "For type T = InlinedRefined[A], refinedTo(a)[T] with an invalid `a` should return Either[String, T] = Left(String)",
+      testInlinedRefined_RefinedTAInvalid,
+    ),
+  )
+
+  def testARefinedT: Property =
+    for {
+      s <- Gen.string(Gen.unicode, Range.linear(1, 10)).log("s")
+    } yield {
+
+      val expected = s.asRight[String]
+      val actual   = s.refinedTo[MyType]
+      actual ==== expected
+    }
+
+  def testARefinedTVInvalid: Result = {
+    val expected = "Invalid value: []. It has to be a non-empty String but got \"\"".asLeft[MyType]
+    val actual   = "".refinedTo[MyType]
+    actual ==== expected
+  }
+
+  def testRefinedTA: Property =
+    for {
+      s <- Gen.string(Gen.unicode, Range.linear(1, 10)).log("s")
+    } yield {
+
+      val expected = s.asRight[String]
+      val actual   = refinedTo(s)[MyType]
+      actual ==== expected
+    }
+
+  def testRefinedTAInvalid: Result = {
+    val expected = "Invalid value: []. It has to be a non-empty String but got \"\"".asLeft[MyType]
+    val actual   = refinedTo("")[MyType]
+    actual ==== expected
+  }
+
+  import InlinedRefinedType.*
+
+  def testInlinedRefined_ARefinedT: Property =
+    for {
+      s <- Gen.string(Gen.unicode, Range.linear(3, 10)).log("s")
+    } yield {
+
+      val expected = s.asRight[String]
+      val actual   = s.refinedTo[MoreThan2CharsString]
+      actual ==== expected
+    }
+
+  def testInlinedRefined_ARefinedTVInvalid: Property =
+    for {
+      s <- Gen.string(Gen.unicode, Range.linear(0, 2)).log("s")
+    } yield {
+      val expected =
+        s"Invalid value: [$s]. The String should have more than 2 chars but got $s instead".asLeft[MoreThan2CharsString]
+      val actual   = s.refinedTo[MoreThan2CharsString]
+      (actual ==== expected).log(
+        raw"""       s: ${s.encodeToUnicode}
+             |  actual: ${actual.leftMap(_.encodeToUnicode)}
+             |expected: ${expected.leftMap(_.encodeToUnicode)}
+             |""".stripMargin
+      )
+    }
+
+  def testInlinedRefined_RefinedTA: Property =
+    for {
+      s <- Gen.string(Gen.unicode, Range.linear(3, 10)).log("s")
+    } yield {
+
+      val expected = s.asRight[String]
+      val actual   = refinedTo(s)[MoreThan2CharsString]
+      actual ==== expected
+    }
+
+  def testInlinedRefined_RefinedTAInvalid: Property =
+    for {
+      s <- Gen.string(Gen.unicode, Range.linear(0, 2)).log("s")
+    } yield {
+      val expected =
+        s"Invalid value: [$s]. The String should have more than 2 chars but got $s instead".asLeft[MoreThan2CharsString]
+      val actual   = refinedTo(s)[MoreThan2CharsString]
+      (actual ==== expected).log(
+        raw"""       s: ${s.encodeToUnicode}
+             |  actual: ${actual.leftMap(_.encodeToUnicode)}
+             |expected: ${expected.leftMap(_.encodeToUnicode)}
+             |""".stripMargin
+      )
+    }
+
+  type MyType = MyType.Type
+  @SuppressWarnings(Array("org.wartremover.warts.Equals"))
+  object MyType extends Refined[String] {
+
+    override inline def invalidReason(a: String): String =
+      "It has to be a non-empty String but got \"" + a + "\""
+
+    override inline def predicate(a: String): Boolean = a != ""
+
+    given eqMyType: Eq[MyType] = deriving[Eq]
+
+    given showMyType: Show[MyType] = deriving[Show]
+  }
+
+}


### PR DESCRIPTION
Close #53 - Add `A.refinedTo[T]` syntax to create `Refined[A]` and `InlinedRefined[A]`