### PR TITLE
Update: GitHub Actions - `release.yml`: Scala version for test coverage from 3.2.2 to 3.3.1

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -73,7 +73,7 @@ jobs:
     strategy:
       matrix:
         scala:
-          - { name: "Scala 3", version: "3.2.2", binary-version: "3", java-version: "11", java-distribution: "temurin", report: "report" }
+          - { name: "Scala 3", version: "3.3.1", binary-version: "3", java-version: "11", java-distribution: "temurin", report: "report" }
 
     steps:
       - uses: actions/checkout@v4.1.1


### PR DESCRIPTION
Update: GitHub Actions - `release.yml`: Scala version for test coverage from 3.2.2 to 3.3.1