### PR TITLE
refined4s v0.11.0

### DIFF
--- a/changelogs/0.11.0.md
+++ b/changelogs/0.11.0.md
@@ -1,0 +1,37 @@
+## [0.11.0](https://github.com/kevin-lee/refined4s/issues?q=is%3Aissue+is%3Aclosed+-label%3Ainvalid+milestone%3Am11) - 2024-01-04
+
+### New Feature
+
+* [`refined4s-core`] Add `MinValue` and `MaxValue` to refined basic numeric types (#223)
+  * Add `Min` trait
+  * Add `Max` trait
+  * Add `MinMax` trait
+
+  Add `MinMax` to the following types to have `MinValue` and `MaxValue`
+  * `NegInt`
+  * `NonNegInt`
+  * `PosInt`
+  * `NonPosInt`
+  * `NegLong`
+  * `NonNegLong`
+  * `PosLong`
+  * `NonPosLong`
+  * `NegShort`
+  * `NonNegShort`
+  * `PosShort`
+  * `NonPosShort`
+  * `NegByte`
+  * `NonNegByte`
+  * `PosByte`
+  * `NonPosByte`
+  * `NegFloat`
+  * `NonNegFloat`
+  * `PosFloat`
+  * `NonPosFloat`
+  * `NegDouble`
+  * `NonNegDouble`
+  * `PosDouble`
+  * `NonPosDouble`
+
+### Internal Change
+* [`refined4s-core`] Move `Numeric` and `InlinedNumeric` from `numeric` trait to `numeric` object (#225)


### PR DESCRIPTION
# refined4s v0.11.0
## [0.11.0](https://github.com/kevin-lee/refined4s/issues?q=is%3Aissue+is%3Aclosed+-label%3Ainvalid+milestone%3Am11) - 2024-01-04

### New Feature

* [`refined4s-core`] Add `MinValue` and `MaxValue` to refined basic numeric types (#223)
  * Add `Min` trait
  * Add `Max` trait
  * Add `MinMax` trait

  Add `MinMax` to the following types to have `MinValue` and `MaxValue`
  * `NegInt`
  * `NonNegInt`
  * `PosInt`
  * `NonPosInt`
  * `NegLong`
  * `NonNegLong`
  * `PosLong`
  * `NonPosLong`
  * `NegShort`
  * `NonNegShort`
  * `PosShort`
  * `NonPosShort`
  * `NegByte`
  * `NonNegByte`
  * `PosByte`
  * `NonPosByte`
  * `NegFloat`
  * `NonNegFloat`
  * `PosFloat`
  * `NonPosFloat`
  * `NegDouble`
  * `NonNegDouble`
  * `PosDouble`
  * `NonPosDouble`

### Internal Change
* [`refined4s-core`] Move `Numeric` and `InlinedNumeric` from `numeric` trait to `numeric` object (#225)
