### PR TITLE
GitHub Actions - `release.yml`: Remove `devOopsGitHubReleaseUploadArtifacts` to avoid uploading the artifacts to GitHub Release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -193,13 +193,12 @@ jobs:
           echo "SOURCE_DATE_EPOCH=$SOURCE_DATE_EPOCH"
           echo "JVM_OPTS=${JVM_OPTS}"
           echo "SBT_OPTS=${SBT_OPTS}"
-          echo 'sbt -v clean +packagedArtifacts ci-release devOopsGitHubReleaseUploadArtifacts'
+          echo 'sbt -v clean +packagedArtifacts ci-release'
           sbt \
             -v \
             clean \
             +packagedArtifacts \
-            ci-release \
-            devOopsGitHubReleaseUploadArtifacts
+            ci-release
 
 
   publish-snapshot:


### PR DESCRIPTION
GitHub Actions - `release.yml`: Remove `devOopsGitHubReleaseUploadArtifacts` to avoid uploading the artifacts to GitHub Release