### PR TITLE
Close #104 - [`refined4s-circe`] Add `CirceEncoder`, `CirceNewtypeDecoder`, `CirceRefinedDecoder`, `CirceNewtypeCodec` and `CirceRefinedCodec` to have circe `Encoder` and `Decoder` derived from the actual type for `Newtype`, `Refined` and `InlinedRefined`

### DIFF
--- a/modules/refined4s-circe/shared/src/main/scala/refined4s/modules/circe/derivation/CirceEncoder.scala
+++ b/modules/refined4s-circe/shared/src/main/scala/refined4s/modules/circe/derivation/CirceEncoder.scala
@@ -1,0 +1,13 @@
+package refined4s.modules.circe.derivation
+
+import io.circe.Encoder
+import refined4s.NewtypeBase
+
+/** @author Kevin Lee
+  * @since 2023-12-11
+  */
+trait CirceEncoder[A: Encoder] {
+  self: NewtypeBase[A] =>
+
+  given derivedEncoder: Encoder[Type] = deriving[Encoder]
+}

--- a/modules/refined4s-circe/shared/src/main/scala/refined4s/modules/circe/derivation/CirceNewtypeCodec.scala
+++ b/modules/refined4s-circe/shared/src/main/scala/refined4s/modules/circe/derivation/CirceNewtypeCodec.scala
@@ -1,0 +1,11 @@
+package refined4s.modules.circe.derivation
+
+import io.circe.*
+import refined4s.*
+
+/** @author Kevin Lee
+  * @since 2023-12-11
+  */
+trait CirceNewtypeCodec[A: Encoder: Decoder] extends CirceEncoder[A] with CirceNewtypeDecoder[A] {
+  self: NewtypeBase[A] =>
+}

--- a/modules/refined4s-circe/shared/src/main/scala/refined4s/modules/circe/derivation/CirceNewtypeDecoder.scala
+++ b/modules/refined4s-circe/shared/src/main/scala/refined4s/modules/circe/derivation/CirceNewtypeDecoder.scala
@@ -1,0 +1,13 @@
+package refined4s.modules.circe.derivation
+
+import io.circe.Decoder
+import refined4s.*
+
+/** @author Kevin Lee
+  * @since 2023-12-11
+  */
+trait CirceNewtypeDecoder[A: Decoder] {
+  self: NewtypeBase[A] =>
+
+  given derivedDecoder: Decoder[Type] = deriving[Decoder]
+}

--- a/modules/refined4s-circe/shared/src/main/scala/refined4s/modules/circe/derivation/CirceRefinedCodec.scala
+++ b/modules/refined4s-circe/shared/src/main/scala/refined4s/modules/circe/derivation/CirceRefinedCodec.scala
@@ -1,0 +1,11 @@
+package refined4s.modules.circe.derivation
+
+import io.circe.*
+import refined4s.*
+
+/** @author Kevin Lee
+  * @since 2023-12-11
+  */
+trait CirceRefinedCodec[A: Encoder: Decoder] extends CirceEncoder[A] with CirceRefinedDecoder[A] {
+  self: RefinedBase[A] =>
+}

--- a/modules/refined4s-circe/shared/src/main/scala/refined4s/modules/circe/derivation/CirceRefinedDecoder.scala
+++ b/modules/refined4s-circe/shared/src/main/scala/refined4s/modules/circe/derivation/CirceRefinedDecoder.scala
@@ -1,0 +1,13 @@
+package refined4s.modules.circe.derivation
+
+import io.circe.Decoder
+import refined4s.*
+
+/** @author Kevin Lee
+  * @since 2023-12-11
+  */
+trait CirceRefinedDecoder[A: Decoder] {
+  self: RefinedBase[A] =>
+
+  given derivedDecoder: Decoder[Type] = Decoder[A].emap(from)
+}

