### PR TITLE
Close #332 - [`refined4s-chimney`] Add `refined4s.modules.chimney.derivation.types.numeric` to support Chimney for pre-defined refined types in `refined4s.types.numeric`

### DIFF
--- a/modules/refined4s-chimney/shared/src/main/scala/refined4s/modules/chimney/derivation/types/numeric.scala
+++ b/modules/refined4s-chimney/shared/src/main/scala/refined4s/modules/chimney/derivation/types/numeric.scala
@@ -1,0 +1,205 @@
+package refined4s.modules.chimney.derivation.types
+
+import io.scalaland.chimney
+import io.scalaland.chimney.{PartialTransformer, Transformer}
+import refined4s.types.numeric.*
+
+/** @author Kevin Lee
+  * @since 2023-12-25
+  */
+trait numeric {
+
+  inline given derivedNegIntTransformer: Transformer[NegInt, Int] with {
+    override def transform(src: NegInt): Int = src.value
+  }
+  inline given derivedNegIntPartialTransformer: PartialTransformer[Int, NegInt] =
+    PartialTransformer(value => chimney.partial.Result.fromEitherString(NegInt.from(value)))
+
+  inline given derivedNonNegIntTransformer: Transformer[NonNegInt, Int] with {
+    override def transform(src: NonNegInt): Int = src.value
+  }
+  inline given derivedNonNegIntPartialTransformer: PartialTransformer[Int, NonNegInt] =
+    PartialTransformer(value => chimney.partial.Result.fromEitherString(NonNegInt.from(value)))
+
+  inline given derivedPosIntTransformer: Transformer[PosInt, Int] with {
+    override def transform(src: PosInt): Int = src.value
+  }
+  inline given derivedPosIntPartialTransformer: PartialTransformer[Int, PosInt] =
+    PartialTransformer(value => chimney.partial.Result.fromEitherString(PosInt.from(value)))
+
+  inline given derivedNonPosIntTransformer: Transformer[NonPosInt, Int] with {
+    override def transform(src: NonPosInt): Int = src.value
+  }
+  inline given derivedNonPosIntPartialTransformer: PartialTransformer[Int, NonPosInt] =
+    PartialTransformer(value => chimney.partial.Result.fromEitherString(NonPosInt.from(value)))
+
+  inline given derivedNegLongTransformer: Transformer[NegLong, Long] with {
+    override def transform(src: NegLong): Long = src.value
+  }
+  inline given derivedNegLongPartialTransformer: PartialTransformer[Long, NegLong] =
+    PartialTransformer(value => chimney.partial.Result.fromEitherString(NegLong.from(value)))
+
+  inline given derivedNonNegLongTransformer: Transformer[NonNegLong, Long] with {
+    override def transform(src: NonNegLong): Long = src.value
+  }
+  inline given derivedNonNegLongPartialTransformer: PartialTransformer[Long, NonNegLong] =
+    PartialTransformer(value => chimney.partial.Result.fromEitherString(NonNegLong.from(value)))
+
+  inline given derivedPosLongTransformer: Transformer[PosLong, Long] with {
+    override def transform(src: PosLong): Long = src.value
+  }
+  inline given derivedPosLongPartialTransformer: PartialTransformer[Long, PosLong] =
+    PartialTransformer(value => chimney.partial.Result.fromEitherString(PosLong.from(value)))
+
+  inline given derivedNonPosLongTransformer: Transformer[NonPosLong, Long] with {
+    override def transform(src: NonPosLong): Long = src.value
+  }
+  inline given derivedNonPosLongPartialTransformer: PartialTransformer[Long, NonPosLong] =
+    PartialTransformer(value => chimney.partial.Result.fromEitherString(NonPosLong.from(value)))
+
+  inline given derivedNegShortTransformer: Transformer[NegShort, Short] with {
+    override def transform(src: NegShort): Short = src.value
+  }
+  inline given derivedNegShortPartialTransformer: PartialTransformer[Short, NegShort] =
+    PartialTransformer(value => chimney.partial.Result.fromEitherString(NegShort.from(value)))
+
+  inline given derivedNonNegShortTransformer: Transformer[NonNegShort, Short] with {
+    override def transform(src: NonNegShort): Short = src.value
+  }
+  inline given derivedNonNegShortPartialTransformer: PartialTransformer[Short, NonNegShort] =
+    PartialTransformer(value => chimney.partial.Result.fromEitherString(NonNegShort.from(value)))
+
+  inline given derivedPosShortTransformer: Transformer[PosShort, Short] with {
+    override def transform(src: PosShort): Short = src.value
+  }
+  inline given derivedPosShortPartialTransformer: PartialTransformer[Short, PosShort] =
+    PartialTransformer(value => chimney.partial.Result.fromEitherString(PosShort.from(value)))
+
+  inline given derivedNonPosShortTransformer: Transformer[NonPosShort, Short] with {
+    override def transform(src: NonPosShort): Short = src.value
+  }
+  inline given derivedNonPosShortPartialTransformer: PartialTransformer[Short, NonPosShort] =
+    PartialTransformer(value => chimney.partial.Result.fromEitherString(NonPosShort.from(value)))
+
+  inline given derivedNegByteTransformer: Transformer[NegByte, Byte] with {
+    override def transform(src: NegByte): Byte = src.value
+  }
+  inline given derivedNegBytePartialTransformer: PartialTransformer[Byte, NegByte] =
+    PartialTransformer(value => chimney.partial.Result.fromEitherString(NegByte.from(value)))
+
+  inline given derivedNonNegByteTransformer: Transformer[NonNegByte, Byte] with {
+    override def transform(src: NonNegByte): Byte = src.value
+  }
+  inline given derivedNonNegBytePartialTransformer: PartialTransformer[Byte, NonNegByte] =
+    PartialTransformer(value => chimney.partial.Result.fromEitherString(NonNegByte.from(value)))
+
+  inline given derivedPosByteTransformer: Transformer[PosByte, Byte] with {
+    override def transform(src: PosByte): Byte = src.value
+  }
+  inline given derivedPosBytePartialTransformer: PartialTransformer[Byte, PosByte] =
+    PartialTransformer(value => chimney.partial.Result.fromEitherString(PosByte.from(value)))
+
+  inline given derivedNonPosByteTransformer: Transformer[NonPosByte, Byte] with {
+    override def transform(src: NonPosByte): Byte = src.value
+  }
+  inline given derivedNonPosBytePartialTransformer: PartialTransformer[Byte, NonPosByte] =
+    PartialTransformer(value => chimney.partial.Result.fromEitherString(NonPosByte.from(value)))
+
+  inline given derivedNegFloatTransformer: Transformer[NegFloat, Float] with {
+    override def transform(src: NegFloat): Float = src.value
+  }
+  inline given derivedNegFloatPartialTransformer: PartialTransformer[Float, NegFloat] =
+    PartialTransformer(value => chimney.partial.Result.fromEitherString(NegFloat.from(value)))
+
+  inline given derivedNonNegFloatTransformer: Transformer[NonNegFloat, Float] with {
+    override def transform(src: NonNegFloat): Float = src.value
+  }
+  inline given derivedNonNegFloatPartialTransformer: PartialTransformer[Float, NonNegFloat] =
+    PartialTransformer(value => chimney.partial.Result.fromEitherString(NonNegFloat.from(value)))
+
+  inline given derivedPosFloatTransformer: Transformer[PosFloat, Float] with {
+    override def transform(src: PosFloat): Float = src.value
+  }
+  inline given derivedPosFloatPartialTransformer: PartialTransformer[Float, PosFloat] =
+    PartialTransformer(value => chimney.partial.Result.fromEitherString(PosFloat.from(value)))
+
+  inline given derivedNonPosFloatTransformer: Transformer[NonPosFloat, Float] with {
+    override def transform(src: NonPosFloat): Float = src.value
+  }
+  inline given derivedNonPosFloatPartialTransformer: PartialTransformer[Float, NonPosFloat] =
+    PartialTransformer(value => chimney.partial.Result.fromEitherString(NonPosFloat.from(value)))
+
+  inline given derivedNegDoubleTransformer: Transformer[NegDouble, Double] with {
+    override def transform(src: NegDouble): Double = src.value
+  }
+  inline given derivedNegDoublePartialTransformer: PartialTransformer[Double, NegDouble] =
+    PartialTransformer(value => chimney.partial.Result.fromEitherString(NegDouble.from(value)))
+
+  inline given derivedNonNegDoubleTransformer: Transformer[NonNegDouble, Double] with {
+    override def transform(src: NonNegDouble): Double = src.value
+  }
+  inline given derivedNonNegDoublePartialTransformer: PartialTransformer[Double, NonNegDouble] =
+    PartialTransformer(value => chimney.partial.Result.fromEitherString(NonNegDouble.from(value)))
+
+  inline given derivedPosDoubleTransformer: Transformer[PosDouble, Double] with {
+    override def transform(src: PosDouble): Double = src.value
+  }
+  inline given derivedPosDoublePartialTransformer: PartialTransformer[Double, PosDouble] =
+    PartialTransformer(value => chimney.partial.Result.fromEitherString(PosDouble.from(value)))
+
+  inline given derivedNonPosDoubleTransformer: Transformer[NonPosDouble, Double] with {
+    override def transform(src: NonPosDouble): Double = src.value
+  }
+  inline given derivedNonPosDoublePartialTransformer: PartialTransformer[Double, NonPosDouble] =
+    PartialTransformer(value => chimney.partial.Result.fromEitherString(NonPosDouble.from(value)))
+
+  inline given derivedNegBigIntTransformer: Transformer[NegBigInt, BigInt] with {
+    override def transform(src: NegBigInt): BigInt = src.value
+  }
+  inline given derivedNegBigIntPartialTransformer: PartialTransformer[BigInt, NegBigInt] =
+    PartialTransformer(value => chimney.partial.Result.fromEitherString(NegBigInt.from(value)))
+
+  inline given derivedNonNegBigIntTransformer: Transformer[NonNegBigInt, BigInt] with {
+    override def transform(src: NonNegBigInt): BigInt = src.value
+  }
+  inline given derivedNonNegBigIntPartialTransformer: PartialTransformer[BigInt, NonNegBigInt] =
+    PartialTransformer(value => chimney.partial.Result.fromEitherString(NonNegBigInt.from(value)))
+
+  inline given derivedPosBigIntTransformer: Transformer[PosBigInt, BigInt] with {
+    override def transform(src: PosBigInt): BigInt = src.value
+  }
+  inline given derivedPosBigIntPartialTransformer: PartialTransformer[BigInt, PosBigInt] =
+    PartialTransformer(value => chimney.partial.Result.fromEitherString(PosBigInt.from(value)))
+
+  inline given derivedNonPosBigIntTransformer: Transformer[NonPosBigInt, BigInt] with {
+    override def transform(src: NonPosBigInt): BigInt = src.value
+  }
+  inline given derivedNonPosBigIntPartialTransformer: PartialTransformer[BigInt, NonPosBigInt] =
+    PartialTransformer(value => chimney.partial.Result.fromEitherString(NonPosBigInt.from(value)))
+
+  inline given derivedNegBigDecimalTransformer: Transformer[NegBigDecimal, BigDecimal] with {
+    override def transform(src: NegBigDecimal): BigDecimal = src.value
+  }
+  inline given derivedNegBigDecimalPartialTransformer: PartialTransformer[BigDecimal, NegBigDecimal] =
+    PartialTransformer(value => chimney.partial.Result.fromEitherString(NegBigDecimal.from(value)))
+
+  inline given derivedNonNegBigDecimalTransformer: Transformer[NonNegBigDecimal, BigDecimal] with {
+    override def transform(src: NonNegBigDecimal): BigDecimal = src.value
+  }
+  inline given derivedNonNegBigDecimalPartialTransformer: PartialTransformer[BigDecimal, NonNegBigDecimal] =
+    PartialTransformer(value => chimney.partial.Result.fromEitherString(NonNegBigDecimal.from(value)))
+
+  inline given derivedPosBigDecimalTransformer: Transformer[PosBigDecimal, BigDecimal] with {
+    override def transform(src: PosBigDecimal): BigDecimal = src.value
+  }
+  inline given derivedPosBigDecimalPartialTransformer: PartialTransformer[BigDecimal, PosBigDecimal] =
+    PartialTransformer(value => chimney.partial.Result.fromEitherString(PosBigDecimal.from(value)))
+
+  inline given derivedNonPosBigDecimalTransformer: Transformer[NonPosBigDecimal, BigDecimal] with {
+    override def transform(src: NonPosBigDecimal): BigDecimal = src.value
+  }
+  inline given derivedNonPosBigDecimalPartialTransformer: PartialTransformer[BigDecimal, NonPosBigDecimal] =
+    PartialTransformer(value => chimney.partial.Result.fromEitherString(NonPosBigDecimal.from(value)))
+
+}
+object numeric extends numeric

