### PR TITLE
Close #208 - [`refined4s-core`] Change `NewtypeBase.unapply` and `RefinedBase.unapply` to return `Some[A]` instead of `Option[A]`

### DIFF
--- a/modules/refined4s-core/shared/src/main/scala/refined4s/Newtype.scala
+++ b/modules/refined4s-core/shared/src/main/scala/refined4s/Newtype.scala
@@ -8,7 +8,11 @@ trait Newtype[A] extends NewtypeBase[A] {
 
   def apply(a: A): Type = a
 
-  def unapply(typ: Type): Option[A] = Some(typ)
+  /* The reason to have `Some[A]` as a return type here is
+   * https://github.com/scala/bug/issues/12232
+   * So sad :(
+   */
+  def unapply(typ: Type): Some[A] = Some(typ)
 
   inline given wrap: Coercible[A, Type] = Coercible.instance
 

--- a/modules/refined4s-core/shared/src/main/scala/refined4s/RefinedBase.scala
+++ b/modules/refined4s-core/shared/src/main/scala/refined4s/RefinedBase.scala
@@ -12,7 +12,11 @@ trait RefinedBase[A] extends NewtypeBase[A] {
     override def create(a: A): Either[String, Type] = from(a)
   }
 
-  def unapply(typ: Type): Option[A] = Some(typ)
+  /* The reason to have `Some[A]` as a return type here is
+   * https://github.com/scala/bug/issues/12232
+   * So sad :(
+   */
+  def unapply(typ: Type): Some[A] = Some(typ)
 
   @SuppressWarnings(Array("org.wartremover.warts.ToString"))
   def from(a: A): Either[String, Type] =


### PR DESCRIPTION
Close #208 - [`refined4s-core`] Change `NewtypeBase.unapply` and `RefinedBase.unapply` to return `Some[A]` instead of `Option[A]`