### PR TITLE
Close #127 - [`refined4s-doobie`] Add `DoobiePut`, `DoobieNewtypeGet`, `DoobieRefinedGet`, `DoobieNewtypeGetPut` and `DoobieRefinedGetPut` to have circe `Get` and `Put` derived from the actual type for `Newtype`, `Refined` and `InlinedRefined`

### DIFF
--- a/modules/refined4s-doobie-ce2/shared/src/main/scala/refined4s/modules/doobie/derivation/DoobieNewtypeGet.scala
+++ b/modules/refined4s-doobie-ce2/shared/src/main/scala/refined4s/modules/doobie/derivation/DoobieNewtypeGet.scala
@@ -1,0 +1,13 @@
+package refined4s.modules.doobie.derivation
+
+import doobie.Get
+import refined4s.NewtypeBase
+
+/** @author Kevin Lee
+  * @since 2023-12-16
+  */
+trait DoobieNewtypeGet[A: Get] {
+  self: NewtypeBase[A] =>
+
+  given derivedGet: Get[Type] = deriving[Get]
+}

--- a/modules/refined4s-doobie-ce2/shared/src/main/scala/refined4s/modules/doobie/derivation/DoobieNewtypeGetPut.scala
+++ b/modules/refined4s-doobie-ce2/shared/src/main/scala/refined4s/modules/doobie/derivation/DoobieNewtypeGetPut.scala
@@ -1,0 +1,11 @@
+package refined4s.modules.doobie.derivation
+
+import doobie.Get
+import refined4s.NewtypeBase
+
+/** @author Kevin Lee
+  * @since 2023-12-16
+  */
+trait DoobieNewtypeGetPut[A] extends DoobieNewtypeGet[A] with DoobiePut[A] {
+  self: NewtypeBase[A] =>
+}

--- a/modules/refined4s-doobie-ce2/shared/src/main/scala/refined4s/modules/doobie/derivation/DoobiePut.scala
+++ b/modules/refined4s-doobie-ce2/shared/src/main/scala/refined4s/modules/doobie/derivation/DoobiePut.scala
@@ -1,0 +1,13 @@
+package refined4s.modules.doobie.derivation
+
+import doobie.Put
+import refined4s.NewtypeBase
+
+/** @author Kevin Lee
+  * @since 2023-12-16
+  */
+trait DoobiePut[A: Put] {
+  self: NewtypeBase[A] =>
+
+  given derivedPut: Put[Type] = deriving[Put]
+}

--- a/modules/refined4s-doobie-ce2/shared/src/main/scala/refined4s/modules/doobie/derivation/DoobieRefinedGet.scala
+++ b/modules/refined4s-doobie-ce2/shared/src/main/scala/refined4s/modules/doobie/derivation/DoobieRefinedGet.scala
@@ -1,0 +1,14 @@
+package refined4s.modules.doobie.derivation
+
+import cats.Show
+import doobie.Get
+import refined4s.RefinedBase
+
+/** @author Kevin Lee
+  * @since 2023-12-16
+  */
+trait DoobieRefinedGet[A: Get: Show] {
+  self: RefinedBase[A] =>
+
+  given derivedGet: Get[Type] = Get[A].temap(from)
+}

--- a/modules/refined4s-doobie-ce2/shared/src/main/scala/refined4s/modules/doobie/derivation/DoobieRefinedGetPut.scala
+++ b/modules/refined4s-doobie-ce2/shared/src/main/scala/refined4s/modules/doobie/derivation/DoobieRefinedGetPut.scala
@@ -1,0 +1,11 @@
+package refined4s.modules.doobie.derivation
+
+import doobie.Get
+import refined4s.{NewtypeBase, RefinedBase}
+
+/** @author Kevin Lee
+  * @since 2023-12-16
+  */
+trait DoobieRefinedGetPut[A] extends DoobieRefinedGet[A] with DoobiePut[A] {
+  self: RefinedBase[A] =>
+}

