### PR TITLE
Close #61 - Add `toValue` syntax to get the value from `Newtype` containing `Refined[A]` or `InlinedRefined[A]`

### DIFF
--- a/modules/refined4s-core/shared/src/main/scala/refined4s/syntax.scala
+++ b/modules/refined4s-core/shared/src/main/scala/refined4s/syntax.scala
@@ -27,5 +27,11 @@ trait syntax {
 
   }
 
+  extension [N, T, A](nt: N) {
+
+    def toValue(using coercible1: Coercible[N, T], coercible2: Coercible[T, A]): A =
+      coercible2(coercible1(nt))
+  }
+
 }
 object syntax extends syntax

--- a/modules/refined4s-core/shared/src/test/scala/refined4s/syntaxSpec.scala
+++ b/modules/refined4s-core/shared/src/test/scala/refined4s/syntaxSpec.scala
@@ -87,6 +87,15 @@ object syntaxSpec extends Properties {
       "For type T = InlinedRefined[A] and type N = NewType[T], refinedNewtype(a)[N] with an invalid `a` should return Either[String, N] = Left(String)",
       testInlinedRefined_RefinedNewtypeTAInvalid,
     ),
+    ///
+    property(
+      "For type T = Refined[A] and type N = NewType[T], (n: N).toValue should return A",
+      testRefinedNewtypeToValueA,
+    ),
+    property(
+      "For type T = InlinedRefined[A] and type N = NewType[T], (n: N).toValue should return A",
+      testInlinedRefinedNewtypeToValueA,
+    ),
   )
 
   def testTCoerceA: Property =
@@ -276,6 +285,29 @@ object syntaxSpec extends Properties {
              |expected: ${expected.leftMap(_.encodeToUnicode)}
              |""".stripMargin
       )
+    }
+
+  def testRefinedNewtypeToValueA: Property =
+    for {
+      s <- Gen.string(Gen.unicode, Range.linear(1, 10)).log("s")
+    } yield {
+      val newMyType = NewMyType(MyType.unsafeFrom(s))
+
+      val expected       = s
+      val actual: String = newMyType.toValue
+      actual ==== expected
+    }
+
+  def testInlinedRefinedNewtypeToValueA: Property =
+    for {
+      s <- Gen.string(Gen.unicode, Range.linear(3, 10)).log("s")
+    } yield {
+
+      val newMoreThan2CharsString = NewMoreThan2CharsString(MoreThan2CharsString.unsafeFrom(s))
+
+      val expected       = s
+      val actual: String = newMoreThan2CharsString.toValue
+      actual ==== expected
     }
 
   def testInlinedRefined_RefinedNewtypeTAInvalid: Property =


### PR DESCRIPTION
Close #61 - Add `toValue` syntax to get the value from `Newtype` containing `Refined[A]` or `InlinedRefined[A]`