### PR TITLE
Close #188 - [`refined4s-cats`] Add `validateAs` in `refined4s.modules.cats.syntax` to validate and return `Validated`

### DIFF
--- a/modules/refined4s-cats/shared/src/main/scala/refined4s/modules/cats/syntax.scala
+++ b/modules/refined4s-cats/shared/src/main/scala/refined4s/modules/cats/syntax.scala
@@ -36,6 +36,15 @@ trait syntax {
         .toEitherNel
         .map(coercible(_))
 
+    inline def validateAs[N](
+      using coercible: Coercible[T, N],
+      refinedCtor: RefinedCtor[T, A],
+    ): Validated[String, N] =
+      a.refinedTo[T]
+        .leftMap(err => s"Failed to create ${getTypeName[N]}: $err")
+        .toValidated
+        .map(coercible(_))
+
   }
 
 }


### PR DESCRIPTION
Close #188 - [`refined4s-cats`] Add `validateAs` in `refined4s.modules.cats.syntax` to validate and return `Validated`