### PR TITLE
refined4s v0.6.0

### DIFF
--- a/changelogs/0.6.0.md
+++ b/changelogs/0.6.0.md
@@ -1,0 +1,31 @@
+## [0.6.0](https://github.com/kevin-lee/refined4s/issues?q=is%3Aissue+is%3Aclosed+-label%3Ainvalid+milestone%3Am6) - 2023-12-28
+
+### Changes
+
+* All modules: importing `derivation.instances.given` can cause an issue as it overrides all type-classes defined in the companion objects (#163)
+  * [`refined4s-cats`] Add explicit `Eq` and `Show` for pre-defined types (#171)
+
+    - Now it has `refined4s.modules.cats.derivation.types.all` for the all pre-defined types (e.g. `NegInt`, `PosInt`, `NonEmptyString`, etc.)
+    - `refined4s.modules.cats.derivation.instances` => `refined4s.modules.cats.derivation.generic.auto`
+    - `refined4s.modules.cats.derivation.instances.contraCoercible` is moved to `refined4s.modules.cats.syntax`
+  * [`refined4s-circe`] Add explicit `Encoder` and `Decoder` for pre-defined types (#166)
+  * [`refined4s-pureconfig`] Add explicit `ConfigReader` and `ConfigWriter` for pre-defined types (#172)
+  * [`refined4s-doobie`] Add explicit `Get` and `Put` for pre-defined types (#173)
+
+***
+* [`refined4s-core`] Keep only `all` `object` for pre-defined types and remove all the others (#168)
+
+  So this will be the only `import` available for using pre-defined types
+  ```scala 3
+  import refined4s.types.all.*
+  ```
+  The following ones have been removed.
+  ```scala 3
+  import refined4s.types.numeric.*
+  import refined4s.types.strings.*
+  import refined4s.types.network.*
+  ```
+
+***
+
+* Rename derived type classes - some of them have a naming conflict issue (#165)


### PR DESCRIPTION
# refined4s v0.6.0
## [0.6.0](https://github.com/kevin-lee/refined4s/issues?q=is%3Aissue+is%3Aclosed+-label%3Ainvalid+milestone%3Am6) - 2023-12-28

### Changes

* All modules: importing `derivation.instances.given` can cause an issue as it overrides all type-classes defined in the companion objects (#163)
  * [`refined4s-cats`] Add explicit `Eq` and `Show` for pre-defined types (#171)

    - Now it has `refined4s.modules.cats.derivation.types.all` for the all pre-defined types (e.g. `NegInt`, `PosInt`, `NonEmptyString`, etc.)
    - `refined4s.modules.cats.derivation.instances` => `refined4s.modules.cats.derivation.generic.auto`
    - `refined4s.modules.cats.derivation.instances.contraCoercible` is moved to `refined4s.modules.cats.syntax`
  * [`refined4s-circe`] Add explicit `Encoder` and `Decoder` for pre-defined types (#166)
  * [`refined4s-pureconfig`] Add explicit `ConfigReader` and `ConfigWriter` for pre-defined types (#172)
  * [`refined4s-doobie`] Add explicit `Get` and `Put` for pre-defined types (#173)

***
* [`refined4s-core`] Keep only `all` `object` for pre-defined types and remove all the others (#168)

  So this will be the only `import` available for using pre-defined types
  ```scala 3
  import refined4s.types.all.*
  ```
  The following ones have been removed.
  ```scala 3
  import refined4s.types.numeric.*
  import refined4s.types.strings.*
  import refined4s.types.network.*
  ```

***

* Rename derived type classes - some of them have a naming conflict issue (#165)
