### PR TITLE
Close #331 - [`refined4s-chimney`] Add `refined4s.modules.chimney.derivation.types.strings` to support Chimney for pre-defined refined types in `refined4s.types.strings`

### DIFF
--- a/modules/refined4s-chimney/shared/src/main/scala/refined4s/modules/chimney/derivation/types/strings.scala
+++ b/modules/refined4s-chimney/shared/src/main/scala/refined4s/modules/chimney/derivation/types/strings.scala
@@ -1,0 +1,30 @@
+package refined4s.modules.chimney.derivation.types
+
+import io.scalaland.chimney
+import io.scalaland.chimney.{PartialTransformer, Transformer}
+import refined4s.types.strings.*
+
+/** @author Kevin Lee
+  * @since 2023-12-25
+  */
+trait strings {
+
+  inline given derivedNonEmptyStringToStringTransformer: Transformer[NonEmptyString, String] with {
+    override def transform(src: NonEmptyString): String = src.value
+  }
+  inline given derivedStringToNonEmptyStringPartialTransformer: PartialTransformer[String, NonEmptyString] =
+    PartialTransformer(value => chimney.partial.Result.fromEitherString(NonEmptyString.from(value)))
+
+  inline given derivedNonBlankStringToStringTransformer: Transformer[NonBlankString, String] with {
+    override def transform(src: NonBlankString): String = src.value
+  }
+  inline given derivedStringToNonBlankStringPartialTransformer: PartialTransformer[String, NonBlankString] =
+    PartialTransformer(value => chimney.partial.Result.fromEitherString(NonBlankString.from(value)))
+
+  inline given derivedUuidToStringTransformer: Transformer[Uuid, String] with {
+    override def transform(src: Uuid): String = src.value
+  }
+  inline given derivedStringToUuidPartialTransformer: PartialTransformer[String, Uuid] =
+    PartialTransformer(value => chimney.partial.Result.fromEitherString(Uuid.from(value)))
+}
+object strings extends strings

--- a/modules/refined4s-chimney/shared/src/test/scala/refined4s/modules/chimney/derivation/types/stringsSpec.scala
+++ b/modules/refined4s-chimney/shared/src/test/scala/refined4s/modules/chimney/derivation/types/stringsSpec.scala
@@ -1,0 +1,109 @@
+package refined4s.modules.chimney.derivation.types
+
+import hedgehog.*
+import hedgehog.extra.refined4s.gens.StringGens
+import hedgehog.runner.*
+import io.scalaland.chimney
+import io.scalaland.chimney.dsl.*
+import refined4s.types.numeric.PosInt
+import refined4s.types.strings.*
+
+/** @author Kevin Lee
+  * @since 2024-08-06
+  */
+object stringsSpec extends Properties {
+  override def tests: List[Test] = List(
+    // NonEmptyString
+    property("test from NonEmptyString to String", testFromNonEmptyString),
+    property("test from String to NonEmptyString", testToNonEmptyString),
+    // NonBlankString
+    property("test from NonBlankString to String", testFromNonBlankString),
+    property("test from String to NonBlankString", testToNonBlankString),
+    // Uuid
+    property("test from Uuid to String", testFromUuid),
+    property("test from String to Uuid", testToUuid),
+  )
+
+  def testFromNonEmptyString: Property =
+    for {
+      s <- StringGens.genNonEmptyString(Gen.alphaNum, PosInt(10)).log("s")
+    } yield {
+      val input = s
+
+      val expected = s.value
+      val actual   = input.into[String].transform
+
+      actual ==== expected
+    }
+
+  def testToNonEmptyString: Property =
+    for {
+      s <- StringGens.genNonEmptyString(Gen.alphaNum, PosInt(10)).log("s")
+    } yield {
+      val input = s.value
+
+      val expected = chimney.partial.Result.fromValue(s)
+
+      import refined4s.modules.chimney.derivation.types.strings.derivedStringToNonEmptyStringPartialTransformer
+      val actual = input.intoPartial[NonEmptyString].transform
+
+      actual ==== expected
+    }
+
+  //
+
+  def testFromNonBlankString: Property =
+    for {
+      s <- StringGens.genNonBlankString(PosInt(10)).log("s")
+    } yield {
+      val input = s
+
+      val expected = s.value
+      val actual   = input.into[String].transform
+
+      actual ==== expected
+    }
+
+  def testToNonBlankString: Property =
+    for {
+      s <- StringGens.genNonBlankString(PosInt(10)).log("s")
+    } yield {
+      val input = s.value
+
+      val expected = chimney.partial.Result.fromValue(s)
+
+      import refined4s.modules.chimney.derivation.types.strings.derivedStringToNonBlankStringPartialTransformer
+      val actual = input.intoPartial[NonBlankString].transform
+
+      actual ==== expected
+    }
+
+  //
+
+  def testFromUuid: Property =
+    for {
+      uuid <- StringGens.genUuid.log("uuid")
+    } yield {
+      val input = uuid
+
+      val expected = uuid.value
+      val actual   = input.into[String].transform
+
+      actual ==== expected
+    }
+
+  def testToUuid: Property =
+    for {
+      uuid <- StringGens.genUuid.log("uuid")
+    } yield {
+      val input = uuid.value
+
+      val expected = chimney.partial.Result.fromValue(uuid)
+
+      import refined4s.modules.chimney.derivation.types.strings.derivedStringToUuidPartialTransformer
+      val actual = input.intoPartial[Uuid].transform
+
+      actual ==== expected
+    }
+
+}


### PR DESCRIPTION
Close #331 - [`refined4s-chimney`] Add `refined4s.modules.chimney.derivation.types.strings` to support Chimney for pre-defined refined types in `refined4s.types.strings`