### PR TITLE
Close #113 - [`refined4s-pureconfig`] Add `ConfigReader` and `ConfigWriter`s for `Newtype`, `Refined` and `InlinedRefined` with `Coercible` and `RefinedCtor`

### DIFF
--- a/modules/refined4s-pureconfig/shared/src/main/scala/refined4s/modules/pureconfig/derivation/instances.scala
+++ b/modules/refined4s-pureconfig/shared/src/main/scala/refined4s/modules/pureconfig/derivation/instances.scala
@@ -1,0 +1,32 @@
+package refined4s.modules.pureconfig.derivation
+
+import pureconfig.error.UserValidationFailed
+import pureconfig.{ConfigReader, ConfigWriter}
+import refined4s.*
+
+/** @author Kevin Lee
+  * @since 2023-12-13
+  */
+trait instances {
+
+  given derivedNewtypeConfigReader[A, B](using coercible: Coercible[A, B], configReader: ConfigReader[A]): ConfigReader[B] =
+    Coercible.unsafeWrapM(configReader)
+
+//  import refined4s.internal.typeTools.*
+
+  @SuppressWarnings(Array("org.wartremover.warts.ToString"))
+  given derivedRefinedConfigReader[A, B](using refinedCtor: RefinedCtor[B, A], configReader: ConfigReader[A]): ConfigReader[B] =
+    configReader.emap { a =>
+      refinedCtor.create(a).left.map { err =>
+//        val expectedType = getTypeName[B]
+        UserValidationFailed(
+          s"Invalid value found: ${a.toString} with error: $err"
+        )
+      }
+    }
+
+  given derivedConfigWriter[A, B](using coercible: Coercible[A, B], configWriter: ConfigWriter[B]): ConfigWriter[A] =
+    a => configWriter.to(coercible(a))
+
+}
+object instances extends instances

--- a/modules/refined4s-pureconfig/shared/src/test/scala/refined4s/modules/pureconfig/derivation/existingTypesSpec.scala
+++ b/modules/refined4s-pureconfig/shared/src/test/scala/refined4s/modules/pureconfig/derivation/existingTypesSpec.scala
@@ -1,0 +1,64 @@
+package refined4s.modules.pureconfig.derivation
+
+import cats.syntax.all.*
+import hedgehog.*
+import hedgehog.runner.*
+import pureconfig.generic.derivation.default.*
+import pureconfig.{ConfigReader, ConfigSource, ConfigWriter}
+import refined4s.*
+import refined4s.modules.pureconfig.derivation.instances.given
+import refined4s.types.all.*
+import refined4s.types.networkGens
+
+/** @author Kevin Lee
+  * @since 2023-12-13
+  */
+object existingTypesSpec extends Properties {
+  override def tests: List[Test] = List(
+    property("test ConfigReader[Uri]", testConfigReaderUri),
+    property("test ConfigWriter[Uri]", testConfigWriterUri),
+  )
+
+  @SuppressWarnings(Array("org.wartremover.warts.ToString"))
+  def testConfigReaderUri: Property =
+    for {
+      uri <- networkGens.genUriString.log("uri")
+    } yield {
+
+      val confString =
+        raw"""
+             |uri = "$uri"
+             |""".stripMargin
+
+      val expected = Uri.unsafeFrom(uri)
+
+      ConfigSource
+        .string(confString)
+        .load[TestConfig] match {
+        case Right(TestConfig(actual)) =>
+          actual ==== expected
+
+        case Left(err) =>
+          Result.failure.log(s"parse String config failed with error: ${err.toString}")
+      }
+
+    }
+
+  @SuppressWarnings(Array("org.wartremover.warts.ToString"))
+  def testConfigWriterUri: Property =
+    for {
+      uri <- networkGens.genUriString.log("uri")
+    } yield {
+
+      val input  = Uri.unsafeFrom(uri)
+      val actual = ConfigWriter[Uri].to(input)
+
+      val expected = ConfigWriter[String].to(uri)
+
+      actual ==== expected
+
+    }
+
+  final case class TestConfig(uri: Uri) derives ConfigReader
+
+}