--- a/modules/refined4s-doobie-ce2/shared/src/test/scala/refined4s/modules/doobie/derivation/DoobieGetPutSpec.scala
+++ b/modules/refined4s-doobie-ce2/shared/src/test/scala/refined4s/modules/doobie/derivation/DoobieGetPutSpec.scala
@@ -1,0 +1,74 @@
+package refined4s.modules.doobie.derivation
+
+import cats.Eq
+import cats.effect.ContextShift
+import cats.syntax.all.*
+import doobie.syntax.all.*
+import extras.doobie.RunWithDb
+import extras.doobie.ce2.DbTools
+import extras.runner.ce2.RunSyncCe2
+import hedgehog.*
+import hedgehog.runner.*
+import refined4s.*
+import refined4s.modules.cats.derivation.*
+import refined4s.types.all.*
+
+/** @author Kevin Lee
+  * @since 2023-12-16
+  */
+object DoobieGetPutSpec extends Properties with RunSyncCe2 with RunWithDb {
+
+  import effectie.instances.ce2.fx.ioFx
+
+  override def tests: List[Test] = List(
+    propertyWithDb(
+      "test DoobiePut, DoobieNewtypeGet, DoobieRefinedGet, DoobieNewtypeGetPut and DoobieRefinedGetPut all together by fetching and updating data",
+      testFetchUpdateFetch,
+    )
+  )
+
+  @SuppressWarnings(Array("org.wartremover.warts.GlobalExecutionContext"))
+  implicit val cs: ContextShift[F] = F.contextShift(scala.concurrent.ExecutionContext.global)
+
+  def testFetchUpdateFetch(testName: String): Property =
+    for {
+      example <- genExampleWithDoobieGetPut.log("example")
+    } yield withDb[F](testName) { transactor =>
+      val expectedFetchBefore = none[ExampleWithDoobieGetPut]
+      val expectedInsert      = 1
+      val expectedFetchAfter  = example.some
+
+      val fetch = DbTools.fetchSingleRow[F][ExampleWithDoobieGetPut](
+        sql"""
+          SELECT id, name, note, count
+            FROM db_tools_test.example
+        """
+      )(transactor)
+
+      val insert = DbTools.updateSingle[F](
+        sql"""
+          INSERT INTO db_tools_test.example (id, name, note, count) VALUES (${example.id}, ${example.name}, ${example.note}, ${example.count})
+        """
+      )(transactor)
+
+      for {
+        fetchResultBefore <- fetch.map(_ ==== expectedFetchBefore)
+        insertResult      <- insert.map(_ ==== expectedInsert)
+        fetchResultAfter  <- fetch.map(_ ==== expectedFetchAfter)
+      } yield Result.all(
+        List(
+          fetchResultBefore.log("Failed: fetch before"),
+          insertResult.log("Failed: insert"),
+          fetchResultAfter.log("Failed: fetch after"),
+        )
+      )
+    }
+
+  def genExampleWithDoobieGetPut: Gen[ExampleWithDoobieGetPut] = for {
+    id    <- Gen.int(Range.linear(1, Int.MaxValue)).map(ExampleWithDoobieGetPut.Id(_))
+    name  <- Gen.string(Gen.alphaNum, Range.linear(5, 20)).map(s => ExampleWithDoobieGetPut.Name(NonEmptyString.unsafeFrom(s)))
+    note  <-
+      Gen.string(Gen.alphaNum, Range.linear(5, 20)).map(s => ExampleWithDoobieGetPut.Note(ExampleWithDoobieGetPut.MyString.unsafeFrom(s)))
+    count <- Gen.int(Range.linear(0, Int.MaxValue)).map(ExampleWithDoobieGetPut.Count.unsafeFrom)
+  } yield ExampleWithDoobieGetPut(id, name, note, count)
+}

--- a/modules/refined4s-doobie-ce2/shared/src/test/scala/refined4s/modules/doobie/derivation/ExampleWithDoobieGetPut.scala
+++ b/modules/refined4s-doobie-ce2/shared/src/test/scala/refined4s/modules/doobie/derivation/ExampleWithDoobieGetPut.scala
@@ -1,0 +1,47 @@
+package refined4s.modules.doobie.derivation
+
+import cats.*
+import refined4s.*
+import refined4s.modules.cats.derivation.*
+import refined4s.modules.cats.derivation.instances.given
+import refined4s.modules.doobie.derivation.instances.given
+import refined4s.types.all.*
+
+final case class ExampleWithDoobieGetPut(
+  id: ExampleWithDoobieGetPut.Id,
+  name: ExampleWithDoobieGetPut.Name,
+  note: ExampleWithDoobieGetPut.Note,
+  count: ExampleWithDoobieGetPut.Count,
+)
+object ExampleWithDoobieGetPut {
+
+  given eqExampleWithDoobieGetPut: Eq[ExampleWithDoobieGetPut]     = Eq.fromUniversalEquals
+  given showExampleWithDoobieGetPut: Show[ExampleWithDoobieGetPut] = Show.fromToString
+
+  type Id = Id.Type
+  object Id extends Newtype[Int] with CatsEqShow[Int] with DoobieNewtypeGetPut[Int]
+
+  type Name = Name.Type
+  object Name extends Newtype[NonEmptyString] with CatsEqShow[NonEmptyString] with DoobieNewtypeGetPut[NonEmptyString]
+
+  type MyString = MyString.Type
+  @SuppressWarnings(Array("org.wartremover.warts.Equals"))
+  object MyString extends InlinedRefined[String] with DoobieRefinedGetPut[String] {
+    override inline def inlinedPredicate(inline a: String): Boolean = a != ""
+
+    override inline def invalidReason(a: String): String = "It must be a non-empty String"
+
+    override inline def predicate(a: String): Boolean = a != ""
+  }
+
+  type Note = Note.Type
+  object Note extends Newtype[MyString] with CatsEqShow[MyString] with DoobieNewtypeGetPut[MyString]
+
+  type Count = Count.Type
+  object Count extends Refined[Int] with CatsEqShow[Int] with DoobieRefinedGetPut[Int] {
+
+    override inline def invalidReason(a: Int): String = "It must be a non-negative Int"
+
+    override inline def predicate(a: Int): Boolean = a >= 0
+  }
+}


### PR DESCRIPTION
Close #127 - [`refined4s-doobie`] Add `DoobiePut`, `DoobieNewtypeGet`, `DoobieRefinedGet`, `DoobieNewtypeGetPut` and `DoobieRefinedGetPut` to have circe `Get` and `Put` derived from the actual type for `Newtype`, `Refined` and `InlinedRefined`