### PR TITLE
Bump Scala 2.13 for `refined-compat-scala2` to 2.13.13

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -178,7 +178,7 @@ lazy val extrasRenderJs  = extrasRender.js.settings(jsSettingsForFuture)
 
 lazy val refinedCompatScala2    = module("refined-compat-scala2", crossProject(JVMPlatform, JSPlatform))
   .settings(
-    crossScalaVersions := List("2.12.15", "2.13.12"),
+    crossScalaVersions := List("2.12.15", "2.13.13"),
     libraryDependencies ++=
       (
         if (isScala3(scalaVersion.value))


### PR DESCRIPTION
Bump Scala 2.13 for `refined-compat-scala2` to 2.13.13