### PR TITLE
Issue #215 - [`refined4s-extras-render`] Turn `refined4s.modules.extras.derivation.generic.auto` into a `trait` and add the `auto` `object` extending it

### DIFF
--- a/modules/refined4s-extras-render/shared/src/main/scala/refined4s/modules/extras/derivation/generic/auto.scala
+++ b/modules/refined4s-extras-render/shared/src/main/scala/refined4s/modules/extras/derivation/generic/auto.scala
@@ -6,7 +6,7 @@ import extras.render.Render
 /** @author Kevin Lee
   * @since 2024-01-01
   */
-object auto {
+trait auto {
 
   /** `Render` instance for Newtype, Refined and InlinedRefined types that delegates from the `Render`
     * instance of the base type.
@@ -15,3 +15,4 @@ object auto {
     renderB.contramap[A](coercible(_))
 
 }
+object auto extends auto


### PR DESCRIPTION
Issue #215 - [`refined4s-extras-render`] Turn `refined4s.modules.extras.derivation.generic.auto` into a `trait` and add the `auto` `object` extending it