### PR TITLE
Close #248 - [`refined4s-core`] Add `Uuid` `String` which can be validated as `java.util.UUID` and the type-class instances for `Uuid` in the other modules

### DIFF
--- a/modules/refined4s-cats/shared/src/main/scala/refined4s/modules/cats/derivation/types/all.scala
+++ b/modules/refined4s-cats/shared/src/main/scala/refined4s/modules/cats/derivation/types/all.scala
@@ -110,6 +110,9 @@ trait all {
   inline given derivedNonEmptyStringEq(using eqActual: Eq[String]): Eq[NonEmptyString]         = contraCoercible(eqActual)
   inline given derivedNonEmptyStringShow(using showActual: Show[String]): Show[NonEmptyString] = contraCoercible(showActual)
 
+  inline given derivedUuidEq(using eqActual: Eq[String]): Eq[Uuid]         = contraCoercible(eqActual)
+  inline given derivedUuidShow(using showActual: Show[String]): Show[Uuid] = contraCoercible(showActual)
+
   // network
 
   inline given derivedUriEq(using eqActual: Eq[String]): Eq[Uri]         = contraCoercible(eqActual)

--- a/modules/refined4s-cats/shared/src/test/scala/refined4s/modules/cats/derivation/types/allSpec.scala
+++ b/modules/refined4s-cats/shared/src/test/scala/refined4s/modules/cats/derivation/types/allSpec.scala
@@ -7,8 +7,9 @@ import refined4s.modules.cats.derivation.types.all.given
 import refined4s.types.numeric.*
 import refined4s.types.network.*
 import refined4s.types.strings.*
-
 import refined4s.types.networkGens
+
+import java.util.UUID
 
 /** @author Kevin Lee
   * @since 2023-12-10
@@ -115,6 +116,9 @@ object allSpec extends Properties {
     //
     property("test Eq[NonEmptyString]", testEqNonEmptyString),
     property("test Show[NonEmptyString]", testShowNonEmptyString),
+    //
+    property("test Eq[Uuid]", testEqUuid),
+    property("test Show[Uuid]", testShowUuid),
     //
     property("test Eq[Uri]", testEqUri),
     property("test Show[Uri]", testShowUri),
@@ -907,6 +911,8 @@ object allSpec extends Properties {
       actual ==== expected
     }
 
+  ///
+
   def testEqNonEmptyString: Property =
     for {
       s <- Gen.string(Gen.unicode, Range.linear(1, 10)).log("s")
@@ -926,6 +932,39 @@ object allSpec extends Properties {
       val input = NonEmptyString.unsafeFrom(s)
 
       val expected = s
+      val actual   = input.show
+
+      actual ==== expected
+    }
+
+  ///
+
+  def testEqUuid: Property =
+    for {
+      uuid1 <- Gen.constant(UUID.randomUUID()).log("uuid1")
+      uuid2 <- Gen.constant(UUID.randomUUID()).log("uuid2")
+    } yield {
+      val input1 = Uuid(uuid1)
+      val input2 = Uuid(uuid2)
+
+      val expected1 = input1
+      val actual1   = input1
+
+      Result.all(
+        List(
+          Result.diffNamed("Uuid(value) === Uuid(value)", actual1, expected1)(_ === _),
+          Result.diffNamed("Uuid(value) =!= Uuid(different value)", input1, input2)(_ =!= _),
+        )
+      )
+    }
+
+  def testShowUuid: Property =
+    for {
+      uuid <- Gen.constant(UUID.randomUUID()).log("uuid")
+    } yield {
+      val input = Uuid(uuid)
+
+      val expected = uuid.show
       val actual   = input.show
 
       actual ==== expected

--- a/modules/refined4s-circe/shared/src/main/scala/refined4s/modules/circe/derivation/types/strings.scala
+++ b/modules/refined4s-circe/shared/src/main/scala/refined4s/modules/circe/derivation/types/strings.scala
@@ -11,4 +11,7 @@ trait strings {
   inline given derivedNonEmptyStringEncoder: Encoder[NonEmptyString] = Encoder[String].contramap[NonEmptyString](_.value)
   inline given derivedNonEmptyStringDecoder: Decoder[NonEmptyString] = Decoder[String].emap(NonEmptyString.from)
 
+  inline given derivedUuidEncoder: Encoder[Uuid] = Encoder[String].contramap[Uuid](_.value)
+  inline given derivedUuidDecoder: Decoder[Uuid] = Decoder[String].emap(Uuid.from)
+
 }

--- a/modules/refined4s-circe/shared/src/test/scala/refined4s/modules/circe/derivation/types/allSpec.scala
+++ b/modules/refined4s-circe/shared/src/test/scala/refined4s/modules/circe/derivation/types/allSpec.scala
@@ -9,6 +9,8 @@ import refined4s.modules.circe.derivation.types.all.given
 import refined4s.types.all.*
 import refined4s.types.networkGens
 
+import java.util.UUID
+
 /** @author Kevin Lee
   * @since 2023-12-11
   */
@@ -113,6 +115,9 @@ object allSpec extends Properties {
     //
     property("test Encoder[NonEmptyString]", testEncoderNonEmptyString),
     property("test Decoder[NonEmptyString]", testDecoderNonEmptyString),
+    //
+    property("test Encoder[Uuid]", testEncoderUuid),
+    property("test Decoder[Uuid]", testDecoderUuid),
     //
     property("test Encoder[Uri]", testEncoderUri),
     property("test Decoder[Uri]", testDecoderUri),
@@ -1089,6 +1094,41 @@ object allSpec extends Properties {
 
       val expected = NonEmptyString.from(s)
       val actual   = decode[NonEmptyString](input.noSpaces)
+
+      actual ==== expected
+    }
+
+  //
+
+  @SuppressWarnings(Array("org.wartremover.warts.ToString"))
+  def testEncoderUuid: Property =
+    for {
+      uuid <- Gen.constant(UUID.randomUUID()).log("uuid")
+    } yield {
+      val s     = uuid.toString
+      val input = Uuid.unsafeFrom(s)
+
+      val expected = uuid.asJson
+      val actual   = input.asJson
+
+      Result.all(
+        List(
+          actual ==== expected,
+          actual.noSpaces ==== expected.noSpaces,
+        )
+      )
+    }
+
+  @SuppressWarnings(Array("org.wartremover.warts.ToString"))
+  def testDecoderUuid: Property =
+    for {
+      uuid <- Gen.constant(UUID.randomUUID()).log("uuid")
+    } yield {
+      val s     = uuid.toString
+      val input = s.asJson
+
+      val expected = Uuid.from(s)
+      val actual   = decode[Uuid](input.noSpaces)
 
       actual ==== expected
     }

--- a/modules/refined4s-core/shared/src/main/scala/refined4s/types/strings.scala
+++ b/modules/refined4s-core/shared/src/main/scala/refined4s/types/strings.scala
@@ -2,7 +2,10 @@ package refined4s.types
 
 import refined4s.*
 
+import java.util.UUID
 import scala.annotation.targetName
+import scala.quoted.*
+import scala.util.control.NonFatal
 
 /** @author Kevin Lee
   * @since 2023-04-25
@@ -13,6 +16,9 @@ trait strings {
 
   final type NonEmptyString = strings.NonEmptyString
   final val NonEmptyString = strings.NonEmptyString
+
+  final type Uuid = strings.Uuid
+  final val Uuid = strings.Uuid
 
   // scalafix:on
 
@@ -33,4 +39,55 @@ object strings {
       def ++(thatNes: NonEmptyString): NonEmptyString = NonEmptyString.unsafeFrom(thisNes.value + thatNes.value)
     }
   }
+
+  type Uuid = Uuid.Type
+  object Uuid extends InlinedRefined[String], CanBeOrdered[String] {
+    override inline val inlinedExpectedValue = "UUID"
+
+    override inline def inlinedPredicate(inline a: String): Boolean = ${ isValidateUuid('a) }
+
+    override def invalidReason(a: String): String = expectedMessage(inlinedExpectedValue)
+
+    override def predicate(a: String): Boolean =
+      try {
+        UUID.fromString(a)
+        true
+      } catch {
+        case NonFatal(_) =>
+          false
+      }
+
+    @SuppressWarnings(Array("org.wartremover.warts.ToString"))
+    def apply(a: UUID): Type = unsafeFrom(a.toString)
+
+    extension (uuid: Uuid) {
+      def toUUID: UUID = UUID.fromString(uuid.value)
+    }
+
+  }
+
+  val UnexpectedLiteralErrorMessage: String =
+    """Uri must be a string literal.
+      |If it's unknown in compile-time, use `Uuid.from` or `Uuid.unsafeFrom` instead.
+      |(unsafeFrom is not recommended)""".stripMargin
+
+  def isValidateUuid(uuidExpr: Expr[String])(using Quotes): Expr[Boolean] = {
+    import quotes.reflect.*
+    uuidExpr.asTerm match {
+      case Inlined(_, _, Literal(StringConstant(uuidStr))) =>
+        try {
+          java.util.UUID.fromString(uuidStr)
+          Expr(true)
+        } catch {
+          case _: Throwable => Expr(false)
+        }
+      case _ =>
+        report.error(
+          UnexpectedLiteralErrorMessage,
+          uuidExpr,
+        )
+        Expr(false)
+    }
+  }
+
 }

--- a/modules/refined4s-core/shared/src/test/scala/refined4s/types/stringsSpec.scala
+++ b/modules/refined4s-core/shared/src/test/scala/refined4s/types/stringsSpec.scala
@@ -1,15 +1,16 @@
 package refined4s.types
 
-import refined4s.*
-
 import hedgehog.*
 import hedgehog.runner.*
+import refined4s.*
+
+import java.util.UUID
 
 /** @author Kevin Lee
   * @since 2023-04-25
   */
 object stringsSpec extends Properties {
-  override def tests: List[Test] = NonEmptyStringSpec.tests
+  override def tests: List[Test] = NonEmptyStringSpec.tests ++ UuidSpec.tests
 
   object NonEmptyStringSpec {
     import all.NonEmptyString
@@ -126,6 +127,226 @@ object stringsSpec extends Properties {
         val input2   = NonEmptyString.unsafeFrom(s2)
         val expected = s1.compare(s2)
         Result.diff(input1: Ordered[NonEmptyString], input2: NonEmptyString)(_.compare(_) == expected)
+      }
+
+  }
+
+  @SuppressWarnings(Array("org.wartremover.warts.ToString"))
+  object UuidSpec {
+
+    import all.Uuid
+
+    def tests: List[Test] = List(
+      example("test strings.isValidateUuid(valid UUID String)", testStringsIsValidateUuidValid),
+      example("test strings.isValidateUuid(invalid UUID String)", testStringsIsValidateUuidInvalid),
+      example("test strings.isValidateUuid(invalid String literal)", testStringsIsValidateUuidWithInvalidLiteral),
+      example("test Uuid.apply", testApply),
+      example("test Uuid.apply(UUID)", testApplyUUID),
+      example("test Uuid.apply(Invalid)", testApplyInvalid),
+      property("test Uuid.from(valid)", testFromValid),
+      example("test Uuid.from(invalid)", testFromInvalid),
+      property("test Uuid.unsafeFrom(valid)", testUnsafeFromValid),
+      example("test Uuid.unsafeFrom(invalid)", testUnsafeFromInvalid),
+      property("test Uuid.value", testValue),
+      property("test Uuid.unapply", testUnapplyWithPatternMatching),
+      property("test Uuid.toUUID", testToUUID),
+      property("test Ordering[Uuid]", testOrdering),
+      property("test Ordered[Uuid]", testOrdered),
+    )
+
+    inline def runStringsIsValidateUuid(inline a: String): Boolean = ${ strings.isValidateUuid('a) }
+
+    def testStringsIsValidateUuidValid: Result = {
+      val expected = true
+      val actual   = runStringsIsValidateUuid("3108715a-6477-4cd1-9ace-85b1260be03d")
+      (actual ==== expected)
+        .log("""strings.isValidateUuid("3108715a-6477-4cd1-9ace-85b1260be03d") should return true but it returned false.""")
+    }
+
+    def testStringsIsValidateUuidInvalid: Result = {
+      val expected = false
+      val actual   = runStringsIsValidateUuid("blah")
+      (actual ==== expected)
+        .log("""strings.isValidateUuid("blah") should return false but it returned true""")
+    }
+
+    def testStringsIsValidateUuidWithInvalidLiteral: Result = {
+      import scala.compiletime.testing.typeCheckErrors
+      val expectedMessage = strings.UnexpectedLiteralErrorMessage
+
+      val actual = typeCheckErrors(
+        """
+          val a = "blah"
+          runStringsIsValidateUuid(a)
+        """
+      )
+
+      val actualErrorMessage = actual.map(_.message).mkString
+      (actualErrorMessage ==== expectedMessage)
+    }
+
+    def testApply: Result = {
+      val expected = UUID.fromString("3108715a-6477-4cd1-9ace-85b1260be03d")
+      val actual   = Uuid("3108715a-6477-4cd1-9ace-85b1260be03d")
+      actual.value ==== expected.toString
+    }
+
+    def testApplyUUID: Result = {
+      val uuid     = UUID.fromString("3108715a-6477-4cd1-9ace-85b1260be03d")
+      val expected = uuid
+      val actual   = Uuid(uuid)
+      actual.value ==== expected.toString
+    }
+
+    def testApplyInvalid: Result = {
+      import scala.compiletime.testing.typeChecks
+
+      val shouldCompile1 = typeChecks(
+        """
+          import strings.*
+          Uuid("3108715a-6477-4cd1-9ace-85b1260be03d")
+        """
+      )
+
+      val shouldNotCompile1 = !typeChecks(
+        """
+          import strings.*
+          Uuid("blah")
+        """
+      )
+
+      val shouldNotCompile2 = !typeChecks(
+        """
+          import strings.*
+          Uuid("")
+        """
+      )
+
+      val shouldNotCompile3 = !typeChecks(
+        """
+          import strings.*
+          Uuid(123)
+        """
+      )
+
+      Result.all(
+        List(
+          Result
+            .assert(shouldCompile1)
+            .log("""Uuid("3108715a-6477-4cd1-9ace-85b1260be03d") should have compiled without any compile-time error but it failed."""),
+          Result.assert(shouldNotCompile1).log("""Uuid("blah") should have failed compilation but it succeeded."""),
+          Result.assert(shouldNotCompile2).log("""Uuid("") should have failed compilation but it succeeded."""),
+          Result.assert(shouldNotCompile3).log("""Uuid(123) should have failed compilation but it succeeded."""),
+        )
+      )
+    }
+
+    def testFromValid: Property =
+      for {
+        uuid <- Gen.constant(UUID.randomUUID()).log("uuid")
+      } yield {
+        val s        = uuid.toString
+        val expected = Uuid.unsafeFrom(s)
+        val actual   = Uuid.from(s)
+        actual ==== Right(expected)
+      }
+
+    def testFromInvalid: Result = {
+      val expected1 = "Invalid value: [blah]. It must be UUID"
+      val expected2 = "Invalid value: []. It must be UUID"
+      val actual1   = Uuid.from("blah")
+      val actual2   = Uuid.from("")
+      Result.all(
+        List(
+          actual1 ==== Left(expected1),
+          actual2 ==== Left(expected2),
+        )
+      )
+    }
+
+    def testUnsafeFromValid: Property =
+      for {
+        uuid <- Gen.constant(UUID.randomUUID()).log("uuid")
+      } yield {
+        val s        = uuid.toString
+        val expected = Uuid.unsafeFrom(s)
+        val actual   = Uuid.unsafeFrom(s)
+        actual ==== expected
+      }
+
+    def testUnsafeFromInvalid: Result = {
+      val expected = "Invalid value: [blah]. It must be UUID"
+      try {
+        Uuid.unsafeFrom("blah")
+        Result
+          .failure
+          .log("""IllegalArgumentException was expected from Uuid.unsafeFrom("blah"), but it was not thrown.""")
+      } catch {
+        case ex: IllegalArgumentException =>
+          ex.getMessage ==== expected
+
+      }
+    }
+
+    def testValue: Property =
+      for {
+        uuid <- Gen.constant(UUID.randomUUID()).log("uuid")
+      } yield {
+        val s        = uuid.toString
+        val expected = s
+        val actual   = Uuid.unsafeFrom(s)
+        actual.value ==== expected
+      }
+
+    def testUnapplyWithPatternMatching: Property =
+      for {
+        uuid <- Gen.constant(UUID.randomUUID()).log("uuid")
+      } yield {
+        val s        = uuid.toString
+        val expected = s
+        val nes      = Uuid.unsafeFrom(s)
+        nes match {
+          case Uuid(actual) =>
+            actual ==== expected
+        }
+      }
+
+    def testToUUID: Property =
+      for {
+        uuid <- Gen.constant(UUID.randomUUID()).log("uuid")
+
+      } yield {
+        val s        = uuid.toString
+        val nes1     = Uuid.unsafeFrom(s)
+        val actual   = nes1.toUUID
+        val expected = uuid
+        actual ==== expected
+      }
+
+    def testOrdering: Property =
+      for {
+        uuid1 <- Gen.constant(UUID.randomUUID()).log("uuid1")
+        uuid2 <- Gen.constant(UUID.randomUUID()).log("uuid2")
+      } yield {
+        val s1       = uuid1.toString
+        val s2       = uuid2.toString
+        val input1   = Uuid.unsafeFrom(s1)
+        val input2   = Uuid.unsafeFrom(s2)
+        val expected = s1.compare(s2)
+        Result.diff(input1, input2)(Ordering[Uuid].compare(_, _) == expected)
+      }
+
+    def testOrdered: Property =
+      for {
+        uuid1 <- Gen.constant(UUID.randomUUID()).log("uuid1")
+        uuid2 <- Gen.constant(UUID.randomUUID()).log("uuid2")
+      } yield {
+        val s1       = uuid1.toString
+        val s2       = uuid2.toString
+        val input1   = Uuid.unsafeFrom(s1)
+        val input2   = Uuid.unsafeFrom(s2)
+        val expected = s1.compare(s2)
+        Result.diff(input1: Ordered[Uuid], input2: Uuid)(_.compare(_) == expected)
       }
 
   }

--- a/modules/refined4s-doobie-ce2/shared/src/main/scala/refined4s/modules/doobie/derivation/types/all.scala
+++ b/modules/refined4s-doobie-ce2/shared/src/main/scala/refined4s/modules/doobie/derivation/types/all.scala
@@ -109,6 +109,9 @@ trait all {
   inline given derivedNonEmptyStringGet(using Show[String]): Get[NonEmptyString] = Get[String].temap(NonEmptyString.from)
   inline given derivedNonEmptyStringPut: Put[NonEmptyString]                     = Put[String].contramap(_.value)
 
+  inline given derivedUuidGet(using Show[String]): Get[Uuid] = Get[String].temap(Uuid.from)
+  inline given derivedUuidPut: Put[Uuid]                     = Put[String].contramap(_.value)
+
   // network
   inline given derivedUriGet(using Show[String]): Get[Uri] = Get[String].temap(Uri.from)
   inline given derivedUriPut: Put[Uri]                     = Put[String].contramap(_.value)

--- a/modules/refined4s-doobie-ce2/shared/src/test/scala/refined4s/modules/doobie/derivation/types/allSpec.scala
+++ b/modules/refined4s-doobie-ce2/shared/src/test/scala/refined4s/modules/doobie/derivation/types/allSpec.scala
@@ -14,6 +14,7 @@ import refined4s.types.all.*
 import refined4s.types.networkGens
 import refined4s.modules.doobie.derivation.types.all.given
 
+import java.util.UUID
 import java.util.concurrent.atomic.AtomicInteger
 
 /** @author Kevin Lee
@@ -101,6 +102,8 @@ object allSpec extends Properties, RunSyncCe2, RunWithDb {
     ),
     //
     propertyWithDb("test Get[NonEmptyString] and Put[NonEmptyString]", postgresPortNumber.getAndIncrement(), testGetAndPutNonEmptyString),
+    //
+    propertyWithDb("test Get[Uuid] and Put[Uuid]", postgresPortNumber.getAndIncrement(), testGetAndPutUuid),
     //
     propertyWithDb("test Get[Uri] and Put[Uri]", postgresPortNumber.getAndIncrement(), testGetAndPutUri),
 
@@ -1784,6 +1787,57 @@ object allSpec extends Properties, RunSyncCe2, RunWithDb {
       val expectedFetchAfter  = s.some
 
       val fetch = DbTools.fetchSingleRow[F][NonEmptyString](
+        sql"""
+            SELECT value
+              FROM db_tools_test.example
+        """
+      )(transactor)
+
+      val insert = DbTools.updateSingle[F](
+        sql"""
+             INSERT INTO db_tools_test.example (value) VALUES ($expected)
+        """
+      )(transactor)
+
+      for {
+        fetchResultBefore <- fetch.map(_ ==== expectedFetchBefore)
+        insertResult      <- insert.map(_ ==== expectedInsert)
+        fetchResultAfter  <- fetch.map(_ ==== expectedFetchAfter)
+      } yield Result.all(
+        List(
+          fetchResultBefore.log("Failed: fetch before"),
+          insertResult.log("Failed: insert"),
+          fetchResultAfter.log("Failed: fetch after"),
+        )
+      )
+
+    }
+
+  ///
+
+  def testGetAndPutUuid(testName: String, postgresPortNumber: Int): Property =
+    for {
+      uuid <- Gen.constant(UUID.randomUUID()).log("uuid")
+    } yield withDb[F](
+      testName,
+      postgresPortNumber,
+      sql"""CREATE SCHEMA IF NOT EXISTS db_tools_test""",
+      sql"""
+        CREATE TABLE IF NOT EXISTS db_tools_test.example
+        (
+           id SERIAL PRIMARY KEY,
+           value TEXT NOT NULL
+        )
+      """,
+    ) { transactor =>
+
+      val expected = Uuid(uuid)
+
+      val expectedFetchBefore = none[Uuid]
+      val expectedInsert      = 1
+      val expectedFetchAfter  = expected.some
+
+      val fetch = DbTools.fetchSingleRow[F][Uuid](
         sql"""
             SELECT value
               FROM db_tools_test.example

--- a/modules/refined4s-doobie-ce3/shared/src/main/scala/refined4s/modules/doobie/derivation/types/all.scala
+++ b/modules/refined4s-doobie-ce3/shared/src/main/scala/refined4s/modules/doobie/derivation/types/all.scala
@@ -109,6 +109,9 @@ trait all {
   inline given derivedNonEmptyStringGet(using Show[String]): Get[NonEmptyString] = Get[String].temap(NonEmptyString.from)
   inline given derivedNonEmptyStringPut: Put[NonEmptyString]                     = Put[String].contramap(_.value)
 
+  inline given derivedUuidGet(using Show[String]): Get[Uuid] = Get[String].temap(Uuid.from)
+  inline given derivedUuidPut: Put[Uuid]                     = Put[String].contramap(_.value)
+
   // network
   inline given derivedUriGet(using Show[String]): Get[Uri] = Get[String].temap(Uri.from)
   inline given derivedUriPut: Put[Uri]                     = Put[String].contramap(_.value)

--- a/modules/refined4s-extras-render/shared/src/main/scala/refined4s/modules/extras/derivation/types/all.scala
+++ b/modules/refined4s-extras-render/shared/src/main/scala/refined4s/modules/extras/derivation/types/all.scala
@@ -104,6 +104,9 @@ trait all {
   inline given derivedNonEmptyStringRender(using renderActual: Render[String]): Render[NonEmptyString] =
     renderActual.contramap(_.value)
 
+  inline given derivedUuidRender(using renderActual: Render[String]): Render[Uuid] =
+    renderActual.contramap(_.value)
+
   // network
 
   inline given derivedUriRender(using renderActual: Render[String]): Render[Uri] = renderActual.contramap(_.value)

--- a/modules/refined4s-extras-render/shared/src/test/scala/refined4s/modules/extras/derivation/types/allSpec.scala
+++ b/modules/refined4s-extras-render/shared/src/test/scala/refined4s/modules/extras/derivation/types/allSpec.scala
@@ -7,6 +7,8 @@ import refined4s.modules.extras.derivation.types.all.given
 import refined4s.types.all.*
 import refined4s.types.networkGens
 
+import java.util.UUID
+
 /** @author Kevin Lee
   * @since 2024-01-01
   */
@@ -79,6 +81,8 @@ object allSpec extends Properties {
     property("test Render[NonPosBigDecimal]", testRenderNonPosBigDecimal),
     //
     property("test Render[NonEmptyString]", testRenderNonEmptyString),
+    //
+    property("test Render[Uuid]", testRenderUuid),
     //
     property("test Render[Uri]", testRenderUri),
 
@@ -485,6 +489,18 @@ object allSpec extends Properties {
       val input = NonEmptyString.unsafeFrom(s)
 
       val expected = s
+      val actual   = input.render
+
+      actual ==== expected
+    }
+
+  def testRenderUuid: Property =
+    for {
+      uuid <- Gen.constant(UUID.randomUUID()).log("uuid")
+    } yield {
+      val input = Uuid(uuid)
+
+      val expected = uuid.toString
       val actual   = input.render
 
       actual ==== expected

--- a/modules/refined4s-pureconfig/shared/src/main/scala/refined4s/modules/pureconfig/derivation/types/all.scala
+++ b/modules/refined4s-pureconfig/shared/src/main/scala/refined4s/modules/pureconfig/derivation/types/all.scala
@@ -443,6 +443,19 @@ trait all {
       ConfigWriter[String].to(a.value)
   }
 
+  given derivedUuidConfigReader: ConfigReader[Uuid] = ConfigReader[String].emap { a =>
+    Uuid.from(a).left.map { err =>
+      val expectedType = getTypeName[Uuid]
+      UserValidationFailed(
+        s"The value $a cannot be created as the expected type, $expectedType, due to the following error: $err"
+      )
+    }
+  }
+  given derivedUuidConfigWriter: ConfigWriter[Uuid] with {
+    override inline def to(a: Uuid): ConfigValue =
+      ConfigWriter[String].to(a.value)
+  }
+
   // network
 
   given derivedUriConfigReader: ConfigReader[Uri] = ConfigReader[String].emap { a =>


### PR DESCRIPTION
Close #248 - [`refined4s-core`] Add `Uuid` `String` which can be validated as `java.util.UUID` and the type-class instances for `Uuid` in the other modules