### PR TITLE
refined4s v0.7.0

### DIFF
--- a/changelogs/0.7.0.md
+++ b/changelogs/0.7.0.md
@@ -1,0 +1,177 @@
+## [0.7.0](https://github.com/kevin-lee/refined4s/issues?q=is%3Aissue+is%3Aclosed+-label%3Ainvalid+milestone%3Am7) - 2023-12-30
+
+### Changes
+
+* [`refined4s-cats`] Rename `validateAs` in `refined4s.modules.cats.syntax` to `refinedNewtypeNec` (#182)
+
+***
+
+* [`refined4s-core`] Move `toValue` from `refined4s.syntax` to `refined4s.NewtypeBase` (#186)
+
+  So with the given following code,
+  ```scala 3
+  import refined4s.*
+  import refined4s.types.all.*
+  
+  type Name = Name.Type
+  object Name extends Newtype[NonEmptyString]
+  
+  ```
+  the following is possible without importing any `syntax`.
+  ```scala 3
+  val name = Name(NonEmptyString("Kevin"))
+  name.toValue
+  // String = "Kevin"
+  ```
+***
+
+
+### New Features
+
+* [`refined4s-cats`] Add `refinedNewtypeNel` in `refined4s.modules.cats.syntax` (#184)
+
+  ```scala 3
+  import refined4s.*
+  import refined4s.types.all.*
+  
+  import refined4s.modules.cats.syntax.*
+  
+  type Name = Name.Type
+  object Name extends Newtype[NonEmptyString]
+  
+  "Kevin".refinedNewtypeNel[Name]
+  // EitherNel[String, Name] = Right(Name(NonEmptyString("Kevin")))
+  
+  "".refinedNewtypeNel[Name]
+  // EitherNel[String, Name] = Left(NonEmptyList("Failed to create Name: Invalid value: []. It has to be a non-empty String but got \"\"))
+  ```
+***
+
+* [`refined4s-cats`] Add `validateAs` in `refined4s.modules.cats.syntax` to validate a value and return `Validated` (#188)
+
+  ```scala 3
+  import refined4s.*
+  import refined4s.types.all.*
+  
+  import refined4s.modules.cats.syntax.*
+  
+  type Name = Name.Type
+  object Name extends Newtype[NonEmptyString]
+  
+  "Kevin".validateAs[Name]
+  // Validated[String, Name] = Valid(Name(NonEmptyString("Kevin")))
+  
+  "".validateAs[Name]
+  // Validated[String, Name] = Invalid("Failed to create Name: Invalid value: []. It has to be a non-empty String but got \"\")
+  ```
+***
+
+* [`refined4s-cats`] Add `validateNecAs` in `refined4s.modules.cats.syntax` to validate a value and return `ValidatedNec` (#189)
+
+  ```scala 3
+  import refined4s.*
+  import refined4s.types.all.*
+  
+  import refined4s.modules.cats.syntax.*
+  
+  type Name = Name.Type
+  object Name extends Newtype[NonEmptyString]
+  
+  "Kevin".validateNecAs[Name]
+  // ValidatedNec[String, Name] = Valid(Name(NonEmptyString("Kevin")))
+  
+  "".validateNecAs[Name]
+  // ValidatedNec[String, Name] = Invalid(NonEmptyChain("Failed to create Name: Invalid value: []. It has to be a non-empty String but got \"\"))
+  ```
+***
+
+* [`refined4s-cats`] Add `validateNelAs` in `refined4s.modules.cats.syntax` to validate a value and return `ValidatedNel` (#190)
+
+  ```scala 3
+  import refined4s.*
+  import refined4s.types.all.*
+  
+  import refined4s.modules.cats.syntax.*
+  
+  type Name = Name.Type
+  object Name extends Newtype[NonEmptyString]
+  
+  "Kevin".validateNelAs[Name]
+  // ValidatedNel[String, Name] = Valid(Name(NonEmptyString("Kevin")))
+  
+  "".validateNelAs[Name]
+  // ValidatedNel[String, Name] = Invalid(NonEmptyList("Failed to create Name: Invalid value: []. It has to be a non-empty String but got \"\"))
+  ```
+***
+
+* [`refined4s-cats`] Add `derivedOrder` to have the instance of `Order[A]` derived from `Coercible[A, B]` and `Order[B]` (#194)
+
+  Given
+  ```scala 3
+  import refined4s.*
+  
+  type MyNum = MyNum.Type
+  object MyNum extends Newtype[Int]
+  ```
+  it can be
+  ```scala 3
+  import cats.*
+  
+  val n1 = MyNum(1)
+  val n2 = MyNum(2)
+  
+  Order[MyNum].compare(n1, n2)
+  // Int = -1
+  ```
+***
+
+* [`refined4s-core`] Add `CanBeOrdered` for providing `Ordering` and `Conversion[Type, Ordered[Type]]` (#196)
+
+  ```scala 3
+  import refined4s.*
+  
+  type MyNum = MyNum.Type
+  object MyNum extends Newtype[Int]
+  ```
+  ```scala 3
+  val input1 = MyNum(1)
+  val input2 = MyNum(2)
+  
+  Ordering[MyNum].compare(input1, input2)
+  // Int = -1
+  
+  (input1: Ordered[MyNum]).compare(input2)
+  // Int = -1
+  ```
+
+***
+
+* [`refined4s-core`] Make `NonEmptyString` `CanBeOrdered` to have `Ordering[NonEmptyString]` and `Conversion[NonEmptyString, Ordered[NonEmptyString]]` (#198)
+***
+
+* [`refined4s-cats`] Add `CatsOrder` (#203)
+  ```scala 3
+  import refined4s.*
+  
+  type MyNum = MyNum.Type
+  object MyNum extends Newtype[Int], CatsOrder[Int]
+  ```
+  ```scala 3
+  import cats.*
+  val myNum1 = NyNum(1)
+  val myNum2 = NyNum(2)
+  
+  Order[MyNum].compare(myNum1, myNum1)
+  // Int = 0
+  
+  Order[MyNum].compare(myNum1, myNum2)
+  // Int = -1
+  
+  Order[MyNum].compare(myNum2, myNum1)
+  // Int = 1
+  ```
+
+
+### Internal Changes
+
+* [`refined4s-core`] Replace `Ordering` and `Conversion[Type, Ordered[Type]]` for numeric types with `CanBeOrdered` (#199)


### PR DESCRIPTION
# refined4s v0.7.0
## [0.7.0](https://github.com/kevin-lee/refined4s/issues?q=is%3Aissue+is%3Aclosed+-label%3Ainvalid+milestone%3Am7) - 2023-12-30

### Changes

* [`refined4s-cats`] Rename `validateAs` in `refined4s.modules.cats.syntax` to `refinedNewtypeNec` (#182)

***

* [`refined4s-core`] Move `toValue` from `refined4s.syntax` to `refined4s.NewtypeBase` (#186)

  So with the given following code,
  ```scala 3
  import refined4s.*
  import refined4s.types.all.*
  
  type Name = Name.Type
  object Name extends Newtype[NonEmptyString]
  
  ```
  the following is possible without importing any `syntax`.
  ```scala 3
  val name = Name(NonEmptyString("Kevin"))
  name.toValue
  // String = "Kevin"
  ```
***


### New Features

* [`refined4s-cats`] Add `refinedNewtypeNel` in `refined4s.modules.cats.syntax` (#184)

  ```scala 3
  import refined4s.*
  import refined4s.types.all.*
  
  import refined4s.modules.cats.syntax.*
  
  type Name = Name.Type
  object Name extends Newtype[NonEmptyString]
  
  "Kevin".refinedNewtypeNel[Name]
  // EitherNel[String, Name] = Right(Name(NonEmptyString("Kevin")))
  
  "".refinedNewtypeNel[Name]
  // EitherNel[String, Name] = Left(NonEmptyList("Failed to create Name: Invalid value: []. It has to be a non-empty String but got \"\"))
  ```
***

* [`refined4s-cats`] Add `validateAs` in `refined4s.modules.cats.syntax` to validate a value and return `Validated` (#188)

  ```scala 3
  import refined4s.*
  import refined4s.types.all.*
  
  import refined4s.modules.cats.syntax.*
  
  type Name = Name.Type
  object Name extends Newtype[NonEmptyString]
  
  "Kevin".validateAs[Name]
  // Validated[String, Name] = Valid(Name(NonEmptyString("Kevin")))
  
  "".validateAs[Name]
  // Validated[String, Name] = Invalid("Failed to create Name: Invalid value: []. It has to be a non-empty String but got \"\")
  ```
***

* [`refined4s-cats`] Add `validateNecAs` in `refined4s.modules.cats.syntax` to validate a value and return `ValidatedNec` (#189)

  ```scala 3
  import refined4s.*
  import refined4s.types.all.*
  
  import refined4s.modules.cats.syntax.*
  
  type Name = Name.Type
  object Name extends Newtype[NonEmptyString]
  
  "Kevin".validateNecAs[Name]
  // ValidatedNec[String, Name] = Valid(Name(NonEmptyString("Kevin")))
  
  "".validateNecAs[Name]
  // ValidatedNec[String, Name] = Invalid(NonEmptyChain("Failed to create Name: Invalid value: []. It has to be a non-empty String but got \"\"))
  ```
***

* [`refined4s-cats`] Add `validateNelAs` in `refined4s.modules.cats.syntax` to validate a value and return `ValidatedNel` (#190)

  ```scala 3
  import refined4s.*
  import refined4s.types.all.*
  
  import refined4s.modules.cats.syntax.*
  
  type Name = Name.Type
  object Name extends Newtype[NonEmptyString]
  
  "Kevin".validateNelAs[Name]
  // ValidatedNel[String, Name] = Valid(Name(NonEmptyString("Kevin")))
  
  "".validateNelAs[Name]
  // ValidatedNel[String, Name] = Invalid(NonEmptyList("Failed to create Name: Invalid value: []. It has to be a non-empty String but got \"\"))
  ```
***

* [`refined4s-cats`] Add `derivedOrder` to have the instance of `Order[A]` derived from `Coercible[A, B]` and `Order[B]` (#194)

  Given
  ```scala 3
  import refined4s.*
  
  type MyNum = MyNum.Type
  object MyNum extends Newtype[Int]
  ```
  it can be
  ```scala 3
  import cats.*
  
  val n1 = MyNum(1)
  val n2 = MyNum(2)
  
  Order[MyNum].compare(n1, n2)
  // Int = -1
  ```
***

* [`refined4s-core`] Add `CanBeOrdered` for providing `Ordering` and `Conversion[Type, Ordered[Type]]` (#196)

  ```scala 3
  import refined4s.*
  
  type MyNum = MyNum.Type
  object MyNum extends Newtype[Int]
  ```
  ```scala 3
  val input1 = MyNum(1)
  val input2 = MyNum(2)
  
  Ordering[MyNum].compare(input1, input2)
  // Int = -1
  
  (input1: Ordered[MyNum]).compare(input2)
  // Int = -1
  ```

***

* [`refined4s-core`] Make `NonEmptyString` `CanBeOrdered` to have `Ordering[NonEmptyString]` and `Conversion[NonEmptyString, Ordered[NonEmptyString]]` (#198)
***

* [`refined4s-cats`] Add `CatsOrder` (#203)
  ```scala 3
  import refined4s.*
  
  type MyNum = MyNum.Type
  object MyNum extends Newtype[Int], CatsOrder[Int]
  ```
  ```scala 3
  import cats.*
  val myNum1 = NyNum(1)
  val myNum2 = NyNum(2)
  
  Order[MyNum].compare(myNum1, myNum1)
  // Int = 0
  
  Order[MyNum].compare(myNum1, myNum2)
  // Int = -1
  
  Order[MyNum].compare(myNum2, myNum1)
  // Int = 1
  ```


### Internal Changes

* [`refined4s-core`] Replace `Ordering` and `Conversion[Type, Ordered[Type]]` for numeric types with `CanBeOrdered` (#199)
