### PR TITLE
Close #150 - [`refined4s-pureconfig`] Add type name to the error message of `PureconfigRefinedConfigReader` and `refined4s.modules.pureconfig.derivation.instances.derivedRefinedConfigReader`

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -197,6 +197,7 @@ lazy val props =
     val RepoName       = GitHubRepo.fold("refined4s")(_.nameToString)
 
     val Scala3Version = "3.1.3"
+//    val Scala3Version = "3.3.1"
 
     val ProjectScalaVersion = Scala3Version
 

--- a/modules/refined4s-pureconfig/shared/src/test/scala/refined4s/modules/pureconfig/derivation/instancesSpec.scala
+++ b/modules/refined4s-pureconfig/shared/src/test/scala/refined4s/modules/pureconfig/derivation/instancesSpec.scala
@@ -78,7 +78,9 @@ object instancesSpec extends Properties {
              |}
              |""".stripMargin
 
-      val expected = s"Invalid value found: ${id.toString} with error: Invalid value: [${id.toString}]. It must be a positive Long"
+      val expected =
+        s"The value ${id.toString} cannot be created as the expected type, ${Id.getClass.getName.replace("$", ".")}Type, due to the following error: " +
+          s"Invalid value: [${id.toString}]. It must be a positive Long"
 
       ConfigSource
         .string(confString)


### PR DESCRIPTION
Close #150 - [`refined4s-pureconfig`] Add type name to the error message of `PureconfigRefinedConfigReader` and `refined4s.modules.pureconfig.derivation.instances.derivedRefinedConfigReader`