### PR TITLE
Close #273 - [`refined4s-tapir`] Add `TapirNewtypeSchema` and `TapirRefinedSchema` to support `sttp.tapir.Schema` for `refined4s`

### DIFF
--- a/modules/refined4s-tapir/shared/src/main/scala/refined4s/modules/tapir/derivation/TapirNewtypeSchema.scala
+++ b/modules/refined4s-tapir/shared/src/main/scala/refined4s/modules/tapir/derivation/TapirNewtypeSchema.scala
@@ -1,0 +1,13 @@
+package refined4s.modules.tapir.derivation
+
+import refined4s.NewtypeBase
+import sttp.tapir.Schema
+
+/** @author Kevin Lee
+  * @since 2024-04-03
+  */
+trait TapirNewtypeSchema[A: Schema] {
+  self: NewtypeBase[A] =>
+
+  given derivedSchema: Schema[Type] = deriving[Schema]
+}

--- a/modules/refined4s-tapir/shared/src/main/scala/refined4s/modules/tapir/derivation/TapirRefinedSchema.scala
+++ b/modules/refined4s-tapir/shared/src/main/scala/refined4s/modules/tapir/derivation/TapirRefinedSchema.scala
@@ -1,0 +1,13 @@
+package refined4s.modules.tapir.derivation
+
+import refined4s.RefinedBase
+import sttp.tapir.Schema
+
+/** @author Kevin Lee
+  * @since 2024-04-03
+  */
+trait TapirRefinedSchema[A: Schema] {
+  self: RefinedBase[A] =>
+
+  given derivedSchema: Schema[Type] = summon[Schema[A]].map[Type](from(_).toOption)(_.value)
+}

--- a/modules/refined4s-tapir/shared/src/test/scala/refined4s/modules/tapir/derivation/TapirSchemaSpec.scala
+++ b/modules/refined4s-tapir/shared/src/test/scala/refined4s/modules/tapir/derivation/TapirSchemaSpec.scala
@@ -1,0 +1,70 @@
+package refined4s.modules.tapir.derivation
+
+import hedgehog.*
+import hedgehog.runner.*
+import refined4s.*
+import refined4s.syntax.*
+import sttp.tapir.Schema
+
+/** @author Kevin Lee
+  * @since 2024-04-03
+  */
+object TapirSchemaSpec extends Properties {
+  override def tests: List[Test] = List(
+    property(
+      "Given Newtype with TapirNewtypeSchema. summon[Schema[Newtype[A]]].applyValidation(a) where a is Newtype[A] should return an empty List[ValidationError[_]]",
+      testRenderNewtype,
+    ),
+    property(
+      "Given Refined with TapirRefinedSchema. summon[Schema[Refined[A]]].applyValidation(a) where a is Refined[A] should return an empty List[ValidationError[_]]",
+      testRenderRefined,
+    ),
+    property(
+      "Given Newtype[Refined] with TapirNewtypeSchema. summon[Schema[Newtype[Refined[A]]]].applyValidation(a) where a is Newtype[Refined[A]] should return an empty List[ValidationError[_]]",
+      testRenderNewtypeRefined,
+    ),
+  )
+
+  def testRenderNewtype: Property =
+    for {
+      s <- Gen.string(Gen.unicode, Range.linear(0, 10)).log("s")
+    } yield {
+      val a      = MyNewtype(s)
+      val actual = summon[Schema[MyNewtype]].applyValidation(a)
+      actual ==== List.empty
+    }
+
+  def testRenderRefined: Property =
+    for {
+      s <- Gen.string(Gen.unicode, Range.linear(1, 10)).log("s")
+    } yield {
+      val a      = MyRefinedType.unsafeFrom(s)
+      val actual = summon[Schema[MyRefinedType]].applyValidation(a)
+      actual ==== List.empty
+    }
+
+  def testRenderNewtypeRefined: Property =
+    for {
+      s <- Gen.string(Gen.unicode, Range.linear(1, 10)).log("s")
+    } yield {
+      val a      = MyRefinedNewtype(MyRefinedType.unsafeFrom(s))
+      val actual = summon[Schema[MyRefinedNewtype]].applyValidation(a)
+      actual ==== List.empty
+    }
+
+  type MyNewtype = MyNewtype.Type
+  object MyNewtype extends Newtype[String] with TapirNewtypeSchema[String]
+
+  type MyRefinedType = MyRefinedType.Type
+  @SuppressWarnings(Array("org.wartremover.warts.Equals"))
+  object MyRefinedType extends Refined[String] with TapirRefinedSchema[String] {
+    override inline def invalidReason(a: String): String =
+      "It has to be a non-empty String but got \"" + a + "\""
+
+    override inline def predicate(a: String): Boolean = a != ""
+  }
+
+  type MyRefinedNewtype = MyRefinedNewtype.Type
+  object MyRefinedNewtype extends Newtype[MyRefinedType] with TapirNewtypeSchema[MyRefinedType]
+
+}


### PR DESCRIPTION
Close #273 - [`refined4s-tapir`] Add `TapirNewtypeSchema` and `TapirRefinedSchema` to support `sttp.tapir.Schema` for `refined4s`