### PR TITLE
Close #182 - [`refined4s-cats`] Rename `validateAs` in `refined4s.modules.cats.syntax` to `refinedNewtypeNec`

### DIFF
--- a/modules/refined4s-cats/shared/src/main/scala/refined4s/modules/cats/syntax.scala
+++ b/modules/refined4s-cats/shared/src/main/scala/refined4s/modules/cats/syntax.scala
@@ -18,7 +18,7 @@ trait syntax {
 
   extension [A, T](a: A) {
 
-    inline def validateAs[N](
+    inline def refinedNewtypeNec[N](
       using coercible: Coercible[T, N],
       refinedCtor: RefinedCtor[T, A],
     ): EitherNec[String, N] =

--- a/modules/refined4s-cats/shared/src/test/scala/refined4s/modules/cats/syntaxSpec.scala
+++ b/modules/refined4s-cats/shared/src/test/scala/refined4s/modules/cats/syntaxSpec.scala
@@ -13,141 +13,146 @@ import refined4s.modules.cats.syntax.*
   * @since 2023-12-06
   */
 object syntaxSpec extends Properties {
-  override def tests: List[Test] = List(
-    ///
-    property(
-      "For type T = Refined[A] and type N = NewType[T], a.validateAs[N] with a valid `a` should return EitherNec[String, N] = Right(N)",
-      testAValidateAsT,
-    ),
-    example(
-      "For type T = Refined[A] and type N = NewType[T], a.validateAs[N] with an invalid `a` should return EitherNec[String, N] = Left(String)",
-      testAValidateAsTInvalid,
-    ),
-    property(
-      "For type T = Refined[A] and type N = NewType[T], validateAs(a)[N] with a valid `a` should return EitherNec[String, N] = Right(N)",
-      testValidateAsTA,
-    ),
-    example(
-      "For type T = Refined[A] and type N = NewType[T], validateAs(a)[N] with an invalid `a` should return EitherNec[String, N] = Left(String)",
-      testValidateAsTAInvalid,
-    ),
-    ///
-    property(
-      "For type T = InlinedRefined[A] and type N = NewType[T], a.validateAs[N] with a valid `a` should return EitherNec[String, N] = Right(N)",
-      testInlinedRefined_AValidateAsT,
-    ),
-    property(
-      "For type T = InlinedRefined[A] and type N = NewType[T], a.validateAs[N] with an invalid `a` should return EitherNec[String, N] = Left(String)",
-      testInlinedRefined_AValidateAsTInvalid,
-    ),
-    property(
-      "For type T = InlinedRefined[A] and type N = NewType[T], validateAs(a)[N] with a valid `a` should return EitherNec[String, N] = Right(N)",
-      testInlinedRefined_ValidateAsTA,
-    ),
-    property(
-      "For type T = InlinedRefined[A] and type N = NewType[T], validateAs(a)[N] with an invalid `a` should return EitherNec[String, N] = Left(String)",
-      testInlinedRefined_ValidateAsTAInvalid,
-    ),
-  )
+  override def tests: List[Test] = RefinedNewtypeNec.tests
 
-  def testAValidateAsT: Property =
-    for {
-      s <- Gen.string(Gen.unicode, Range.linear(1, 10)).log("s")
-    } yield {
+  object RefinedNewtypeNec {
 
-      val expected = NewMyType(MyType.unsafeFrom(s)).rightNec[String]
-      val actual   = s.validateAs[NewMyType]
+    def tests: List[Test] = List(
+      ///
+      property(
+        "For type T = Refined[A] and type N = NewType[T], a.refinedNewtypeNec[N] with a valid `a` should return EitherNec[String, N] = Right(N)",
+        testARefinedNewtypeNecT,
+      ),
+      example(
+        "For type T = Refined[A] and type N = NewType[T], a.refinedNewtypeNec[N] with an invalid `a` should return EitherNec[String, N] = Left(String)",
+        testARefinedNewtypeNecTInvalid,
+      ),
+      property(
+        "For type T = Refined[A] and type N = NewType[T], refinedNewtypeNec(a)[N] with a valid `a` should return EitherNec[String, N] = Right(N)",
+        testRefinedNewtypeNecTA,
+      ),
+      example(
+        "For type T = Refined[A] and type N = NewType[T], refinedNewtypeNec(a)[N] with an invalid `a` should return EitherNec[String, N] = Left(String)",
+        testRefinedNewtypeNecTAInvalid,
+      ),
+      ///
+      property(
+        "For type T = InlinedRefined[A] and type N = NewType[T], a.refinedNewtypeNec[N] with a valid `a` should return EitherNec[String, N] = Right(N)",
+        testInlinedRefined_ARefinedNewtypeNecT,
+      ),
+      property(
+        "For type T = InlinedRefined[A] and type N = NewType[T], a.refinedNewtypeNec[N] with an invalid `a` should return EitherNec[String, N] = Left(String)",
+        testInlinedRefined_ARefinedNewtypeNecTInvalid,
+      ),
+      property(
+        "For type T = InlinedRefined[A] and type N = NewType[T], refinedNewtypeNec(a)[N] with a valid `a` should return EitherNec[String, N] = Right(N)",
+        testInlinedRefined_RefinedNewtypeNecTA,
+      ),
+      property(
+        "For type T = InlinedRefined[A] and type N = NewType[T], refinedNewtypeNec(a)[N] with an invalid `a` should return EitherNec[String, N] = Left(String)",
+        testInlinedRefined_RefinedNewtypeNecTAInvalid,
+      ),
+    )
+
+    def testARefinedNewtypeNecT: Property =
+      for {
+        s <- Gen.string(Gen.unicode, Range.linear(1, 10)).log("s")
+      } yield {
+
+        val expected = NewMyType(MyType.unsafeFrom(s)).rightNec[String]
+        val actual   = s.refinedNewtypeNec[NewMyType]
+        actual ==== expected
+      }
+
+    def testARefinedNewtypeNecTInvalid: Result = {
+      val expected =
+        "Failed to create refined4s.modules.cats.syntaxSpec.NewMyType: Invalid value: []. It has to be a non-empty String but got \"\""
+          .leftNec[NewMyType]
+      val actual   = "".refinedNewtypeNec[NewMyType]
       actual ==== expected
     }
 
-  def testAValidateAsTInvalid: Result = {
-    val expected =
-      "Failed to create refined4s.modules.cats.syntaxSpec.NewMyType: Invalid value: []. It has to be a non-empty String but got \"\""
-        .leftNec[NewMyType]
-    val actual   = "".validateAs[NewMyType]
-    actual ==== expected
-  }
+    def testRefinedNewtypeNecTA: Property =
+      for {
+        s <- Gen.string(Gen.unicode, Range.linear(1, 10)).log("s")
+      } yield {
 
-  def testValidateAsTA: Property =
-    for {
-      s <- Gen.string(Gen.unicode, Range.linear(1, 10)).log("s")
-    } yield {
+        val expected = NewMyType(MyType.unsafeFrom(s)).rightNec[String]
+        val actual   = refinedNewtypeNec(s)[NewMyType]
+        actual ==== expected
+      }
 
-      val expected = NewMyType(MyType.unsafeFrom(s)).rightNec[String]
-      val actual   = validateAs(s)[NewMyType]
+    def testRefinedNewtypeNecTAInvalid: Result = {
+      val expected =
+        "Failed to create refined4s.modules.cats.syntaxSpec.NewMyType: Invalid value: []. It has to be a non-empty String but got \"\""
+          .leftNec[NewMyType]
+      val actual   = refinedNewtypeNec("")[NewMyType]
       actual ==== expected
     }
 
-  def testValidateAsTAInvalid: Result = {
-    val expected =
-      "Failed to create refined4s.modules.cats.syntaxSpec.NewMyType: Invalid value: []. It has to be a non-empty String but got \"\""
-        .leftNec[NewMyType]
-    val actual   = validateAs("")[NewMyType]
-    actual ==== expected
+    def testInlinedRefined_ARefinedNewtypeNecT: Property =
+      for {
+        s <- Gen.string(Gen.unicode, Range.linear(3, 10)).log("s")
+      } yield {
+
+        val expected = NewMoreThan2CharsString(MoreThan2CharsString.unsafeFrom(s)).rightNec[String]
+        val actual   = s.refinedNewtypeNec[NewMoreThan2CharsString]
+        (actual ==== expected).log(
+          raw"""       s: ${s.encodeToUnicode}
+               |  actual: ${actual.leftMap(_.map(_.encodeToUnicode))}
+               |expected: ${expected.leftMap(_.map(_.encodeToUnicode))}
+               |""".stripMargin
+        )
+      }
+
+    def testInlinedRefined_ARefinedNewtypeNecTInvalid: Property =
+      for {
+        s <- Gen.string(Gen.unicode, Range.linear(0, 2)).log("s")
+      } yield {
+        val expected =
+          s"Failed to create refined4s.modules.cats.syntaxSpec.NewMoreThan2CharsString: Invalid value: [$s]. The String should have more than 2 chars but got $s instead"
+            .leftNec[NewMoreThan2CharsString]
+
+        val actual = s.refinedNewtypeNec[NewMoreThan2CharsString]
+        (actual ==== expected).log(
+          raw"""       s: ${s.encodeToUnicode}
+               |  actual: ${actual.leftMap(_.map(_.encodeToUnicode))}
+               |expected: ${expected.leftMap(_.map(_.encodeToUnicode))}
+               |""".stripMargin
+        )
+      }
+
+    def testInlinedRefined_RefinedNewtypeNecTA: Property =
+      for {
+        s <- Gen.string(Gen.unicode, Range.linear(3, 10)).log("s")
+      } yield {
+
+        val expected = NewMoreThan2CharsString(MoreThan2CharsString.unsafeFrom(s)).rightNec[String]
+        val actual   = refinedNewtypeNec(s)[NewMoreThan2CharsString]
+        (actual ==== expected).log(
+          raw"""       s: ${s.encodeToUnicode}
+               |  actual: ${actual.leftMap(_.map(_.encodeToUnicode))}
+               |expected: ${expected.leftMap(_.map(_.encodeToUnicode))}
+               |""".stripMargin
+        )
+      }
+
+    def testInlinedRefined_RefinedNewtypeNecTAInvalid: Property =
+      for {
+        s <- Gen.string(Gen.unicode, Range.linear(0, 2)).log("s")
+      } yield {
+        val expected =
+          s"Failed to create refined4s.modules.cats.syntaxSpec.NewMoreThan2CharsString: Invalid value: [$s]. The String should have more than 2 chars but got $s instead"
+            .leftNec[NewMoreThan2CharsString]
+        val actual   = refinedNewtypeNec(s)[NewMoreThan2CharsString]
+        (actual ==== expected).log(
+          raw"""       s: ${s.encodeToUnicode}
+               |  actual: ${actual.leftMap(_.map(_.encodeToUnicode))}
+               |expected: ${expected.leftMap(_.map(_.encodeToUnicode))}
+               |""".stripMargin
+        )
+      }
   }
-
-  def testInlinedRefined_AValidateAsT: Property =
-    for {
-      s <- Gen.string(Gen.unicode, Range.linear(3, 10)).log("s")
-    } yield {
-
-      val expected = NewMoreThan2CharsString(MoreThan2CharsString.unsafeFrom(s)).rightNec[String]
-      val actual   = s.validateAs[NewMoreThan2CharsString]
-      (actual ==== expected).log(
-        raw"""       s: ${s.encodeToUnicode}
-             |  actual: ${actual.leftMap(_.map(_.encodeToUnicode))}
-             |expected: ${expected.leftMap(_.map(_.encodeToUnicode))}
-             |""".stripMargin
-      )
-    }
-
-  def testInlinedRefined_AValidateAsTInvalid: Property =
-    for {
-      s <- Gen.string(Gen.unicode, Range.linear(0, 2)).log("s")
-    } yield {
-      val expected =
-        s"Failed to create refined4s.modules.cats.syntaxSpec.NewMoreThan2CharsString: Invalid value: [$s]. The String should have more than 2 chars but got $s instead"
-          .leftNec[NewMoreThan2CharsString]
-
-      val actual = s.validateAs[NewMoreThan2CharsString]
-      (actual ==== expected).log(
-        raw"""       s: ${s.encodeToUnicode}
-             |  actual: ${actual.leftMap(_.map(_.encodeToUnicode))}
-             |expected: ${expected.leftMap(_.map(_.encodeToUnicode))}
-             |""".stripMargin
-      )
-    }
-
-  def testInlinedRefined_ValidateAsTA: Property =
-    for {
-      s <- Gen.string(Gen.unicode, Range.linear(3, 10)).log("s")
-    } yield {
-
-      val expected = NewMoreThan2CharsString(MoreThan2CharsString.unsafeFrom(s)).rightNec[String]
-      val actual   = validateAs(s)[NewMoreThan2CharsString]
-      (actual ==== expected).log(
-        raw"""       s: ${s.encodeToUnicode}
-             |  actual: ${actual.leftMap(_.map(_.encodeToUnicode))}
-             |expected: ${expected.leftMap(_.map(_.encodeToUnicode))}
-             |""".stripMargin
-      )
-    }
-
-  def testInlinedRefined_ValidateAsTAInvalid: Property =
-    for {
-      s <- Gen.string(Gen.unicode, Range.linear(0, 2)).log("s")
-    } yield {
-      val expected =
-        s"Failed to create refined4s.modules.cats.syntaxSpec.NewMoreThan2CharsString: Invalid value: [$s]. The String should have more than 2 chars but got $s instead"
-          .leftNec[NewMoreThan2CharsString]
-      val actual   = validateAs(s)[NewMoreThan2CharsString]
-      (actual ==== expected).log(
-        raw"""       s: ${s.encodeToUnicode}
-             |  actual: ${actual.leftMap(_.map(_.encodeToUnicode))}
-             |expected: ${expected.leftMap(_.map(_.encodeToUnicode))}
-             |""".stripMargin
-      )
-    }
 
   type MyType = MyType.Type
   @SuppressWarnings(Array("org.wartremover.warts.Equals"))


### PR DESCRIPTION
Close #182 - [`refined4s-cats`] Rename `validateAs` in `refined4s.modules.cats.syntax` to `refinedNewtypeNec`