### PR TITLE
refined4s v0.2.0

### DIFF
--- a/changelogs/0.2.0.md
+++ b/changelogs/0.2.0.md
@@ -1,0 +1,53 @@
+## [0.2.0](https://github.com/kevin-lee/refined4s/issues?q=is%3Aissue+is%3Aclosed+-label%3Ainvalid+milestone%3Am2) - 2023-12-10
+
+### Changes
+
+* Rename `refined4s.cats` to `refined4s.modules.cats` (#94)
+  ```scala 3
+  import refined4s.modules.cats.derivation.*
+  import refined4s.modules.cats.syntax.*
+  ```
+
+### New Features
+
+* Add `Eq[A]` and `Show[A]` instances for the existing refined types (#95)
+
+  So with
+  ```scala 3
+  import refined4s.modules.cats.derivation.instances.given
+  ```
+  `Eq` and `Show` instances for the following types are available
+  * `NegInt`
+  * `NonNegInt`
+  * `PosInt`
+  * `NonPosInt`
+  * `NegLong`
+  * `NonNegLong`
+  * `PosLong`
+  * `NonPosLong`
+  * `NegShort`
+  * `NonNegShort`
+  * `PosShort`
+  * `NonPosShort`
+  * `NegByte`
+  * `NonNegByte`
+  * `PosByte`
+  * `NonPosByte`
+  * `NegFloat`
+  * `NonNegFloat`
+  * `PosFloat`
+  * `NonPosFloat`
+  * `NegDouble`
+  * `NonNegDouble`
+  * `PosDouble`
+  * `NonPosDouble`
+  * `NegBigInt`
+  * `NonNegBigInt`
+  * `PosBigInt`
+  * `NonPosBigInt`
+  * `NegBigDecimal`
+  * `NonNegBigDecimal`
+  * `PosBigDecimal`
+  * `NonPosBigDecimal`
+  * `NonEmptyString`
+  * `Uri`


### PR DESCRIPTION
# refined4s v0.2.0
## [0.2.0](https://github.com/kevin-lee/refined4s/issues?q=is%3Aissue+is%3Aclosed+-label%3Ainvalid+milestone%3Am2) - 2023-12-10

### Changes

* Rename `refined4s.cats` to `refined4s.modules.cats` (#94)
  ```scala 3
  import refined4s.modules.cats.derivation.*
  import refined4s.modules.cats.syntax.*
  ```

### New Features

* Add `Eq[A]` and `Show[A]` instances for the existing refined types (#95)

  So with
  ```scala 3
  import refined4s.modules.cats.derivation.instances.given
  ```
  `Eq` and `Show` instances for the following types are available
  * `NegInt`
  * `NonNegInt`
  * `PosInt`
  * `NonPosInt`
  * `NegLong`
  * `NonNegLong`
  * `PosLong`
  * `NonPosLong`
  * `NegShort`
  * `NonNegShort`
  * `PosShort`
  * `NonPosShort`
  * `NegByte`
  * `NonNegByte`
  * `PosByte`
  * `NonPosByte`
  * `NegFloat`
  * `NonNegFloat`
  * `PosFloat`
  * `NonPosFloat`
  * `NegDouble`
  * `NonNegDouble`
  * `PosDouble`
  * `NonPosDouble`
  * `NegBigInt`
  * `NonNegBigInt`
  * `PosBigInt`
  * `NonPosBigInt`
  * `NegBigDecimal`
  * `NonNegBigDecimal`
  * `PosBigDecimal`
  * `NonPosBigDecimal`
  * `NonEmptyString`
  * `Uri`
