### PR TITLE
refined4s v0.16.0

### DIFF
--- a/changelogs/0.16.0.md
+++ b/changelogs/0.16.0.md
@@ -1,0 +1,12 @@
+## [0.16.0](https://github.com/kevin-lee/refined4s/issues?q=is%3Aissue+is%3Aclosed+-label%3Ainvalid+-label%3Awontfix+milestone%3Am16) - 2024-08-03
+
+### Improvement
+
+* [`refined4s-core`] Add unicode encoding for the error message from `NonBlankString.from` (#312)
+  ```scala 3
+  val s = "\u0009\u200a\u2004\u1680"
+  // String = "	   "
+  NonBlankString.from(s)
+  // Left(Invalid value: [	   ], unicode=[\u0009\u200a\u2004\u1680]. It must be not all whitespace non-empty String)
+  ```
+* [`refined4s-circe`] Add `numeric`, `strings` and `network` objects in `refined4s.modules.circe.derivation.types`


### PR DESCRIPTION
# refined4s v0.16.0
## [0.16.0](https://github.com/kevin-lee/refined4s/issues?q=is%3Aissue+is%3Aclosed+-label%3Ainvalid+-label%3Awontfix+milestone%3Am16) - 2024-08-03

### Improvement

* [`refined4s-core`] Add unicode encoding for the error message from `NonBlankString.from` (#312)
  ```scala 3
  val s = "\u0009\u200a\u2004\u1680"
  // String = "	   "
  NonBlankString.from(s)
  // Left(Invalid value: [	   ], unicode=[\u0009\u200a\u2004\u1680]. It must be not all whitespace non-empty String)
  ```
* [`refined4s-circe`] Add `numeric`, `strings` and `network` objects in `refined4s.modules.circe.derivation.types`
