### PR TITLE
refined4s v0.9.0

### DIFF
--- a/changelogs/0.9.0.md
+++ b/changelogs/0.9.0.md
@@ -1,0 +1,48 @@
+## [0.9.0](https://github.com/kevin-lee/refined4s/issues?q=is%3Aissue+is%3Aclosed+-label%3Ainvalid+milestone%3Am9) - 2023-12-31
+
+### New Feature
+
+* Add `refined4s-extras-render` to support `Render` for `refined4s` (#215)
+  ```scala 3
+  refined4s.modules.extras.derivation.ExtrasRender
+  refined4s.modules.extras.derivation.types.all.given
+  refined4s.modules.extras.derivation.generic.auto.given
+  ```
+  e.g.)
+  ```scala 3
+  import extras.render.Render
+  
+  import refined4s.types.all.*
+  import refined4s.modules.extras.derivation.types.all.given
+  
+  val name = NonEmptyString("Kevin")
+  Render[NonEmptyString].render(name)
+  // String = Kevin
+  ```
+  ```scala 3
+  import extras.render.Render
+  
+  import refined4s.Newtype
+  import refined4s.modules.extras.derivation.ExtrasRender
+  
+  type Name = Name.Type
+  object Name extends Newtype[String], ExtrasRender[String]
+  
+  val name = Name("Kevin")
+  Render[Name].render(name)
+  // String = Kevin
+  ```
+  ```scala 3
+  import extras.render.Render
+  
+  import refined4s.Newtype
+  
+  type Name = Name.Type
+  object Name extends Newtype[String]
+  
+  import refined4s.modules.extras.derivation.generic.auto.given
+  
+  val name = Name("Kevin")
+  Render[Name].render(name)
+  // String = Kevin
+  ```


### PR DESCRIPTION
# refined4s v0.9.0
## [0.9.0](https://github.com/kevin-lee/refined4s/issues?q=is%3Aissue+is%3Aclosed+-label%3Ainvalid+milestone%3Am9) - 2023-12-31

### New Feature

* Add `refined4s-extras-render` to support `Render` for `refined4s` (#215)
  ```scala 3
  refined4s.modules.extras.derivation.ExtrasRender
  refined4s.modules.extras.derivation.types.all.given
  refined4s.modules.extras.derivation.generic.auto.given
  ```
  e.g.)
  ```scala 3
  import extras.render.Render
  
  import refined4s.types.all.*
  import refined4s.modules.extras.derivation.types.all.given
  
  val name = NonEmptyString("Kevin")
  Render[NonEmptyString].render(name)
  // String = Kevin
  ```
  ```scala 3
  import extras.render.Render
  
  import refined4s.Newtype
  import refined4s.modules.extras.derivation.ExtrasRender
  
  type Name = Name.Type
  object Name extends Newtype[String], ExtrasRender[String]
  
  val name = Name("Kevin")
  Render[Name].render(name)
  // String = Kevin
  ```
  ```scala 3
  import extras.render.Render
  
  import refined4s.Newtype
  
  type Name = Name.Type
  object Name extends Newtype[String]
  
  import refined4s.modules.extras.derivation.generic.auto.given
  
  val name = Name("Kevin")
  Render[Name].render(name)
  // String = Kevin
  ```