--- a/modules/refined4s-circe/shared/src/test/scala/refined4s/modules/circe/derivation/CirceCodecSpec.scala
+++ b/modules/refined4s-circe/shared/src/test/scala/refined4s/modules/circe/derivation/CirceCodecSpec.scala
@@ -1,0 +1,258 @@
+package refined4s.modules.circe.derivation
+
+import cats.syntax.all.*
+import hedgehog.*
+import hedgehog.runner.*
+import io.circe.*
+import io.circe.parser.*
+import io.circe.syntax.*
+import refined4s.*
+import refined4s.modules.circe.derivation.*
+
+/** @author Kevin Lee
+  * @since 2023-12-12
+  */
+object CirceCodecSpec extends Properties {
+  override def tests: List[Test] = List(
+    property("test CirceEncoder for Newtype", testNewtypeEncoder),
+    property("test CirceEncoder for Refined", testRefinedEncoder),
+    property("test CirceEncoder for Newtype(Refined)", testRefinedNewtypeEncoder),
+    property("test CirceEncoder for InlinedRefined", testInlinedRefinedEncoder),
+    property("test CirceEncoder for Newtype(InlinedRefined)", testInlinedRefinedNewtypeEncoder),
+    //
+    property("test CirceDecoder for Newtype", testNewtypeDecoder),
+    property("test CirceDecoder for Refined", testRefinedDecoder),
+    example("test CirceDecoder for Refined with invalid value", testRefinedDecoderInvalid),
+    property("test CirceDecoder for Newtype(Refined)", testRefinedNewtypeDecoder),
+    example("test CirceDecoder for Newtype(Refined) with invalid value", testRefinedNewtypeDecoderInvalid),
+    property("test CirceDecoder for InlinedRefined", testInlinedRefinedDecoder),
+    example("test CirceDecoder for InlinedRefined with invalid value", testInlinedRefinedDecoderInvalid),
+    property("test CirceDecoder for Newtype(InlinedRefined)", testInlinedRefinedNewtypeDecoder),
+    example("test CirceDecoder for Newtype(InlinedRefined) with invalid value", testInlinedRefinedNewtypeDecoderInvalid),
+  )
+
+  def testNewtypeEncoder: Property =
+    for {
+      s <- Gen.string(Gen.unicode, Range.linear(1, 10)).log("s")
+    } yield {
+      val input    = MyNewtype(s)
+      val expected = Json.fromString(s)
+      val actual   = input.asJson
+      Result.all(
+        List(
+          actual ==== expected,
+          actual.noSpaces ==== expected.noSpaces,
+        )
+      )
+    }
+
+  def testRefinedEncoder: Property =
+    for {
+      s <- Gen.string(Gen.unicode, Range.linear(1, 10)).log("s")
+    } yield {
+      val input    = MyRefinedType.unsafeFrom(s)
+      val expected = Json.fromString(s)
+      val actual   = input.asJson
+      Result.all(
+        List(
+          actual ==== expected,
+          actual.noSpaces ==== expected.noSpaces,
+        )
+      )
+    }
+
+  def testRefinedNewtypeEncoder: Property =
+    for {
+      s <- Gen.string(Gen.unicode, Range.linear(1, 10)).log("s")
+    } yield {
+      val input    = MyRefinedNewtype(MyRefinedType.unsafeFrom(s))
+      val expected = Json.fromString(s)
+      val actual   = input.asJson
+      Result.all(
+        List(
+          actual ==== expected,
+          actual.noSpaces ==== expected.noSpaces,
+        )
+      )
+    }
+
+  def testInlinedRefinedEncoder: Property =
+    for {
+      s <- Gen.string(Gen.unicode, Range.linear(1, 10)).log("s")
+    } yield {
+      val input    = MyInlinedRefinedType.unsafeFrom(s)
+      val expected = Json.fromString(s)
+      val actual   = input.asJson
+      Result.all(
+        List(
+          actual ==== expected,
+          actual.noSpaces ==== expected.noSpaces,
+        )
+      )
+    }
+
+  def testInlinedRefinedNewtypeEncoder: Property =
+    for {
+      s <- Gen.string(Gen.unicode, Range.linear(1, 10)).log("s")
+    } yield {
+      val input    = MyInlinedRefinedNewtype(MyInlinedRefinedType.unsafeFrom(s))
+      val expected = Json.fromString(s)
+      val actual   = input.asJson
+      Result.all(
+        List(
+          actual ==== expected,
+          actual.noSpaces ==== expected.noSpaces,
+        )
+      )
+    }
+
+  def testNewtypeDecoder: Property =
+    for {
+      s <- Gen.string(Gen.unicode, Range.linear(1, 10)).log("s")
+    } yield {
+      val expected = MyNewtype(s).asRight[String]
+      val input    = s.asJson
+      val actual   = decode[MyNewtype](input.noSpaces)
+      Result.all(
+        List(
+          actual ==== expected
+        )
+      )
+    }
+
+  def testRefinedDecoder: Property =
+    for {
+      s <- Gen.string(Gen.unicode, Range.linear(1, 10)).log("s")
+    } yield {
+      val expected = MyRefinedType.from(s)
+      val input    = s.asJson
+      val actual   = decode[MyRefinedType](input.noSpaces)
+      Result.all(
+        List(
+          actual ==== expected
+        )
+      )
+    }
+
+  def testRefinedDecoderInvalid: Result = {
+    val expected = MyRefinedType.from("").leftMap(io.circe.DecodingFailure(_, List.empty))
+    val input    = "".asJson
+    val actual   = decode[MyRefinedType](input.noSpaces)
+    Result.all(
+      List(
+        actual ==== expected
+      )
+    )
+  }
+
+  def testRefinedNewtypeDecoder: Property =
+    for {
+      s <- Gen.string(Gen.unicode, Range.linear(1, 10)).log("s")
+    } yield {
+      val expected = MyRefinedType.from(s).map(MyRefinedNewtype(_))
+      val input    = s.asJson
+      val actual   = decode[MyRefinedNewtype](input.noSpaces)
+      Result.all(
+        List(
+          actual ==== expected
+        )
+      )
+    }
+
+  def testRefinedNewtypeDecoderInvalid: Result = {
+    val expected = MyRefinedType
+      .from("")
+      .leftMap(io.circe.DecodingFailure(_, List.empty))
+      .map(MyRefinedNewtype(_))
+    val input    = "".asJson
+    val actual   = decode[MyRefinedNewtype](input.noSpaces)
+    Result.all(
+      List(
+        actual ==== expected
+      )
+    )
+  }
+
+  def testInlinedRefinedDecoder: Property =
+    for {
+      s <- Gen.string(Gen.unicode, Range.linear(1, 10)).log("s")
+    } yield {
+      val expected = MyInlinedRefinedType.from(s)
+      val input    = s.asJson
+      val actual   = decode[MyInlinedRefinedType](input.noSpaces)
+      Result.all(
+        List(
+          actual ==== expected
+        )
+      )
+    }
+
+  def testInlinedRefinedDecoderInvalid: Result = {
+    val expected = MyInlinedRefinedType.from("").leftMap(io.circe.DecodingFailure(_, List.empty))
+    val input    = "".asJson
+    val actual   = decode[MyInlinedRefinedType](input.noSpaces)
+    Result.all(
+      List(
+        actual ==== expected
+      )
+    )
+  }
+
+  def testInlinedRefinedNewtypeDecoder: Property =
+    for {
+      s <- Gen.string(Gen.unicode, Range.linear(1, 10)).log("s")
+    } yield {
+      val expected = MyInlinedRefinedType.from(s).map(MyInlinedRefinedNewtype(_))
+      val input    = s.asJson
+      val actual   = decode[MyInlinedRefinedNewtype](input.noSpaces)
+      Result.all(
+        List(
+          actual ==== expected
+        )
+      )
+    }
+
+  def testInlinedRefinedNewtypeDecoderInvalid: Result = {
+    val expected = MyInlinedRefinedType
+      .from("")
+      .leftMap(io.circe.DecodingFailure(_, List.empty))
+      .map(MyInlinedRefinedNewtype(_))
+    val input    = "".asJson
+    val actual   = decode[MyInlinedRefinedNewtype](input.noSpaces)
+    Result.all(
+      List(
+        actual ==== expected
+      )
+    )
+  }
+
+  type MyNewtype = MyNewtype.Type
+  object MyNewtype extends Newtype[String] with CirceNewtypeCodec[String]
+
+  type MyRefinedType = MyRefinedType.Type
+  @SuppressWarnings(Array("org.wartremover.warts.Equals"))
+  object MyRefinedType extends Refined[String] with CirceRefinedCodec[String] {
+    override inline def invalidReason(a: String): String =
+      "It has to be a non-empty String but got \"" + a + "\""
+
+    override inline def predicate(a: String): Boolean = a != ""
+  }
+
+  type MyRefinedNewtype = MyRefinedNewtype.Type
+  object MyRefinedNewtype extends Newtype[MyRefinedType] with CirceNewtypeCodec[MyRefinedType]
+
+  type MyInlinedRefinedType = MyInlinedRefinedType.Type
+  @SuppressWarnings(Array("org.wartremover.warts.Equals"))
+  object MyInlinedRefinedType extends InlinedRefined[String] with CirceRefinedCodec[String] {
+    override inline def invalidReason(a: String): String =
+      "It has to be a non-empty String but got \"" + a + "\""
+
+    override inline def predicate(a: String): Boolean = a != ""
+
+    override inline def inlinedPredicate(inline a: String): Boolean = a != ""
+  }
+
+  type MyInlinedRefinedNewtype = MyInlinedRefinedNewtype.Type
+  object MyInlinedRefinedNewtype extends Newtype[MyInlinedRefinedType] with CirceNewtypeCodec[MyInlinedRefinedType]
+
+}

