### PR TITLE
Close #186 - [`refined4s-core`] Move `toValue` from `refined4s.syntax` to `refined4s.NewtypeBase`

### DIFF
--- a/modules/refined4s-cats/shared/src/test/scala/refined4s/modules/cats/derivation/types/CatsWithCustomTypeClassesSpec.scala
+++ b/modules/refined4s-cats/shared/src/test/scala/refined4s/modules/cats/derivation/types/CatsWithCustomTypeClassesSpec.scala
@@ -6,7 +6,6 @@ import hedgehog.*
 import hedgehog.runner.*
 import refined4s.*
 import refined4s.modules.cats.derivation.types.all.given
-import refined4s.syntax.*
 import refined4s.types.all.*
 
 import java.time.Instant

--- a/modules/refined4s-core/shared/src/main/scala/refined4s/NewtypeBase.scala
+++ b/modules/refined4s-core/shared/src/main/scala/refined4s/NewtypeBase.scala
@@ -16,6 +16,11 @@ trait NewtypeBase[A] {
     def value: A
   }
 
+  extension [B](typ: Type) {
+    def toValue(using coercibleA2B: Coercible[A, B]): B =
+      coercibleA2B(typ.value)
+  }
+
   def deriving[F[*]](using fa: F[A]): F[Type]
 
 }

--- a/modules/refined4s-core/shared/src/main/scala/refined4s/syntax.scala
+++ b/modules/refined4s-core/shared/src/main/scala/refined4s/syntax.scala
@@ -27,11 +27,5 @@ trait syntax {
 
   }
 
-  extension [N, T, A](nt: N) {
-
-    def toValue(using coercible1: Coercible[N, T], coercible2: Coercible[T, A]): A =
-      coercible2(coercible1(nt))
-  }
-
 }
 object syntax extends syntax


### PR DESCRIPTION
Close #186 - [`refined4s-core`] Move `toValue` from `refined4s.syntax` to `refined4s.NewtypeBase`