### PR TITLE
Close #160 - Rename `Coercible` methods and type parameters

### DIFF
--- a/modules/refined4s-circe/shared/src/main/scala/refined4s/modules/circe/derivation/instances.scala
+++ b/modules/refined4s-circe/shared/src/main/scala/refined4s/modules/circe/derivation/instances.scala
@@ -12,7 +12,7 @@ trait instances {
     refined4s.modules.cats.derivation.instances.contraCoercible(encoder)
 
   inline given derivedNewtypeDecoder[A, B](using coercible: Coercible[A, B], decoder: Decoder[A]): Decoder[B] =
-    Coercible.unsafeWrapM(decoder)
+    Coercible.unsafeWrapTC(decoder)
 
   inline given derivedRefinedDecoder[A, B](using refinedCtor: RefinedCtor[B, A], decoder: Decoder[A]): Decoder[B] =
     decoder.emap(refinedCtor.create)

--- a/modules/refined4s-core/shared/src/main/scala/refined4s/Coercible.scala
+++ b/modules/refined4s-core/shared/src/main/scala/refined4s/Coercible.scala
@@ -23,12 +23,12 @@ object Coercible {
   private object coercible extends Coercible[Any, Any]
 
   /* For type constructors */
-  given unsafeWrapM[M[*], A, B](
+  given unsafeWrapTC[F[*], A, B](
     using Coercible[A, B]
-  ): Coercible[M[A], M[B]] = Coercible.instance
+  ): Coercible[F[A], F[B]] = Coercible.instance
 
-  /* For nested type constructors */
-  given unsafeWrapMOfM[M1[*], M2[*], A, B](
-    using Coercible[M2[A], M2[B]]
-  ): Coercible[M1[M2[A]], M1[M2[B]]] = Coercible.instance
+  /* For higher-kinded type */
+  given unsafeWrapHKT[F[*], G[*], A, B](
+    using Coercible[G[A], G[B]]
+  ): Coercible[F[G[A]], F[G[B]]] = Coercible.instance
 }

--- a/modules/refined4s-core/shared/src/main/scala/refined4s/Newtype.scala
+++ b/modules/refined4s-core/shared/src/main/scala/refined4s/Newtype.scala
@@ -10,12 +10,13 @@ trait Newtype[A] extends NewtypeBase[A] {
 
   def unapply(typ: Type): Option[A] = Some(typ)
 
-  inline given wrap: Coercible[A, Type]              = Coercible.instance
-  inline given wrapM[M[*]]: Coercible[M[A], M[Type]] = Coercible.instance
+  inline given wrap: Coercible[A, Type] = Coercible.instance
+
+  inline given wrapTC[F[*]]: Coercible[F[A], F[Type]] = Coercible.instance
 
   extension (typ: Type) {
     override inline def value: A = typ
   }
 
-  override def deriving[M[*]](using fa: M[A]): M[Type] = fa
+  override def deriving[F[*]](using fa: F[A]): F[Type] = fa
 }

--- a/modules/refined4s-core/shared/src/main/scala/refined4s/NewtypeBase.scala
+++ b/modules/refined4s-core/shared/src/main/scala/refined4s/NewtypeBase.scala
@@ -8,13 +8,14 @@ trait NewtypeBase[A] {
 
   given newRefinedCanEqual: CanEqual[Type, Type] = CanEqual.derived
 
-  inline given unwrap: Coercible[Type, A]              = Coercible.instance
-  inline given unwrapM[M[*]]: Coercible[M[Type], M[A]] = Coercible.instance
+  inline given unwrap: Coercible[Type, A] = Coercible.instance
+
+  inline given unwrapTC[F[*]]: Coercible[F[Type], F[A]] = Coercible.instance
 
   extension (typ: Type) {
     def value: A
   }
 
-  def deriving[M[*]](using fa: M[A]): M[Type]
+  def deriving[F[*]](using fa: F[A]): F[Type]
 
 }

--- a/modules/refined4s-core/shared/src/main/scala/refined4s/RefinedBase.scala
+++ b/modules/refined4s-core/shared/src/main/scala/refined4s/RefinedBase.scala
@@ -33,6 +33,6 @@ trait RefinedBase[A] extends NewtypeBase[A] {
     override inline def value: A = typ
   }
 
-  override def deriving[M[*]](using fa: M[A]): M[Type] = fa
+  override def deriving[F[*]](using fa: F[A]): F[Type] = fa
 
 }

--- a/modules/refined4s-core/shared/src/test/scala/refined4s/CoercibleSpec.scala
+++ b/modules/refined4s-core/shared/src/test/scala/refined4s/CoercibleSpec.scala
@@ -12,8 +12,8 @@ object CoercibleSpec extends Properties {
   override def tests: List[Test] = List(
     property("test Coercible[A, B].apply", testApply),
     property("test Coercible[A, B].instance.apply", testApply),
-    property("Coercible.unsafeWrapM[M[*], A, B](M[A]) should return M[B]", testUnsafeWrapM),
-    property("Coercible.unsafeWrapMOfM[M1[*], M2[*], A, B](M1[M2[A]]) should return M1[M2[B]]", testUnsafeWrapMOfM),
+    property("Coercible.unsafeWrapTC[F[*], A, B](F[A]) should return F[B]", testUnsafeWrapM),
+    property("Coercible.unsafeWrapHKT[F[*], G[*], A, B](F[G[A]]) should return F[G[B]]", testUnsafeWrapMOfM),
   )
 
   def testApply: Property =
@@ -44,7 +44,7 @@ object CoercibleSpec extends Properties {
       testType <- Gen.constant(TestType(s).some).log("testType")
     } yield {
       val expected  = s.some
-      val coercible = Coercible.unsafeWrapM[Option, TestType, String]
+      val coercible = Coercible.unsafeWrapTC[Option, TestType, String]
       val actual    = coercible(testType)
       actual ==== expected
     }
@@ -55,7 +55,7 @@ object CoercibleSpec extends Properties {
       testType <- Gen.constant(List(TestType(s).some)).log("testType")
     } yield {
       val expected  = List(s.some)
-      val coercible = Coercible.unsafeWrapMOfM[List, Option, TestType, String]
+      val coercible = Coercible.unsafeWrapHKT[List, Option, TestType, String]
       val actual    = coercible(testType)
       actual ==== expected
     }

--- a/modules/refined4s-pureconfig/shared/src/main/scala/refined4s/modules/pureconfig/derivation/instances.scala
+++ b/modules/refined4s-pureconfig/shared/src/main/scala/refined4s/modules/pureconfig/derivation/instances.scala
@@ -11,7 +11,7 @@ import refined4s.*
 trait instances {
 
   inline given derivedNewtypeConfigReader[A, B](using coercible: Coercible[A, B], configReader: ConfigReader[A]): ConfigReader[B] =
-    Coercible.unsafeWrapM(configReader)
+    Coercible.unsafeWrapTC(configReader)
 
   import refined4s.internal.typeTools.*
 


### PR DESCRIPTION
* `wrap` and `unwrap` suffixed with `M`: `M` to `TC` (type constructor)
* `wrap` and `unwrap` suffixed with `MOfM`: `MOfM` to `HKT` (higher-kinded type)
* `M[*]` to `F[*]`
* `M1[*]` to `F[*]` and `M2[*]` to `G[*]` e.g.) `M1[M2[A]]` to `F[G[A]]`