--- a/modules/refined4s-circe/shared/src/test/scala/refined4s/modules/circe/derivation/CirceDecoderSpec.scala
+++ b/modules/refined4s-circe/shared/src/test/scala/refined4s/modules/circe/derivation/CirceDecoderSpec.scala
@@ -1,0 +1,177 @@
+package refined4s.modules.circe.derivation
+
+import cats.syntax.all.*
+import hedgehog.*
+import hedgehog.runner.*
+import io.circe.*
+import io.circe.parser.*
+import io.circe.syntax.*
+import refined4s.*
+import refined4s.modules.circe.derivation.*
+
+/** @author Kevin Lee
+  * @since 2023-12-11
+  */
+object CirceDecoderSpec extends Properties {
+  override def tests: List[Test] = List(
+    property("test CirceDecoder for Newtype", testNewtypeDecoder),
+    property("test CirceDecoder for Refined", testRefinedDecoder),
+    example("test CirceDecoder for Refined with invalid value", testRefinedDecoderInvalid),
+    property("test CirceDecoder for Newtype(Refined)", testRefinedNewtypeDecoder),
+    example("test CirceDecoder for Newtype(Refined) with invalid value", testRefinedNewtypeDecoderInvalid),
+    property("test CirceDecoder for InlinedRefined", testInlinedRefinedDecoder),
+    example("test CirceDecoder for InlinedRefined with invalid value", testInlinedRefinedDecoderInvalid),
+    property("test CirceDecoder for Newtype(InlinedRefined)", testInlinedRefinedNewtypeDecoder),
+    example("test CirceDecoder for Newtype(InlinedRefined) with invalid value", testInlinedRefinedNewtypeDecoderInvalid),
+  )
+
+  def testNewtypeDecoder: Property =
+    for {
+      s <- Gen.string(Gen.unicode, Range.linear(1, 10)).log("s")
+    } yield {
+      val expected = MyNewtype(s).asRight[String]
+      val input    = s.asJson
+      val actual   = decode[MyNewtype](input.noSpaces)
+      Result.all(
+        List(
+          actual ==== expected
+        )
+      )
+    }
+
+  def testRefinedDecoder: Property =
+    for {
+      s <- Gen.string(Gen.unicode, Range.linear(1, 10)).log("s")
+    } yield {
+      val expected = MyRefinedType.from(s)
+      val input    = s.asJson
+      val actual   = decode[MyRefinedType](input.noSpaces)
+      Result.all(
+        List(
+          actual ==== expected
+        )
+      )
+    }
+
+  def testRefinedDecoderInvalid: Result = {
+    val expected = MyRefinedType.from("").leftMap(io.circe.DecodingFailure(_, List.empty))
+    val input    = "".asJson
+    val actual   = decode[MyRefinedType](input.noSpaces)
+    Result.all(
+      List(
+        actual ==== expected
+      )
+    )
+  }
+
+  def testRefinedNewtypeDecoder: Property =
+    for {
+      s <- Gen.string(Gen.unicode, Range.linear(1, 10)).log("s")
+    } yield {
+      val expected = MyRefinedType.from(s).map(MyRefinedNewtype(_))
+      val input    = s.asJson
+      val actual   = decode[MyRefinedNewtype](input.noSpaces)
+      Result.all(
+        List(
+          actual ==== expected
+        )
+      )
+    }
+
+  def testRefinedNewtypeDecoderInvalid: Result = {
+    val expected = MyRefinedType
+      .from("")
+      .leftMap(io.circe.DecodingFailure(_, List.empty))
+      .map(MyRefinedNewtype(_))
+    val input    = "".asJson
+    val actual   = decode[MyRefinedNewtype](input.noSpaces)
+    Result.all(
+      List(
+        actual ==== expected
+      )
+    )
+  }
+
+  def testInlinedRefinedDecoder: Property =
+    for {
+      s <- Gen.string(Gen.unicode, Range.linear(1, 10)).log("s")
+    } yield {
+      val expected = MyInlinedRefinedType.from(s)
+      val input    = s.asJson
+      val actual   = decode[MyInlinedRefinedType](input.noSpaces)
+      Result.all(
+        List(
+          actual ==== expected
+        )
+      )
+    }
+
+  def testInlinedRefinedDecoderInvalid: Result = {
+    val expected = MyInlinedRefinedType.from("").leftMap(io.circe.DecodingFailure(_, List.empty))
+    val input    = "".asJson
+    val actual   = decode[MyInlinedRefinedType](input.noSpaces)
+    Result.all(
+      List(
+        actual ==== expected
+      )
+    )
+  }
+
+  def testInlinedRefinedNewtypeDecoder: Property =
+    for {
+      s <- Gen.string(Gen.unicode, Range.linear(1, 10)).log("s")
+    } yield {
+      val expected = MyInlinedRefinedType.from(s).map(MyInlinedRefinedNewtype(_))
+      val input    = s.asJson
+      val actual   = decode[MyInlinedRefinedNewtype](input.noSpaces)
+      Result.all(
+        List(
+          actual ==== expected
+        )
+      )
+    }
+
+  def testInlinedRefinedNewtypeDecoderInvalid: Result = {
+    val expected = MyInlinedRefinedType
+      .from("")
+      .leftMap(io.circe.DecodingFailure(_, List.empty))
+      .map(MyInlinedRefinedNewtype(_))
+    val input    = "".asJson
+    val actual   = decode[MyInlinedRefinedNewtype](input.noSpaces)
+    Result.all(
+      List(
+        actual ==== expected
+      )
+    )
+  }
+
+  type MyNewtype = MyNewtype.Type
+  object MyNewtype extends Newtype[String] with CirceNewtypeDecoder[String]
+
+  type MyRefinedType = MyRefinedType.Type
+  @SuppressWarnings(Array("org.wartremover.warts.Equals"))
+  object MyRefinedType extends Refined[String] with CirceRefinedDecoder[String] {
+    override inline def invalidReason(a: String): String =
+      "It has to be a non-empty String but got \"" + a + "\""
+
+    override inline def predicate(a: String): Boolean = a != ""
+  }
+
+  type MyRefinedNewtype = MyRefinedNewtype.Type
+  object MyRefinedNewtype extends Newtype[MyRefinedType] with CirceNewtypeDecoder[MyRefinedType]
+
+  type MyInlinedRefinedType = MyInlinedRefinedType.Type
+  @SuppressWarnings(Array("org.wartremover.warts.Equals"))
+  object MyInlinedRefinedType extends InlinedRefined[String] with CirceRefinedDecoder[String] {
+    override inline def invalidReason(a: String): String =
+      "It has to be a non-empty String but got \"" + a + "\""
+
+    override inline def predicate(a: String): Boolean = a != ""
+
+    override inline def inlinedPredicate(inline a: String): Boolean = a != ""
+  }
+
+  type MyInlinedRefinedNewtype = MyInlinedRefinedNewtype.Type
+  object MyInlinedRefinedNewtype extends Newtype[MyInlinedRefinedType] with CirceNewtypeDecoder[MyInlinedRefinedType]
+
+}