--- a/modules/refined4s-chimney/shared/src/test/scala/refined4s/modules/chimney/derivation/types/numericSpec.scala
+++ b/modules/refined4s-chimney/shared/src/test/scala/refined4s/modules/chimney/derivation/types/numericSpec.scala
@@ -1,0 +1,949 @@
+package refined4s.modules.chimney.derivation.types
+
+import hedgehog.*
+import hedgehog.runner.*
+import hedgehog.extra.refined4s.gens.NumGens
+
+import refined4s.*
+import refined4s.types.numeric.*
+
+import io.scalaland.chimney
+import io.scalaland.chimney.dsl.*
+
+/** @author Kevin Lee
+  * @since 2024-08-09
+  */
+object numericSpec extends Properties {
+  override def tests: List[Test] = List(
+    property("test Transformer[NegInt, Int]", testTransformerNegInt),
+    property("test PartialTransformer[Int, NegInt]", testPartialTransformerNegInt),
+    //
+    property("test Transformer[NonNegInt, Int]", testTransformerNonNegInt),
+    property("test PartialTransformer[Int, NonNegInt]", testPartialTransformerNonNegInt),
+    //
+    property("test Transformer[PosInt, Int]", testTransformerPosInt),
+    property("test PartialTransformer[Int, PosInt]", testPartialTransformerPosInt),
+    //
+    property("test Transformer[NonPosInt, Int]", testTransformerNonPosInt),
+    property("test PartialTransformer[Int, NonPosInt]", testPartialTransformerNonPosInt),
+    //
+    property("test Transformer[NegLong, Long]", testTransformerNegLong),
+    property("test PartialTransformer[Long, NegLong]", testPartialTransformerNegLong),
+    //
+    property("test Transformer[NonNegLong, Long]", testTransformerNonNegLong),
+    property("test PartialTransformer[Long, NonNegLong]", testPartialTransformerNonNegLong),
+    //
+    property("test Transformer[PosLong, Long]", testTransformerPosLong),
+    property("test PartialTransformer[Long, PosLong]", testPartialTransformerPosLong),
+    //
+    property("test Transformer[NonPosLong, Long]", testTransformerNonPosLong),
+    property("test PartialTransformer[Long, NonPosLong]", testPartialTransformerNonPosLong),
+    //
+    property("test Transformer[NegShort, Short]", testTransformerNegShort),
+    property("test PartialTransformer[Short, NegShort]", testPartialTransformerNegShort),
+    //
+    property("test Transformer[NonNegShort, Short]", testTransformerNonNegShort),
+    property("test PartialTransformer[Short, NonNegShort]", testPartialTransformerNonNegShort),
+    //
+    property("test Transformer[PosShort, Short]", testTransformerPosShort),
+    property("test PartialTransformer[Short, PosShort]", testPartialTransformerPosShort),
+    //
+    property("test Transformer[NonPosShort, Short]", testTransformerNonPosShort),
+    property("test PartialTransformer[Short, NonPosShort]", testPartialTransformerNonPosShort),
+    //
+    property("test Transformer[NegByte, Byte]", testTransformerNegByte),
+    property("test PartialTransformer[Byte, NegByte]", testPartialTransformerNegByte),
+    //
+    property("test Transformer[NonNegByte, Byte]", testTransformerNonNegByte),
+    property("test PartialTransformer[Byte, NonNegByte]", testPartialTransformerNonNegByte),
+    //
+    property("test Transformer[PosByte, Byte]", testTransformerPosByte),
+    property("test PartialTransformer[Byte, PosByte]", testPartialTransformerPosByte),
+    //
+    property("test Transformer[NonPosByte, Byte]", testTransformerNonPosByte),
+    property("test PartialTransformer[Byte, NonPosByte]", testPartialTransformerNonPosByte),
+    //
+    property("test Transformer[NegFloat, Float]", testTransformerNegFloat),
+    property("test PartialTransformer[Float, NegFloat]", testPartialTransformerNegFloat),
+    //
+    property("test Transformer[NonNegFloat, Float]", testTransformerNonNegFloat),
+    property("test PartialTransformer[Float, NonNegFloat]", testPartialTransformerNonNegFloat),
+    //
+    property("test Transformer[PosFloat, Float]", testTransformerPosFloat),
+    property("test PartialTransformer[Float, PosFloat]", testPartialTransformerPosFloat),
+    //
+    property("test Transformer[NonPosFloat, Float]", testTransformerNonPosFloat),
+    property("test PartialTransformer[Float, NonPosFloat]", testPartialTransformerNonPosFloat),
+    //
+    property("test Transformer[NegDouble, Double]", testTransformerNegDouble),
+    property("test PartialTransformer[Double, NegDouble]", testPartialTransformerNegDouble),
+    //
+    property("test Transformer[NonNegDouble, Double]", testTransformerNonNegDouble),
+    property("test PartialTransformer[Double, NonNegDouble]", testPartialTransformerNonNegDouble),
+    //
+    property("test Transformer[PosDouble, Double]", testTransformerPosDouble),
+    property("test PartialTransformer[Double, PosDouble]", testPartialTransformerPosDouble),
+    //
+    property("test Transformer[NonPosDouble, Double]", testTransformerNonPosDouble),
+    property("test PartialTransformer[Double, NonPosDouble]", testPartialTransformerNonPosDouble),
+    //
+    property("test Transformer[NegBigInt, BigInt]", testTransformerNegBigInt),
+    property("test PartialTransformer[BigInt, NegBigInt]", testPartialTransformerNegBigInt),
+    //
+    property("test Transformer[NonNegBigInt, BigInt]", testTransformerNonNegBigInt),
+    property("test PartialTransformer[BigInt, NonNegBigInt]", testPartialTransformerNonNegBigInt),
+    //
+    property("test Transformer[PosBigInt, BigInt]", testTransformerPosBigInt),
+    property("test PartialTransformer[BigInt, PosBigInt]", testPartialTransformerPosBigInt),
+    //
+    property("test Transformer[NonPosBigInt, BigInt]", testTransformerNonPosBigInt),
+    property("test PartialTransformer[BigInt, NonPosBigInt]", testPartialTransformerNonPosBigInt),
+    //
+    property("test Transformer[NegBigDecimal, BigDecimal]", testTransformerNegBigDecimal),
+    property("test PartialTransformer[BigDecimal, NegBigDecimal]", testPartialTransformerNegBigDecimal),
+    //
+    property("test Transformer[NonNegBigDecimal, BigDecimal]", testTransformerNonNegBigDecimal),
+    property("test PartialTransformer[BigDecimal, NonNegBigDecimal]", testPartialTransformerNonNegBigDecimal),
+    //
+    property("test Transformer[PosBigDecimal, BigDecimal]", testTransformerPosBigDecimal),
+    property("test PartialTransformer[BigDecimal, PosBigDecimal]", testPartialTransformerPosBigDecimal),
+    //
+    property("test Transformer[NonPosBigDecimal, BigDecimal]", testTransformerNonPosBigDecimal),
+    property("test PartialTransformer[BigDecimal, NonPosBigDecimal]", testPartialTransformerNonPosBigDecimal),
+  )
+
+  import refined4s.modules.chimney.derivation.types.numeric.given
+
+  def testTransformerNegInt: Property =
+    for {
+      n <- NumGens.genNegIntMinTo(NegInt(Int.MinValue)).log("n")
+    } yield {
+      val input = n
+
+      val expected = n.value
+
+      val actual = input.into[Int].transform
+
+      actual ==== expected
+    }
+
+  def testPartialTransformerNegInt: Property =
+    for {
+      n <- NumGens.genNegIntMinTo(NegInt(Int.MinValue)).log("n")
+    } yield {
+      val input = n.value
+
+      val expected = chimney.partial.Result.fromValue(n)
+
+      val actual = input.intoPartial[NegInt].transform
+
+      actual ==== expected
+    }
+
+  //
+
+  def testTransformerNonNegInt: Property =
+    for {
+      n <- NumGens.genNonNegIntMaxTo(NonNegInt(Int.MaxValue)).log("n")
+    } yield {
+      val input = n
+
+      val expected = n.value
+      val actual   = input.into[Int].transform
+
+      actual ==== expected
+    }
+
+  def testPartialTransformerNonNegInt: Property =
+    for {
+      n <- NumGens.genNonNegIntMaxTo(NonNegInt(Int.MaxValue)).log("n")
+    } yield {
+      val input = n.value
+
+      val expected = chimney.partial.Result.fromValue(n)
+      val actual   = input.intoPartial[NonNegInt].transform
+
+      actual ==== expected
+    }
+
+  //
+
+  def testTransformerPosInt: Property =
+    for {
+      n <- NumGens.genPosIntMaxTo(PosInt(Int.MaxValue)).log("n")
+    } yield {
+      val input = n
+
+      val expected = n.value
+      val actual   = input.into[Int].transform
+
+      actual ==== expected
+    }
+
+  def testPartialTransformerPosInt: Property =
+    for {
+      n <- NumGens.genPosIntMaxTo(PosInt(Int.MaxValue)).log("n")
+    } yield {
+      val input = n.value
+
+      val expected = chimney.partial.Result.fromValue(n)
+      val actual   = input.intoPartial[PosInt].transform
+      actual ==== expected
+    }
+
+  //
+
+  def testTransformerNonPosInt: Property =
+    for {
+      n <- NumGens.genNonPosIntMinTo(NonPosInt(Int.MinValue)).log("n")
+    } yield {
+      val input = n
+
+      val expected = n.value
+      val actual   = input.into[Int].transform
+
+      actual ==== expected
+    }
+
+  def testPartialTransformerNonPosInt: Property =
+    for {
+      n <- NumGens.genNonPosIntMinTo(NonPosInt(Int.MinValue)).log("n")
+    } yield {
+      val input = n.value
+
+      val expected = chimney.partial.Result.fromValue(n)
+      val actual   = input.intoPartial[NonPosInt].transform
+
+      actual ==== expected
+    }
+
+  //
+
+  def testTransformerNegLong: Property =
+    for {
+      n <- NumGens.genNegLongMinTo(NegLong(Long.MinValue)).log("n")
+    } yield {
+      val input = n
+
+      val expected = n.value
+      val actual   = input.into[Long].transform
+
+      actual ==== expected
+    }
+
+  def testPartialTransformerNegLong: Property =
+    for {
+      n <- NumGens.genNegLongMinTo(NegLong(Long.MinValue)).log("n")
+    } yield {
+      val input = n.value
+
+      val expected = chimney.partial.Result.fromValue(n)
+      val actual   = input.intoPartial[NegLong].transform
+
+      actual ==== expected
+    }
+
+  //
+
+  def testTransformerNonNegLong: Property =
+    for {
+      n <- NumGens.genNonNegLongMaxTo(NonNegLong(Long.MaxValue)).log("n")
+    } yield {
+      val input = n
+
+      val expected = n.value
+      val actual   = input.into[Long].transform
+
+      actual ==== expected
+    }
+
+  def testPartialTransformerNonNegLong: Property =
+    for {
+      n <- NumGens.genNonNegLongMaxTo(NonNegLong(Long.MaxValue)).log("n")
+    } yield {
+      val input = n.value
+
+      val expected = chimney.partial.Result.fromValue(n)
+      val actual   = input.intoPartial[NonNegLong].transform
+      actual ==== expected
+    }
+
+  //
+
+  def testTransformerPosLong: Property =
+    for {
+      n <- NumGens.genPosLongMaxTo(PosLong(Long.MaxValue)).log("n")
+    } yield {
+      val input = n
+
+      val expected = n.value
+      val actual   = input.into[Long].transform
+
+      actual ==== expected
+    }
+
+  def testPartialTransformerPosLong: Property =
+    for {
+      n <- NumGens.genPosLongMaxTo(PosLong(Long.MaxValue)).log("n")
+    } yield {
+      val input = n.value
+
+      val expected = chimney.partial.Result.fromValue(n)
+      val actual   = input.intoPartial[PosLong].transform
+
+      actual ==== expected
+    }
+
+  //
+
+  def testTransformerNonPosLong: Property =
+    for {
+      n <- NumGens.genNonPosLongMinTo(NonPosLong(Long.MinValue)).log("n")
+    } yield {
+      val input = n
+
+      val expected = n.value
+      val actual   = input.into[Long].transform
+
+      actual ==== expected
+    }
+
+  def testPartialTransformerNonPosLong: Property =
+    for {
+      n <- NumGens.genNonPosLongMinTo(NonPosLong(Long.MinValue)).log("n")
+    } yield {
+      val input = n.value
+
+      val expected = chimney.partial.Result.fromValue(n)
+      val actual   = input.intoPartial[NonPosLong].transform
+
+      actual ==== expected
+    }
+
+  //
+
+  def testTransformerNegShort: Property =
+    for {
+      n <- Gen.short(Range.linear(-1, Short.MinValue)).log("n")
+    } yield {
+      val input = NegShort.unsafeFrom(n)
+
+      val expected = n
+      val actual   = input.into[Short].transform
+
+      actual ==== expected
+    }
+
+  def testPartialTransformerNegShort: Property =
+    for {
+      n <- Gen.short(Range.linear(-1, Short.MinValue)).log("n")
+    } yield {
+      val input = n
+
+      val expected = chimney.partial.Result.fromValue(NegShort.unsafeFrom(n))
+      val actual   = input.intoPartial[NegShort].transform
+
+      actual ==== expected
+    }
+
+  //
+
+  def testTransformerNonNegShort: Property =
+    for {
+      n <- Gen.short(Range.linear(0, Short.MaxValue)).log("n")
+    } yield {
+      val input = NonNegShort.unsafeFrom(n)
+
+      val expected = n
+      val actual   = input.into[Short].transform
+
+      actual ==== expected
+    }
+
+  def testPartialTransformerNonNegShort: Property =
+    for {
+      n <- Gen.short(Range.linear(0, Short.MaxValue)).log("n")
+    } yield {
+      val input = n
+
+      val expected = chimney.partial.Result.fromValue(NonNegShort.unsafeFrom(n))
+      val actual   = input.intoPartial[NonNegShort].transform
+
+      actual ==== expected
+    }
+
+  //
+
+  def testTransformerPosShort: Property =
+    for {
+      n <- Gen.short(Range.linear(1, Short.MaxValue)).log("n")
+    } yield {
+      val input = PosShort.unsafeFrom(n)
+
+      val expected = n
+      val actual   = input.into[Short].transform
+
+      actual ==== expected
+    }
+
+  def testPartialTransformerPosShort: Property =
+    for {
+      n <- Gen.short(Range.linear(1, Short.MaxValue)).log("n")
+    } yield {
+      val input = n
+
+      val expected = chimney.partial.Result.fromValue(PosShort.unsafeFrom(n))
+      val actual   = input.intoPartial[PosShort].transform
+
+      actual ==== expected
+    }
+
+  //
+
+  def testTransformerNonPosShort: Property =
+    for {
+      n <- Gen.short(Range.linear(0, Short.MinValue)).log("n")
+    } yield {
+      val input = NonPosShort.unsafeFrom(n)
+
+      val expected = n
+      val actual   = input.into[Short].transform
+
+      actual ==== expected
+    }
+
+  def testPartialTransformerNonPosShort: Property =
+    for {
+      n <- Gen.short(Range.linear(0, Short.MinValue)).log("n")
+    } yield {
+      val input = n
+
+      val expected = chimney.partial.Result.fromValue(NonPosShort.unsafeFrom(n))
+      val actual   = input.intoPartial[NonPosShort].transform
+
+      actual ==== expected
+    }
+
+  //
+
+  def testTransformerNegByte: Property =
+    for {
+      n <- Gen.byte(Range.linear(-1, Byte.MinValue)).log("n")
+    } yield {
+      val input = NegByte.unsafeFrom(n)
+
+      val expected = n
+      val actual   = input.into[Byte].transform
+
+      actual ==== expected
+    }
+
+  def testPartialTransformerNegByte: Property =
+    for {
+      n <- Gen.byte(Range.linear(-1, Byte.MinValue)).log("n")
+    } yield {
+      val input = n
+
+      val expected = chimney.partial.Result.fromValue(NegByte.unsafeFrom(n))
+      val actual   = input.intoPartial[NegByte].transform
+
+      actual ==== expected
+    }
+
+  //
+
+  def testTransformerNonNegByte: Property =
+    for {
+      n <- Gen.byte(Range.linear(0, Byte.MaxValue)).log("n")
+    } yield {
+      val input = NonNegByte.unsafeFrom(n)
+
+      val expected = n
+      val actual   = input.into[Byte].transform
+
+      actual ==== expected
+    }
+
+  def testPartialTransformerNonNegByte: Property =
+    for {
+      n <- Gen.byte(Range.linear(0, Byte.MaxValue)).log("n")
+    } yield {
+      val input = n
+
+      val expected = chimney.partial.Result.fromValue(NonNegByte.unsafeFrom(n))
+      val actual   = input.intoPartial[NonNegByte].transform
+
+      actual ==== expected
+    }
+
+  //
+
+  def testTransformerPosByte: Property =
+    for {
+      n <- Gen.byte(Range.linear(1, Byte.MaxValue)).log("n")
+    } yield {
+      val input = PosByte.unsafeFrom(n)
+
+      val expected = n
+      val actual   = input.into[Byte].transform
+
+      actual ==== expected
+    }
+
+  def testPartialTransformerPosByte: Property =
+    for {
+      n <- Gen.byte(Range.linear(1, Byte.MaxValue)).log("n")
+    } yield {
+      val input = n
+
+      val expected = chimney.partial.Result.fromValue(PosByte.unsafeFrom(n))
+      val actual   = input.intoPartial[PosByte].transform
+
+      actual ==== expected
+    }
+
+  //
+
+  def testTransformerNonPosByte: Property =
+    for {
+      n <- Gen.byte(Range.linear(0, Byte.MinValue)).log("n")
+    } yield {
+      val input = NonPosByte.unsafeFrom(n)
+
+      val expected = n
+      val actual   = input.into[Byte].transform
+
+      actual ==== expected
+    }
+
+  def testPartialTransformerNonPosByte: Property =
+    for {
+      n <- Gen.byte(Range.linear(0, Byte.MinValue)).log("n")
+    } yield {
+      val input = n
+
+      val expected = chimney.partial.Result.fromValue(NonPosByte.unsafeFrom(n))
+      val actual   = input.intoPartial[NonPosByte].transform
+
+      actual ==== expected
+    }
+
+  //
+
+  def testTransformerNegFloat: Property =
+    for {
+      n <- Gen.double(Range.linearFrac(-0.00001f, Float.MinValue)).map(_.toFloat).log("n")
+    } yield {
+      val input = NegFloat.unsafeFrom(n)
+
+      val expected = n
+      val actual   = input.into[Float].transform
+
+      actual ==== expected
+    }
+
+  def testPartialTransformerNegFloat: Property =
+    for {
+      n <- Gen.double(Range.linearFrac(-0.00001f, Float.MinValue)).map(_.toFloat).log("n")
+    } yield {
+      val input = n
+
+      val expected = chimney.partial.Result.fromValue(NegFloat.unsafeFrom(n))
+      val actual   = input.intoPartial[NegFloat].transform
+
+      actual ==== expected
+    }
+
+  //
+
+  def testTransformerNonNegFloat: Property =
+    for {
+      n <- Gen.double(Range.linearFrac(0f, Float.MaxValue)).map(_.toFloat).log("n")
+    } yield {
+      val input = NonNegFloat.unsafeFrom(n)
+
+      val expected = n
+      val actual   = input.into[Float].transform
+
+      actual ==== expected
+    }
+
+  def testPartialTransformerNonNegFloat: Property =
+    for {
+      n <- Gen.double(Range.linearFrac(0f, Float.MaxValue)).map(_.toFloat).log("n")
+    } yield {
+      val input = n
+
+      val expected = chimney.partial.Result.fromValue(NonNegFloat.unsafeFrom(n))
+      val actual   = input.intoPartial[NonNegFloat].transform
+
+      actual ==== expected
+    }
+
+  //
+
+  def testTransformerPosFloat: Property =
+    for {
+      n <- Gen.double(Range.linearFrac(0.00001f, Float.MaxValue)).map(_.toFloat).log("n")
+    } yield {
+      val input = PosFloat.unsafeFrom(n)
+
+      val expected = n
+      val actual   = input.into[Float].transform
+
+      actual ==== expected
+    }
+
+  def testPartialTransformerPosFloat: Property =
+    for {
+      n <- Gen.double(Range.linearFrac(0.00001f, Float.MaxValue)).map(_.toFloat).log("n")
+    } yield {
+      val input = n
+
+      val expected = chimney.partial.Result.fromValue(PosFloat.unsafeFrom(n))
+      val actual   = input.intoPartial[PosFloat].transform
+
+      actual ==== expected
+    }
+
+  //
+
+  def testTransformerNonPosFloat: Property =
+    for {
+      n <- Gen.double(Range.linearFrac(0f, Float.MinValue)).map(_.toFloat).log("n")
+    } yield {
+      val input = NonPosFloat.unsafeFrom(n)
+
+      val expected = n
+      val actual   = input.into[Float].transform
+
+      actual ==== expected
+    }
+
+  def testPartialTransformerNonPosFloat: Property =
+    for {
+      n <- Gen.double(Range.linearFrac(0f, Float.MinValue)).map(_.toFloat).log("n")
+    } yield {
+      val input = n
+
+      val expected = chimney.partial.Result.fromValue(NonPosFloat.unsafeFrom(n))
+      val actual   = input.intoPartial[NonPosFloat].transform
+
+      actual ==== expected
+    }
+
+  //
+
+  def testTransformerNegDouble: Property =
+    for {
+      n <- Gen.double(Range.linearFrac(-0.0000001d, Double.MinValue)).log("n")
+    } yield {
+      val input = NegDouble.unsafeFrom(n)
+
+      val expected = n
+      val actual   = input.into[Double].transform
+
+      actual ==== expected
+    }
+
+  def testPartialTransformerNegDouble: Property =
+    for {
+      n <- Gen.double(Range.linearFrac(-0.0000001d, Double.MinValue)).log("n")
+    } yield {
+      val input = n
+
+      val expected = chimney.partial.Result.fromValue(NegDouble.unsafeFrom(n))
+      val actual   = input.intoPartial[NegDouble].transform
+
+      actual ==== expected
+    }
+
+  //
+
+  def testTransformerNonNegDouble: Property =
+    for {
+      n <- Gen.double(Range.linearFrac(0d, Double.MaxValue)).log("n")
+    } yield {
+      val input = NonNegDouble.unsafeFrom(n)
+
+      val expected = n
+      val actual   = input.into[Double].transform
+
+      actual ==== expected
+    }
+
+  def testPartialTransformerNonNegDouble: Property =
+    for {
+      n <- Gen.double(Range.linearFrac(0d, Double.MaxValue)).log("n")
+    } yield {
+      val input = n
+
+      val expected = chimney.partial.Result.fromValue(NonNegDouble.unsafeFrom(n))
+      val actual   = input.intoPartial[NonNegDouble].transform
+
+      actual ==== expected
+    }
+
+  //
+
+  def testTransformerPosDouble: Property =
+    for {
+      n <- Gen.double(Range.linearFrac(0.0000001d, Double.MaxValue)).log("n")
+    } yield {
+      val input = PosDouble.unsafeFrom(n)
+
+      val expected = n
+      val actual   = input.into[Double].transform
+
+      actual ==== expected
+    }
+
+  def testPartialTransformerPosDouble: Property =
+    for {
+      n <- Gen.double(Range.linearFrac(0.0000001d, Double.MaxValue)).log("n")
+    } yield {
+      val input = n
+
+      val expected = chimney.partial.Result.fromValue(PosDouble.unsafeFrom(n))
+      val actual   = input.intoPartial[PosDouble].transform
+
+      actual ==== expected
+    }
+
+  //
+
+  def testTransformerNonPosDouble: Property =
+    for {
+      n <- Gen.double(Range.linearFrac(0d, Double.MinValue)).log("n")
+    } yield {
+      val input = NonPosDouble.unsafeFrom(n)
+
+      val expected = n
+      val actual   = input.into[Double].transform
+
+      actual ==== expected
+    }
+
+  def testPartialTransformerNonPosDouble: Property =
+    for {
+      n <- Gen.double(Range.linearFrac(0d, Double.MinValue)).log("n")
+    } yield {
+      val input = n
+
+      val expected = chimney.partial.Result.fromValue(NonPosDouble.unsafeFrom(n))
+      val actual   = input.intoPartial[NonPosDouble].transform
+
+      actual ==== expected
+    }
+
+  //
+
+  def testTransformerNegBigInt: Property =
+    for {
+      n <- Gen.long(Range.linear(-1L, Long.MinValue)).map(BigInt(_)).log("n")
+    } yield {
+      val input = NegBigInt.unsafeFrom(n)
+
+      val expected = n
+      val actual   = input.into[BigInt].transform
+
+      actual ==== expected
+    }
+
+  def testPartialTransformerNegBigInt: Property =
+    for {
+      n <- Gen.long(Range.linear(-1L, Long.MinValue)).map(BigInt(_)).log("n")
+    } yield {
+      val input = n
+
+      val expected = chimney.partial.Result.fromValue(NegBigInt.unsafeFrom(n))
+      val actual   = input.intoPartial[NegBigInt].transform
+
+      actual ==== expected
+    }
+
+  //
+
+  def testTransformerNonNegBigInt: Property =
+    for {
+      n <- Gen.long(Range.linear(0L, Long.MaxValue)).map(BigInt(_)).log("n")
+    } yield {
+      val input = NonNegBigInt.unsafeFrom(n)
+
+      val expected = n
+      val actual   = input.into[BigInt].transform
+
+      actual ==== expected
+    }
+
+  def testPartialTransformerNonNegBigInt: Property =
+    for {
+      n <- Gen.long(Range.linear(0L, Long.MaxValue)).map(BigInt(_)).log("n")
+    } yield {
+      val input = n
+
+      val expected = chimney.partial.Result.fromValue(NonNegBigInt.unsafeFrom(n))
+      val actual   = input.intoPartial[NonNegBigInt].transform
+
+      actual ==== expected
+    }
+
+  //
+
+  def testTransformerPosBigInt: Property =
+    for {
+      n <- Gen.long(Range.linear(1L, Long.MaxValue)).map(BigInt(_)).log("n")
+    } yield {
+      val input = PosBigInt.unsafeFrom(n)
+
+      val expected = n
+      val actual   = input.into[BigInt].transform
+
+      actual ==== expected
+    }
+
+  def testPartialTransformerPosBigInt: Property =
+    for {
+      n <- Gen.long(Range.linear(1L, Long.MaxValue)).map(BigInt(_)).log("n")
+    } yield {
+      val input = n
+
+      val expected = chimney.partial.Result.fromValue(PosBigInt.unsafeFrom(n))
+      val actual   = input.intoPartial[PosBigInt].transform
+
+      actual ==== expected
+    }
+
+  //
+
+  def testTransformerNonPosBigInt: Property =
+    for {
+      n <- Gen.long(Range.linear(0L, Long.MinValue)).map(BigInt(_)).log("n")
+    } yield {
+      val input = NonPosBigInt.unsafeFrom(n)
+
+      val expected = n
+      val actual   = input.into[BigInt].transform
+
+      actual ==== expected
+    }
+
+  def testPartialTransformerNonPosBigInt: Property =
+    for {
+      n <- Gen.long(Range.linear(0L, Long.MinValue)).map(BigInt(_)).log("n")
+    } yield {
+      val input = n
+
+      val expected = chimney.partial.Result.fromValue(NonPosBigInt.unsafeFrom(n))
+      val actual   = input.intoPartial[NonPosBigInt].transform
+
+      actual ==== expected
+    }
+
+  //
+
+  def testTransformerNegBigDecimal: Property =
+    for {
+      n <- Gen.double(Range.linearFrac(-0.0000001d, Double.MinValue)).map(BigDecimal(_)).log("n")
+    } yield {
+      val input = NegBigDecimal.unsafeFrom(n)
+
+      val expected = n
+      val actual   = input.into[BigDecimal].transform
+
+      actual ==== expected
+    }
+
+  def testPartialTransformerNegBigDecimal: Property =
+    for {
+      n <- Gen.double(Range.linearFrac(-0.0000001d, Double.MinValue)).map(BigDecimal(_)).log("n")
+    } yield {
+      val input = n
+
+      val expected = chimney.partial.Result.fromValue(NegBigDecimal.unsafeFrom(n))
+      val actual   = input.intoPartial[NegBigDecimal].transform
+
+      actual ==== expected
+    }
+
+  //
+
+  def testTransformerNonNegBigDecimal: Property =
+    for {
+      n <- Gen.double(Range.linearFrac(0d, Double.MaxValue)).map(BigDecimal(_)).log("n")
+    } yield {
+      val input = NonNegBigDecimal.unsafeFrom(n)
+
+      val expected = n
+      val actual   = input.into[BigDecimal].transform
+
+      actual ==== expected
+    }
+
+  def testPartialTransformerNonNegBigDecimal: Property =
+    for {
+      n <- Gen.double(Range.linearFrac(0d, Double.MaxValue)).map(BigDecimal(_)).log("n")
+    } yield {
+      val input = n
+
+      val expected = chimney.partial.Result.fromValue(NonNegBigDecimal.unsafeFrom(n))
+      val actual   = input.intoPartial[NonNegBigDecimal].transform
+
+      actual ==== expected
+    }
+
+  //
+
+  def testTransformerPosBigDecimal: Property =
+    for {
+      n <- Gen.double(Range.linearFrac(0.0000001d, Double.MaxValue)).map(BigDecimal(_)).log("n")
+    } yield {
+      val input = PosBigDecimal.unsafeFrom(n)
+
+      val expected = n
+      val actual   = input.into[BigDecimal].transform
+
+      actual ==== expected
+    }
+
+  def testPartialTransformerPosBigDecimal: Property =
+    for {
+      n <- Gen.double(Range.linearFrac(0.0000001d, Double.MaxValue)).map(BigDecimal(_)).log("n")
+    } yield {
+      val input = n
+
+      val expected = chimney.partial.Result.fromValue(PosBigDecimal.unsafeFrom(n))
+      val actual   = input.intoPartial[PosBigDecimal].transform
+
+      actual ==== expected
+    }
+
+  //
+
+  def testTransformerNonPosBigDecimal: Property =
+    for {
+      n <- Gen.double(Range.linearFrac(0d, Double.MinValue)).map(BigDecimal(_)).log("n")
+    } yield {
+      val input = NonPosBigDecimal.unsafeFrom(n)
+
+      val expected = n
+      val actual   = input.into[BigDecimal].transform
+
+      actual ==== expected
+    }
+
+  def testPartialTransformerNonPosBigDecimal: Property =
+    for {
+      n <- Gen.double(Range.linearFrac(0d, Double.MinValue)).map(BigDecimal(_)).log("n")
+    } yield {
+      val input = n
+
+      val expected = chimney.partial.Result.fromValue(NonPosBigDecimal.unsafeFrom(n))
+      val actual   = input.intoPartial[NonPosBigDecimal].transform
+
+      actual ==== expected
+    }
+
+  //
+
+}


### PR DESCRIPTION
Close #332 - [`refined4s-chimney`] Add `refined4s.modules.chimney.derivation.types.numeric` to support Chimney for pre-defined refined types in `refined4s.types.numeric`