### PR TITLE
refined4s v0.4.0

### DIFF
--- a/changelogs/0.4.0.md
+++ b/changelogs/0.4.0.md
@@ -1,0 +1,7 @@
+## [0.4.0](https://github.com/kevin-lee/refined4s/issues?q=is%3Aissue+is%3Aclosed+-label%3Ainvalid+milestone%3Am4) - 2023-12-16
+
+### New Features
+
+* Add `refined4s-doobie-ce2` and `refined4s-doobie-ce3` modules to support [doobie](https://github.com/tpolecat/doobie) (#123)
+* [`refined4s-doobie`] Add `Get`s and `Put` for `Newtype`, `Refined` and `InlinedRefined` with `Coercible` and `RefinedCtor` (#124)
+* [`refined4s-doobie`] Add `DoobiePut`, `DoobieNewtypeGet`, `DoobieRefinedGet`, `DoobieNewtypeGetPut` and `DoobieRefinedGetPut` to have circe `Get` and `Put` derived from the actual type for `Newtype`, `Refined` and `InlinedRefined` (#127)


### PR DESCRIPTION
# refined4s v0.4.0
## [0.4.0](https://github.com/kevin-lee/refined4s/issues?q=is%3Aissue+is%3Aclosed+-label%3Ainvalid+milestone%3Am4) - 2023-12-16

### New Features

* Add `refined4s-doobie-ce2` and `refined4s-doobie-ce3` modules to support [doobie](https://github.com/tpolecat/doobie) (#123)
* [`refined4s-doobie`] Add `Get`s and `Put` for `Newtype`, `Refined` and `InlinedRefined` with `Coercible` and `RefinedCtor` (#124)
* [`refined4s-doobie`] Add `DoobiePut`, `DoobieNewtypeGet`, `DoobieRefinedGet`, `DoobieNewtypeGetPut` and `DoobieRefinedGetPut` to have circe `Get` and `Put` derived from the actual type for `Newtype`, `Refined` and `InlinedRefined` (#127)