--- a/modules/refined4s-circe/shared/src/test/scala/refined4s/modules/circe/derivation/CirceEncoderSpec.scala
+++ b/modules/refined4s-circe/shared/src/test/scala/refined4s/modules/circe/derivation/CirceEncoderSpec.scala
@@ -1,0 +1,128 @@
+package refined4s.modules.circe.derivation
+
+import refined4s.*
+import refined4s.modules.circe.derivation.*
+
+import hedgehog.*
+import hedgehog.runner.*
+
+import io.circe.*
+import io.circe.syntax.*
+
+/** @author Kevin Lee
+  * @since 2023-12-11
+  */
+object CirceEncoderSpec extends Properties {
+  override def tests: List[Test] = List(
+    property("test CirceEncoder for Newtype", testNewtypeEncoder),
+    property("test CirceEncoder for Refined", testRefinedEncoder),
+    property("test CirceEncoder for Newtype(Refined)", testRefinedNewtypeEncoder),
+    property("test CirceEncoder for InlinedRefined", testInlinedRefinedEncoder),
+    property("test CirceEncoder for Newtype(InlinedRefined)", testInlinedRefinedNewtypeEncoder),
+  )
+
+  def testNewtypeEncoder: Property =
+    for {
+      s <- Gen.string(Gen.unicode, Range.linear(1, 10)).log("s")
+    } yield {
+      val input    = MyNewtype(s)
+      val expected = Json.fromString(s)
+      val actual   = input.asJson
+      Result.all(
+        List(
+          actual ==== expected,
+          actual.noSpaces ==== expected.noSpaces,
+        )
+      )
+    }
+
+  def testRefinedEncoder: Property =
+    for {
+      s <- Gen.string(Gen.unicode, Range.linear(1, 10)).log("s")
+    } yield {
+      val input    = MyRefinedType.unsafeFrom(s)
+      val expected = Json.fromString(s)
+      val actual   = input.asJson
+      Result.all(
+        List(
+          actual ==== expected,
+          actual.noSpaces ==== expected.noSpaces,
+        )
+      )
+    }
+
+  def testRefinedNewtypeEncoder: Property =
+    for {
+      s <- Gen.string(Gen.unicode, Range.linear(1, 10)).log("s")
+    } yield {
+      val input    = MyRefinedNewtype(MyRefinedType.unsafeFrom(s))
+      val expected = Json.fromString(s)
+      val actual   = input.asJson
+      Result.all(
+        List(
+          actual ==== expected,
+          actual.noSpaces ==== expected.noSpaces,
+        )
+      )
+    }
+
+  def testInlinedRefinedEncoder: Property =
+    for {
+      s <- Gen.string(Gen.unicode, Range.linear(1, 10)).log("s")
+    } yield {
+      val input    = MyInlinedRefinedType.unsafeFrom(s)
+      val expected = Json.fromString(s)
+      val actual   = input.asJson
+      Result.all(
+        List(
+          actual ==== expected,
+          actual.noSpaces ==== expected.noSpaces,
+        )
+      )
+    }
+
+  def testInlinedRefinedNewtypeEncoder: Property =
+    for {
+      s <- Gen.string(Gen.unicode, Range.linear(1, 10)).log("s")
+    } yield {
+      val input    = MyInlinedRefinedNewtype(MyInlinedRefinedType.unsafeFrom(s))
+      val expected = Json.fromString(s)
+      val actual   = input.asJson
+      Result.all(
+        List(
+          actual ==== expected,
+          actual.noSpaces ==== expected.noSpaces,
+        )
+      )
+    }
+
+  type MyNewtype = MyNewtype.Type
+  object MyNewtype extends Newtype[String] with CirceEncoder[String]
+
+  type MyRefinedType = MyRefinedType.Type
+  @SuppressWarnings(Array("org.wartremover.warts.Equals"))
+  object MyRefinedType extends Refined[String] with CirceEncoder[String] {
+    override inline def invalidReason(a: String): String =
+      "It has to be a non-empty String but got \"" + a + "\""
+
+    override inline def predicate(a: String): Boolean = a != ""
+  }
+
+  type MyRefinedNewtype = MyRefinedNewtype.Type
+  object MyRefinedNewtype extends Newtype[MyRefinedType] with CirceEncoder[MyRefinedType]
+
+  type MyInlinedRefinedType = MyInlinedRefinedType.Type
+  @SuppressWarnings(Array("org.wartremover.warts.Equals"))
+  object MyInlinedRefinedType extends InlinedRefined[String] with CirceEncoder[String] {
+    override inline def invalidReason(a: String): String =
+      "It has to be a non-empty String but got \"" + a + "\""
+
+    override inline def predicate(a: String): Boolean = a != ""
+
+    override inline def inlinedPredicate(inline a: String): Boolean = a != ""
+  }
+
+  type MyInlinedRefinedNewtype = MyInlinedRefinedNewtype.Type
+  object MyInlinedRefinedNewtype extends Newtype[MyInlinedRefinedType] with CirceEncoder[MyInlinedRefinedType]
+
+}


### PR DESCRIPTION
Close #104 - [`refined4s-circe`] Add `CirceEncoder`, `CirceNewtypeDecoder`, `CirceRefinedDecoder`, `CirceNewtypeCodec` and `CirceRefinedCodec` to have circe `Encoder` and `Decoder` derived from the actual type for `Newtype`, `Refined` and `InlinedRefined`