--- a/modules/refined4s-pureconfig/shared/src/test/scala/refined4s/modules/pureconfig/derivation/instancesSpec.scala
+++ b/modules/refined4s-pureconfig/shared/src/test/scala/refined4s/modules/pureconfig/derivation/instancesSpec.scala
@@ -1,0 +1,194 @@
+package refined4s.modules.pureconfig.derivation
+
+import cats.syntax.all.*
+import com.typesafe.config.{ConfigRenderOptions, ConfigValue, ConfigValueFactory}
+import com.typesafe.config.impl.SimpleConfigObject
+import hedgehog.*
+import hedgehog.runner.*
+import pureconfig.error.{ConfigReaderFailures, ConvertFailure, UserValidationFailed}
+import pureconfig.{ConfigReader, ConfigSource, ConfigWriter}
+import pureconfig.generic.derivation.default.*
+import refined4s.*
+import refined4s.types.all.*
+import refined4s.modules.pureconfig.derivation.instances.given
+import refined4s.types.networkGens
+
+/** @author Kevin Lee
+  * @since 2023-12-13
+  */
+object instancesSpec extends Properties {
+  override def tests: List[Test] = List(
+    property("test ConfigReader[Newtype], ConfigReader[Refined] and ConfigReader[InlinedRefined] all together", testConfigReaderAll),
+    property("test ConfigReader[Refined] with invalid value", testConfigReaderInvalid),
+    property("test ConfigWriter[Newtype], ConfigWriter[Refined] and ConfigWriter[InlinedRefined] all together", testConfigWriterAll),
+  )
+
+  @SuppressWarnings(Array("org.wartremover.warts.ToString"))
+  def testConfigReaderAll: Property =
+    for {
+      id           <- Gen.long(Range.linear(1L, Long.MaxValue)).log("id")
+      uri          <- networkGens.genUriStringWithoutPath.log("uri")
+      endpointPath <- Gen.string(Gen.alphaNum, Range.linear(1, 7)).list(Range.linear(1, 5)).map(_.mkString("/")).log("endpointPath")
+      additionalId <- Gen.long(Range.linear(1L, Long.MaxValue)).log("additionalId")
+    } yield {
+
+      val confString =
+        raw"""api {
+             |  id = ${id.toString}
+             |  base-uri = "$uri"
+             |  endpoint-path = "$endpointPath"
+             |  additional-id = $additionalId
+             |}
+             |""".stripMargin
+
+      val expected = NewtypeApiConfig(
+        NewtypeApiConfig.Api(
+          Id.unsafeFrom(id),
+          NewtypeBaseUri(Uri.unsafeFrom(uri)),
+          RefinedEndpointPath.unsafeFrom(endpointPath),
+          InlinedRefinedNewtypeId(Id.unsafeFrom(additionalId)),
+        )
+      )
+
+      ConfigSource
+        .string(confString)
+        .load[NewtypeApiConfig] match {
+        case Right(actual) =>
+          actual ==== expected
+
+        case Left(err) =>
+          Result.failure.log(s"parse String config failed with error: ${err.toString}")
+      }
+
+    }
+
+  @SuppressWarnings(Array("org.wartremover.warts.ToString"))
+  def testConfigReaderInvalid: Property =
+    for {
+      id           <- Gen.long(Range.linear(Long.MinValue, 0)).log("id")
+      uri          <- networkGens.genUriStringWithoutPath.log("uri")
+      endpointPath <- Gen.string(Gen.alphaNum, Range.linear(1, 7)).list(Range.linear(1, 5)).map(_.mkString("/")).log("endpointPath")
+      additionalId <- Gen.long(Range.linear(1L, Long.MaxValue)).log("additionalId")
+    } yield {
+
+      val confString =
+        raw"""api {
+             |  id = $id
+             |  base-uri = "$uri"
+             |  endpoint-path = "$endpointPath"
+             |  additional-id = $additionalId
+             |}
+             |""".stripMargin
+
+      val expected = s"Invalid value found: ${id.toString} with error: Invalid value: [${id.toString}]. It must be a positive Long"
+
+      ConfigSource
+        .string(confString)
+        .load[NewtypeApiConfig] match {
+        case Right(actual) =>
+          Result.failure.log(s"It should have failed to parse the config but got $actual")
+
+        case Left(ConfigReaderFailures(ConvertFailure(UserValidationFailed(err), _, _))) =>
+          err ==== expected
+
+        case unexpected =>
+          Result.failure.log(s"Unexpected result: ${unexpected.toString}")
+      }
+
+    }
+
+  import scala.jdk.CollectionConverters.*
+  @SuppressWarnings(Array("org.wartremover.warts.ToString"))
+  def testConfigWriterAll: Property =
+    for {
+      id           <- Gen.long(Range.linear(1L, Long.MaxValue)).log("id")
+      uri          <- networkGens.genUriStringWithoutPath.log("uri")
+      endpointPath <- Gen.string(Gen.alphaNum, Range.linear(1, 7)).list(Range.linear(1, 5)).map(_.mkString("/")).log("endpointPath")
+      additionalId <- Gen.long(Range.linear(1L, Long.MaxValue)).log("additionalId")
+    } yield {
+
+      val expected = ConfigValueFactory.fromMap(
+        Map(
+          "api" -> Map(
+            "id"            -> id,
+            "base-uri"      -> uri,
+            "endpoint-path" -> endpointPath,
+            "additional-id" -> additionalId,
+          ).asJava
+        ).asJava
+      )
+
+      val input = NewtypeApiConfig(
+        NewtypeApiConfig.Api(
+          Id.unsafeFrom(id),
+          NewtypeBaseUri(Uri.unsafeFrom(uri)),
+          RefinedEndpointPath.unsafeFrom(endpointPath),
+          InlinedRefinedNewtypeId(Id.unsafeFrom(additionalId)),
+        )
+      )
+
+      val actual = ConfigWriter[NewtypeApiConfig].to(input)
+
+      (actual ==== expected).log(
+        s"""
+           | >>   actual: ${actual.render(ConfigRenderOptions.concise())}
+           | >> ---------
+           | >> expected: ${expected.render(ConfigRenderOptions.concise())}
+           |""".stripMargin
+      )
+
+    }
+
+  final case class NewtypeApiConfig(api: NewtypeApiConfig.Api) derives ConfigReader
+  object NewtypeApiConfig {
+
+    given configWriterNewtypeApiConfig: ConfigWriter[NewtypeApiConfig] = a =>
+      ConfigValueFactory.fromMap(
+        Map("api" -> ConfigWriter[NewtypeApiConfig.Api].to(a.api)).asJava
+      )
+
+    final case class Api(
+      id: Id,
+      baseUri: NewtypeBaseUri,
+      endpointPath: RefinedEndpointPath,
+      additionalId: InlinedRefinedNewtypeId,
+    ) derives ConfigReader
+    object Api {
+      given configWriterApi: ConfigWriter[Api] = a =>
+        ConfigValueFactory.fromMap(
+          Map(
+            "id"            -> ConfigWriter[Id].to(a.id),
+            "base-uri"      -> ConfigWriter[NewtypeBaseUri].to(a.baseUri),
+            "endpoint-path" -> ConfigWriter[RefinedEndpointPath].to(a.endpointPath),
+            "additional-id" -> ConfigWriter[InlinedRefinedNewtypeId].to(a.additionalId),
+          ).asJava
+        )
+    }
+  }
+
+  type Id = Id.Type
+  object Id extends InlinedRefined[Long] {
+
+    override inline def invalidReason(a: Long): String =
+      "It must be a positive Long"
+
+    override inline def predicate(a: Long): Boolean = a > 0L
+
+    override inline def inlinedPredicate(inline a: Long): Boolean = a > 0L
+  }
+
+  type NewtypeBaseUri = NewtypeBaseUri.Type
+  object NewtypeBaseUri extends Newtype[Uri]
+
+  type RefinedEndpointPath = RefinedEndpointPath.Type
+  @SuppressWarnings(Array("org.wartremover.warts.Equals"))
+  object RefinedEndpointPath extends Refined[String] {
+    override inline def invalidReason(a: String): String =
+      "It must be a non-empty String"
+
+    override inline def predicate(a: String): Boolean = a != ""
+  }
+
+  type InlinedRefinedNewtypeId = InlinedRefinedNewtypeId.Type
+  object InlinedRefinedNewtypeId extends Newtype[Id]
+}


### PR DESCRIPTION
Close #113 - [`refined4s-pureconfig`] Add `ConfigReader` and `ConfigWriter`s for `Newtype`, `Refined` and `InlinedRefined` with `Coercible` and `RefinedCtor`