### PR TITLE
refined4s v0.5.0

### DIFF
--- a/changelogs/0.5.0.md
+++ b/changelogs/0.5.0.md
@@ -1,0 +1,89 @@
+## [0.5.0](https://github.com/kevin-lee/refined4s/issues?q=is%3Aissue+is%3Aclosed+-label%3Ainvalid+milestone%3Am5) - 2023-12-23
+
+### New Features
+
+* [`refined4s-cats`] Add `contraCoercible` to `F[B] => F[A]` with `Contravariant[F]` and `Coercible[A, B]` (#152)
+
+  This is useful to derive type-class instances for `Newtype`, `Refined` and `InlinedRefined` from the type-class instances of the actual types.
+  
+  e.g.)
+  ```scala 3
+  import refined4s.modules.cats.derivation.instances.contraCoercible
+  
+  inline given eqDerived[A, B](using coercible: Coercible[A, B], eqB: Eq[B]): Eq[A] =
+    contraCoercible(eqB)
+  
+  inline given showDerived[A, B](using coercible: Coercible[A, B], showB: Show[B]): Show[A] =
+    contraCoercible(showB)
+  ```
+  where `B` is the actual type and `A` could be a newtype or a refined type.
+***
+
+
+### Improvement
+
+* Add missing `inline` to `invalidReason` in the sub-types of `InlinedNumeric` (#146)
+***
+* [`refined4s-pureconfig`] Add type name to the error message of `PureconfigRefinedConfigReader` and `refined4s.modules.pureconfig.derivation.instances.derivedRefinedConfigReader` (#150)
+
+  So a message like this
+  ```
+  
+  Invalid value found: -2373683071661092303 with error: Invalid value: [-2373683071661092303]. It must be a positive Long
+  ```
+  should be like this instead.
+  ```
+  The value -2373683071661092303 cannot be created as the expected type, mytypes.blah.Id.Type, due to the following error: Invalid value: [-2373683071661092303]. It must be a positive Long
+  ```
+
+***
+
+* [`refined4s-doobie`] Make type-classes in `refined4s.modules.doobie.derivation.instances` `inline` (#156)
+***
+
+* [`refined4s-core`] Improve compile-time error message for `inline apply` method (#158)
+
+  The old compile-time error for the constant value passed to the `inline` `apply` method may look like this.
+  ```
+  [error] 2780 |      NegBigInt(1)
+  [error]      |      ^^^^^^^^^^^^
+  [error]      |A literal string is expected as an argument to `compiletime.error`. Got "Invalid value: [BigInt.apply(1)]. ".+(
+  [error]      |  {
+  [error]      |    val a$proxy4: BigInt = BigInt.apply(1)
+  [error]      |    "It must be a negative BigInt":String:String
+  [error]      |  }:String
+  [error]      |)
+  [error] one error found
+  ```
+  
+  It is not so readable, and it is hard to comprehend what is wrong with the input.
+
+  After this release, it will be like
+  ```
+  [error] 2780 |      NegBigInt(1)
+  [error]      |      ^^^^^^^^^^^^
+  [error]      |      Invalid value: [BigInt.apply(1)]. It must be a negative BigInt
+  [error] one error found
+  ```
+***
+
+
+### Internal Housekeeping
+
+* [`refined4s-circe`] Update `refined4s.modules.circe.derivation.instances.derivedEncoder` to use `contraCoercible` and make it `inline` (#154)
+
+  The old code has the following issue if it's turned into an `inline` method.
+  ```
+  [error] 13 |    a => encoder(coercible(a))
+  [error]    |    ^^^^^^^^^^^^^^^^^^^^^^^^^^
+  [error]    |An inline given alias with a function value as right-hand side can significantly increase
+  [error]    |generated code size. You should either drop the `inline` or rewrite the given with an
+  [error]    |explicit `apply` method.
+  ```
+***
+
+* Rename `Coercible` methods and type parameters (#160)
+  * `wrap` and `unwrap` suffixed with `M`: `M` to `TC` (type constructor)
+  * `wrap` and `unwrap` suffixed with `MOfM`: `MOfM` to `HKT` (higher-kinded type)
+  * `M[*]` to `F[*]`
+  * `M1[*]` to `F[*]` and `M2[*]` to `G[*]` e.g.) `M1[M2[A]]` to `F[G[A]]`


### PR DESCRIPTION
# refined4s v0.5.0
## [0.5.0](https://github.com/kevin-lee/refined4s/issues?q=is%3Aissue+is%3Aclosed+-label%3Ainvalid+milestone%3Am5) - 2023-12-23

### New Features

* [`refined4s-cats`] Add `contraCoercible` to `F[B] => F[A]` with `Contravariant[F]` and `Coercible[A, B]` (#152)

  This is useful to derive type-class instances for `Newtype`, `Refined` and `InlinedRefined` from the type-class instances of the actual types.
  
  e.g.)
  ```scala 3
  import refined4s.modules.cats.derivation.instances.contraCoercible
  
  inline given eqDerived[A, B](using coercible: Coercible[A, B], eqB: Eq[B]): Eq[A] =
    contraCoercible(eqB)
  
  inline given showDerived[A, B](using coercible: Coercible[A, B], showB: Show[B]): Show[A] =
    contraCoercible(showB)
  ```
  where `B` is the actual type and `A` could be a newtype or a refined type.
***


### Improvement

* Add missing `inline` to `invalidReason` in the sub-types of `InlinedNumeric` (#146)
***
* [`refined4s-pureconfig`] Add type name to the error message of `PureconfigRefinedConfigReader` and `refined4s.modules.pureconfig.derivation.instances.derivedRefinedConfigReader` (#150)

  So a message like this
  ```
  
  Invalid value found: -2373683071661092303 with error: Invalid value: [-2373683071661092303]. It must be a positive Long
  ```
  should be like this instead.
  ```
  The value -2373683071661092303 cannot be created as the expected type, mytypes.blah.Id.Type, due to the following error: Invalid value: [-2373683071661092303]. It must be a positive Long
  ```

***

* [`refined4s-doobie`] Make type-classes in `refined4s.modules.doobie.derivation.instances` `inline` (#156)
***

* [`refined4s-core`] Improve compile-time error message for `inline apply` method (#158)

  The old compile-time error for the constant value passed to the `inline` `apply` method may look like this.
  ```
  [error] 2780 |      NegBigInt(1)
  [error]      |      ^^^^^^^^^^^^
  [error]      |A literal string is expected as an argument to `compiletime.error`. Got "Invalid value: [BigInt.apply(1)]. ".+(
  [error]      |  {
  [error]      |    val a$proxy4: BigInt = BigInt.apply(1)
  [error]      |    "It must be a negative BigInt":String:String
  [error]      |  }:String
  [error]      |)
  [error] one error found
  ```
  
  It is not so readable, and it is hard to comprehend what is wrong with the input.

  After this release, it will be like
  ```
  [error] 2780 |      NegBigInt(1)
  [error]      |      ^^^^^^^^^^^^
  [error]      |      Invalid value: [BigInt.apply(1)]. It must be a negative BigInt
  [error] one error found
  ```
***


### Internal Housekeeping

* [`refined4s-circe`] Update `refined4s.modules.circe.derivation.instances.derivedEncoder` to use `contraCoercible` and make it `inline` (#154)

  The old code has the following issue if it's turned into an `inline` method.
  ```
  [error] 13 |    a => encoder(coercible(a))
  [error]    |    ^^^^^^^^^^^^^^^^^^^^^^^^^^
  [error]    |An inline given alias with a function value as right-hand side can significantly increase
  [error]    |generated code size. You should either drop the `inline` or rewrite the given with an
  [error]    |explicit `apply` method.
  ```
***

* Rename `Coercible` methods and type parameters (#160)
  * `wrap` and `unwrap` suffixed with `M`: `M` to `TC` (type constructor)
  * `wrap` and `unwrap` suffixed with `MOfM`: `MOfM` to `HKT` (higher-kinded type)
  * `M[*]` to `F[*]`
  * `M1[*]` to `F[*]` and `M2[*]` to `G[*]` e.g.) `M1[M2[A]]` to `F[G[A]]`
