### PR TITLE
refined4s v0.3.0

### DIFF
--- a/changelogs/0.3.0.md
+++ b/changelogs/0.3.0.md
@@ -1,0 +1,90 @@
+## [0.3.0](https://github.com/kevin-lee/refined4s/issues?q=is%3Aissue+is%3Aclosed+-label%3Ainvalid+milestone%3Am3) - 2023-12-15
+
+### Changes
+
+* [`refined4s-cats`] Replace `Eq` and `Show` instances for the existing refined types with the ones derived from the actual types using `Coercible` (#107)
+
+### New Features
+
+* Add `refined4s-circe` module to support [circe](https://github.com/circe/circe) (#101)
+
+* [`refined4s-circe`] Add `Encoder` and `Decoder`s for `Newtype`, `Refined` and `InlinedRefined` with `Coercible` and `RefinedCtor` (#103)
+
+* [`refined4s-circe`] Add `CirceEncoder`, `CirceNewtypeDecoder`, `CirceRefinedDecoder`, `CirceNewtypeCodec` and `CirceRefinedCodec` to have circe `Encoder` and `Decoder` derived from the actual type for `Newtype`, `Refined` and `InlinedRefined` (#104)
+  ```scala 3
+  import refined4s.modules.circe.derivation.*
+  ```
+  ```scala 3
+  type MyNewtype = MyNewtype.Type
+  object MyNewtype extends Newtype[String] with CirceEncoder[String]
+  
+  type MyRefinedType = MyRefinedType.Type
+  object MyRefinedType extends Refined[String] with CirceEncoder[String] {
+    override inline def invalidReason(a: String): String =
+      "It has to be a non-empty String but got \"" + a + "\""
+  
+    override inline def predicate(a: String): Boolean = a != ""
+  }
+  
+  type MyRefinedNewtype = MyRefinedNewtype.Type
+  object MyRefinedNewtype extends Newtype[MyRefinedType] with CirceEncoder[MyRefinedType]
+  ```
+  
+  ```scala 3
+  type MyNewtype = MyNewtype.Type
+  object MyNewtype extends Newtype[String] with CirceNewtypeDecoder[String]
+  
+  type MyRefinedType = MyRefinedType.Type
+  object MyRefinedType extends Refined[String] with CirceRefinedDecoder[String] {
+    override inline def invalidReason(a: String): String =
+      "It has to be a non-empty String but got \"" + a + "\""
+  
+    override inline def predicate(a: String): Boolean = a != ""
+  }
+  
+  type MyRefinedNewtype = MyRefinedNewtype.Type
+  object MyRefinedNewtype extends Newtype[MyRefinedType] with CirceNewtypeDecoder[MyRefinedType]
+  ```
+
+* [`refined4s-core`] Add `PortNumber`, `SystemPortNumber`, `NonSystemPortNumber`, `UserPortNumber` and `DynamicPortNumber` (#110)
+
+* Add `refined4s-pureconfig` module to support `pureconfig` (#112)
+
+* [`refined4s-pureconfig`] Add `ConfigReader` and `ConfigWriter`s for `Newtype`, `Refined` and `InlinedRefined` with `Coercible` and `RefinedCtor` (#113)
+  
+  ```scala 3
+  import refined4s.modules.pureconfig.derivation.instances.given
+  ```
+
+* [`refined4s-pureconfig`] Add `PureconfigNewtypeConfigReader` and `PureconfigRefinedConfigReader` to provider `ConfigReader` for `Newtype`, `Refined` and `InlinedRefined` (#116)
+  
+  ```scala 3
+  type MyNewtype = MyNewtype.Type
+  object MyNewtype extends Newtype[String] with PureconfigNewtypeConfigReader[String]
+  
+  type MyRefinedType = MyRefinedType.Type
+  object MyRefinedType extends Refined[String] with PureconfigRefinedConfigReader[String] {
+    override inline def invalidReason(a: String): String =
+      "It has to be a non-empty String but got \"" + a + "\""
+  
+    override inline def predicate(a: String): Boolean = a != ""
+  }
+  
+  type MyRefinedNewtype = MyRefinedNewtype.Type
+  object MyRefinedNewtype extends Newtype[MyRefinedType] with PureconfigNewtypeConfigReader[MyRefinedType]
+  
+  type MyInlinedRefinedType = MyInlinedRefinedType.Type
+  object MyInlinedRefinedType extends InlinedRefined[String] with PureconfigRefinedConfigReader[String] {
+    override inline def invalidReason(a: String): String =
+      "It has to be a non-empty String but got \"" + a + "\""
+  
+    override inline def predicate(a: String): Boolean = a != ""
+  
+    override inline def inlinedPredicate(inline a: String): Boolean = a != ""
+  }
+  
+  type MyInlinedRefinedNewtype = MyInlinedRefinedNewtype.Type
+  object MyInlinedRefinedNewtype extends Newtype[MyRefinedType] with PureconfigNewtypeConfigReader[MyRefinedType]
+  ```
+
+* [`refined4s-pureconfig`] Add `PureconfigConfigWriter` to provider `ConfigWriter` for `Newtype`, `Refined` and `InlinedRefined` (#118)


### PR DESCRIPTION
# refined4s v0.3.0
## [0.3.0](https://github.com/kevin-lee/refined4s/issues?q=is%3Aissue+is%3Aclosed+-label%3Ainvalid+milestone%3Am3) - 2023-12-15

### Changes

* [`refined4s-cats`] Replace `Eq` and `Show` instances for the existing refined types with the ones derived from the actual types using `Coercible` (#107)

### New Features

* Add `refined4s-circe` module to support [circe](https://github.com/circe/circe) (#101)

* [`refined4s-circe`] Add `Encoder` and `Decoder`s for `Newtype`, `Refined` and `InlinedRefined` with `Coercible` and `RefinedCtor` (#103)

* [`refined4s-circe`] Add `CirceEncoder`, `CirceNewtypeDecoder`, `CirceRefinedDecoder`, `CirceNewtypeCodec` and `CirceRefinedCodec` to have circe `Encoder` and `Decoder` derived from the actual type for `Newtype`, `Refined` and `InlinedRefined` (#104)
  ```scala 3
  import refined4s.modules.circe.derivation.*
  ```
  ```scala 3
  type MyNewtype = MyNewtype.Type
  object MyNewtype extends Newtype[String] with CirceEncoder[String]
  
  type MyRefinedType = MyRefinedType.Type
  object MyRefinedType extends Refined[String] with CirceEncoder[String] {
    override inline def invalidReason(a: String): String =
      "It has to be a non-empty String but got \"" + a + "\""
  
    override inline def predicate(a: String): Boolean = a != ""
  }
  
  type MyRefinedNewtype = MyRefinedNewtype.Type
  object MyRefinedNewtype extends Newtype[MyRefinedType] with CirceEncoder[MyRefinedType]
  ```
  
  ```scala 3
  type MyNewtype = MyNewtype.Type
  object MyNewtype extends Newtype[String] with CirceNewtypeDecoder[String]
  
  type MyRefinedType = MyRefinedType.Type
  object MyRefinedType extends Refined[String] with CirceRefinedDecoder[String] {
    override inline def invalidReason(a: String): String =
      "It has to be a non-empty String but got \"" + a + "\""
  
    override inline def predicate(a: String): Boolean = a != ""
  }
  
  type MyRefinedNewtype = MyRefinedNewtype.Type
  object MyRefinedNewtype extends Newtype[MyRefinedType] with CirceNewtypeDecoder[MyRefinedType]
  ```

* [`refined4s-core`] Add `PortNumber`, `SystemPortNumber`, `NonSystemPortNumber`, `UserPortNumber` and `DynamicPortNumber` (#110)

* Add `refined4s-pureconfig` module to support `pureconfig` (#112)

* [`refined4s-pureconfig`] Add `ConfigReader` and `ConfigWriter`s for `Newtype`, `Refined` and `InlinedRefined` with `Coercible` and `RefinedCtor` (#113)
  
  ```scala 3
  import refined4s.modules.pureconfig.derivation.instances.given
  ```

* [`refined4s-pureconfig`] Add `PureconfigNewtypeConfigReader` and `PureconfigRefinedConfigReader` to provider `ConfigReader` for `Newtype`, `Refined` and `InlinedRefined` (#116)
  
  ```scala 3
  type MyNewtype = MyNewtype.Type
  object MyNewtype extends Newtype[String] with PureconfigNewtypeConfigReader[String]
  
  type MyRefinedType = MyRefinedType.Type
  object MyRefinedType extends Refined[String] with PureconfigRefinedConfigReader[String] {
    override inline def invalidReason(a: String): String =
      "It has to be a non-empty String but got \"" + a + "\""
  
    override inline def predicate(a: String): Boolean = a != ""
  }
  
  type MyRefinedNewtype = MyRefinedNewtype.Type
  object MyRefinedNewtype extends Newtype[MyRefinedType] with PureconfigNewtypeConfigReader[MyRefinedType]
  
  type MyInlinedRefinedType = MyInlinedRefinedType.Type
  object MyInlinedRefinedType extends InlinedRefined[String] with PureconfigRefinedConfigReader[String] {
    override inline def invalidReason(a: String): String =
      "It has to be a non-empty String but got \"" + a + "\""
  
    override inline def predicate(a: String): Boolean = a != ""
  
    override inline def inlinedPredicate(inline a: String): Boolean = a != ""
  }
  
  type MyInlinedRefinedNewtype = MyInlinedRefinedNewtype.Type
  object MyInlinedRefinedNewtype extends Newtype[MyRefinedType] with PureconfigNewtypeConfigReader[MyRefinedType]
  ```

* [`refined4s-pureconfig`] Add `PureconfigConfigWriter` to provider `ConfigWriter` for `Newtype`, `Refined` and `InlinedRefined` (#118)
