### PR TITLE
refined4s v0.12.0

### DIFF
--- a/changelogs/0.12.0.md
+++ b/changelogs/0.12.0.md
@@ -1,0 +1,48 @@
+## [0.12.0](https://github.com/kevin-lee/refined4s/issues?q=is%3Aissue+is%3Aclosed+-label%3Ainvalid+-label%3Awontfix+milestone%3Am12) - 2024-01-20
+
+### New Feature
+
+* [`refined4s-core`] Make pre-defined types in `types.all` importable from each type category (i.e. `numeric`, `strings` and `network`) (#237)
+
+  So it means a type like `refined4s.types.numeric.NegInt` should be exactly the same as `refined4s.types.all.NegInt`.
+***
+* Add `refined4s-refined-compat` modules for compatibility with the `refined` library in Scala 2 (#241)
+  * `refined4s-refined-compat-scala2` for compatibility with `refined` in Scala 2
+  * `refined4s-refined-compat-scala3` for just using `refined4s` in Scala 3
+***
+
+* Add `RefinedCompatAllTypes` to `refined4s-refined-compat-scala2` and `refined4s-refined-compat-scala3` (#243)
+
+
+### Internal Change
+
+* [`refined4s-core`] Move `MinValue` and `MaxValue` from each `MinMax` to `Min` and `Max` (#239)
+
+  e.g.)
+  ```scala 3
+  type NegInt = NegInt.Type
+  object NegInt extends Numeric[Int], MinMax[Int] {
+    override def min: Type = apply(Int.MinValue)
+    override def max: Type = apply(-1)
+  
+    val MinValue: Type = min
+    val MaxValue: Type = max
+  }
+  ```
+  to
+  ```scala 3
+  trait Min[A] {
+    self: NewtypeBase[A] =>
+    def min: Type
+  
+    val MinValue: Type = min
+  }
+  
+  trait Max[A] {
+    self: NewtypeBase[A] =>
+    def max: Type
+  
+    val MaxValue: Type = max
+  }
+  ```
+***


### PR DESCRIPTION
# refined4s v0.12.0
## [0.12.0](https://github.com/kevin-lee/refined4s/issues?q=is%3Aissue+is%3Aclosed+-label%3Ainvalid+-label%3Awontfix+milestone%3Am12) - 2024-01-20

### New Feature

* [`refined4s-core`] Make pre-defined types in `types.all` importable from each type category (i.e. `numeric`, `strings` and `network`) (#237)

  So it means a type like `refined4s.types.numeric.NegInt` should be exactly the same as `refined4s.types.all.NegInt`.
***
* Add `refined4s-refined-compat` modules for compatibility with the `refined` library in Scala 2 (#241)
  * `refined4s-refined-compat-scala2` for compatibility with `refined` in Scala 2
  * `refined4s-refined-compat-scala3` for just using `refined4s` in Scala 3
***

* Add `RefinedCompatAllTypes` to `refined4s-refined-compat-scala2` and `refined4s-refined-compat-scala3` (#243)


### Internal Change

* [`refined4s-core`] Move `MinValue` and `MaxValue` from each `MinMax` to `Min` and `Max` (#239)

  e.g.)
  ```scala 3
  type NegInt = NegInt.Type
  object NegInt extends Numeric[Int], MinMax[Int] {
    override def min: Type = apply(Int.MinValue)
    override def max: Type = apply(-1)
  
    val MinValue: Type = min
    val MaxValue: Type = max
  }
  ```
  to
  ```scala 3
  trait Min[A] {
    self: NewtypeBase[A] =>
    def min: Type
  
    val MinValue: Type = min
  }
  
  trait Max[A] {
    self: NewtypeBase[A] =>
    def max: Type
  
    val MaxValue: Type = max
  }
  ```
***
