### PR TITLE
Close #189 - [`refined4s-cats`] Add `validateNecAs` in `refined4s.modules.cats.syntax` to validate and return `ValidatedNec`

### DIFF
--- a/modules/refined4s-cats/shared/src/main/scala/refined4s/modules/cats/syntax.scala
+++ b/modules/refined4s-cats/shared/src/main/scala/refined4s/modules/cats/syntax.scala
@@ -45,6 +45,15 @@ trait syntax {
         .toValidated
         .map(coercible(_))
 
+    inline def validateNecAs[N](
+      using coercible: Coercible[T, N],
+      refinedCtor: RefinedCtor[T, A],
+    ): ValidatedNec[String, N] =
+      a.refinedTo[T]
+        .leftMap(err => s"Failed to create ${getTypeName[N]}: $err")
+        .toValidatedNec
+        .map(coercible(_))
+
   }
 
 }


### PR DESCRIPTION
Close #189 - [`refined4s-cats`] Add `validateNecAs` in `refined4s.modules.cats.syntax` to validate and return `ValidatedNec`