### PR TITLE
refined4s v0.8.0

### DIFF
--- a/changelogs/0.8.0.md
+++ b/changelogs/0.8.0.md
@@ -1,0 +1,7 @@
+## [0.8.0](https://github.com/kevin-lee/refined4s/issues?q=is%3Aissue+is%3Aclosed+-label%3Ainvalid+milestone%3Am8) - 2023-12-31
+
+### Changes
+
+* [`refined4s-core`] Change `NewtypeBase.unapply` and `RefinedBase.unapply` to return `Some[A]` instead of `Option[A]` (#208)
+
+  > The reason for having `Some[A]` as the return type of the `unapply` methods can be found at https://github.com/scala/bug/issues/12232. 😔


### PR DESCRIPTION
# refined4s v0.8.0
## [0.8.0](https://github.com/kevin-lee/refined4s/issues?q=is%3Aissue+is%3Aclosed+-label%3Ainvalid+milestone%3Am8) - 2023-12-31

### Changes

* [`refined4s-core`] Change `NewtypeBase.unapply` and `RefinedBase.unapply` to return `Some[A]` instead of `Option[A]` (#208)

  > The reason for having `Some[A]` as the return type of the `unapply` methods can be found at https://github.com/scala/bug/issues/12232. 😔
