### PR TITLE
Close #55 - Add `T.coerce[A]` syntax to easily get the value `A` from `Refined[A]#Type` and `InlinedRefined[A]#Type`

### DIFF
--- a/modules/refined4s-core/shared/src/main/scala/refined4s/syntax.scala
+++ b/modules/refined4s-core/shared/src/main/scala/refined4s/syntax.scala
@@ -6,6 +6,9 @@ package refined4s
 object syntax {
 
   extension [A](a: A) {
+
+    inline def coerce[B](using coercible: Coercible[A, B]): B = coercible(a)
+
     inline def refinedTo[T](using refinedCtor: RefinedCtor[T, A]): Either[String, T] =
       refinedCtor.create(a)
   }

--- a/modules/refined4s-core/shared/src/test/scala/refined4s/syntaxSpec.scala
+++ b/modules/refined4s-core/shared/src/test/scala/refined4s/syntaxSpec.scala
@@ -14,6 +14,10 @@ object syntaxSpec extends Properties {
 
   override def tests: List[Test] = List(
     property(
+      "For type T = Refined[A] and t: T, t.coerce[A] should return A",
+      testTCoerceA,
+    ),
+    property(
       "For type T = Refined[A], a.refinedTo[T] with a valid `a` should return Either[String, T] = Right(T)",
       testARefinedT,
     ),
@@ -28,6 +32,10 @@ object syntaxSpec extends Properties {
     example(
       "For type T = Refined[A], refinedTo(a)[T] with an invalid `a` should return Either[String, T] = Left(String)",
       testRefinedTAInvalid,
+    ),
+    property(
+      "For type T = InlinedRefined[A] and t: T, t.coerce[A] should return A",
+      testInlinedRefined_TCoerceA,
     ),
     property(
       "For type T = InlinedRefined[A], a.refinedTo[T] with a valid `a` should return Either[String, T] = Right(T)",
@@ -46,6 +54,17 @@ object syntaxSpec extends Properties {
       testInlinedRefined_RefinedTAInvalid,
     ),
   )
+
+  def testTCoerceA: Property =
+    for {
+      s <- Gen.string(Gen.unicode, Range.linear(1, 10)).log("s")
+    } yield {
+      val myType = MyType.unsafeFrom(s)
+
+      val expected = s
+      val actual   = myType.coerce[String]
+      actual ==== expected
+    }
 
   def testARefinedT: Property =
     for {
@@ -88,6 +107,17 @@ object syntaxSpec extends Properties {
 
       val expected = s.asRight[String]
       val actual   = s.refinedTo[MoreThan2CharsString]
+      actual ==== expected
+    }
+
+  def testInlinedRefined_TCoerceA: Property =
+    for {
+      s <- Gen.string(Gen.unicode, Range.linear(3, 10)).log("s")
+    } yield {
+      val moreThan2CharsString = MoreThan2CharsString.unsafeFrom(s)
+
+      val expected = s
+      val actual   = moreThan2CharsString.coerce[String]
       actual ==== expected
     }
 


### PR DESCRIPTION
Close #55 - Add `T.coerce[A]` syntax to easily get the value `A` from `Refined[A]#Type` and `InlinedRefined[A]#Type`