### PR TITLE
Close #315 - [refined4s-circe] Add numeric, strings and network objects in refined4s.modules.circe.derivation.types

### DIFF
--- a/modules/refined4s-circe/shared/src/main/scala/refined4s/modules/circe/derivation/types/network.scala
+++ b/modules/refined4s-circe/shared/src/main/scala/refined4s/modules/circe/derivation/types/network.scala
@@ -30,3 +30,4 @@ trait network {
   inline given derivedDynamicPortNumberDecoder: Decoder[DynamicPortNumber] = Decoder[Int].emap(DynamicPortNumber.from)
 
 }
+object network extends network

--- a/modules/refined4s-circe/shared/src/main/scala/refined4s/modules/circe/derivation/types/numeric.scala
+++ b/modules/refined4s-circe/shared/src/main/scala/refined4s/modules/circe/derivation/types/numeric.scala
@@ -105,3 +105,4 @@ trait numeric {
   inline given derivedNonPosBigDecimalDecoder: Decoder[NonPosBigDecimal] = Decoder[BigDecimal].emap(NonPosBigDecimal.from)
 
 }
+object numeric extends numeric

--- a/modules/refined4s-circe/shared/src/main/scala/refined4s/modules/circe/derivation/types/strings.scala
+++ b/modules/refined4s-circe/shared/src/main/scala/refined4s/modules/circe/derivation/types/strings.scala
@@ -18,3 +18,4 @@ trait strings {
   inline given derivedUuidDecoder: Decoder[Uuid] = Decoder[String].emap(Uuid.from)
 
 }
+object strings extends strings


### PR DESCRIPTION
Close #315 - [`refined4s-circe`] Add `numeric`, `strings` and `network` objects in `refined4s.modules.circe.derivation.types`