### PR TITLE
Close #154 - [`refined4s-circe`] Update `refined4s.modules.circe.derivation.instances.derivedEncoder` to use `contraCoercible` and make it `inline`

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -100,7 +100,10 @@ lazy val circe    = module("circe", crossProject(JVMPlatform, JSPlatform))
       libs.extrasTypeInfo % Test,
     )
   )
-  .dependsOn(core % props.IncludeTest)
+  .dependsOn(
+    core % props.IncludeTest,
+    cats,
+  )
 lazy val circeJvm = circe.jvm
 lazy val circeJs  = circe.js.settings(jsSettingsForFuture)
 

--- a/modules/refined4s-circe/shared/src/main/scala/refined4s/modules/circe/derivation/instances.scala
+++ b/modules/refined4s-circe/shared/src/main/scala/refined4s/modules/circe/derivation/instances.scala
@@ -2,20 +2,19 @@ package refined4s.modules.circe.derivation
 
 import io.circe.{Decoder, Encoder}
 import refined4s.{Coercible, RefinedCtor}
-import refined4s.syntax.*
 
 /** @author Kevin Lee
   * @since 2023-12-11
   */
 trait instances {
 
-  given derivedEncoder[A, B](using coercible: Coercible[A, B], encoder: Encoder[B]): Encoder[A] =
-    a => encoder(coercible(a))
+  inline given derivedEncoder[A, B](using coercible: Coercible[A, B], encoder: Encoder[B]): Encoder[A] =
+    refined4s.modules.cats.derivation.instances.contraCoercible(encoder)
 
-  given derivedNewtypeDecoder[A, B](using coercible: Coercible[A, B], decoder: Decoder[A]): Decoder[B] =
+  inline given derivedNewtypeDecoder[A, B](using coercible: Coercible[A, B], decoder: Decoder[A]): Decoder[B] =
     Coercible.unsafeWrapM(decoder)
 
-  given derivedRefinedDecoder[A, B](using refinedCtor: RefinedCtor[B, A], decoder: Decoder[A]): Decoder[B] =
+  inline given derivedRefinedDecoder[A, B](using refinedCtor: RefinedCtor[B, A], decoder: Decoder[A]): Decoder[B] =
     decoder.emap(refinedCtor.create)
 }
 object instances extends instances


### PR DESCRIPTION
Close #154 - [`refined4s-circe`] Update `refined4s.modules.circe.derivation.instances.derivedEncoder` to use `contraCoercible` and make it `inline`