### PR TITLE
Close #152 - [`refined4s-core`] Add `contraCoercible` to `F[B] => F[A]` with `Contravariant[F]` and `Coercible[A, B]`

### DIFF
--- a/modules/refined4s-cats/shared/src/main/scala/refined4s/modules/cats/derivation/instances.scala
+++ b/modules/refined4s-cats/shared/src/main/scala/refined4s/modules/cats/derivation/instances.scala
@@ -2,7 +2,6 @@ package refined4s.modules.cats.derivation
 
 import cats.*
 import refined4s.*
-import refined4s.types.all.*
 
 /** @author Kevin Lee
   * @since 2023-12-07
@@ -10,9 +9,12 @@ import refined4s.types.all.*
 
 trait instances {
 
-  given eqDerived[A, B](using coercible: Coercible[A, B], eqB: Eq[B]): Eq[A] = (a1, a2) => eqB.eqv(coercible(a1), coercible(a2))
+  inline def contraCoercible[F[*], A, B](fb: F[B])(using contravariant: Contravariant[F], coercible: Coercible[A, B]): F[A] =
+    contravariant.contramap[B, A](fb)(coercible(_))
 
-  given showDerived[A, B](using coercible: Coercible[A, B], showB: Show[B]): Show[A] = showB.show.compose(coercible(_))(_)
+  inline given eqDerived[A, B](using coercible: Coercible[A, B], eqB: Eq[B]): Eq[A] = contraCoercible(eqB)
+
+  inline given showDerived[A, B](using coercible: Coercible[A, B], showB: Show[B]): Show[A] = contraCoercible(showB)
 
 }
 object instances extends instances


### PR DESCRIPTION
Close #152 - [`refined4s-core`] Add `contraCoercible` to `F[B] => F[A]` with `Contravariant[F]` and `Coercible[A, B]`
- Now `eqDerived` and `showDerived` use `contraCoercible`