### PR TITLE
Close #334 - [`refined4s-chimney`] Add `refined4s.modules.chimney.derivation.types.all` to support Chimney for pre-defined refined types in `refined4s.types.all`

### DIFF
--- a/modules/refined4s-chimney/shared/src/main/scala/refined4s/modules/chimney/derivation/types/all.scala
+++ b/modules/refined4s-chimney/shared/src/main/scala/refined4s/modules/chimney/derivation/types/all.scala
@@ -1,0 +1,7 @@
+package refined4s.modules.chimney.derivation.types
+
+/** @author Kevin Lee
+  * @since 2024-08-09
+  */
+trait all extends numeric, strings, network
+object all extends all

--- a/modules/refined4s-chimney/shared/src/test/scala/refined4s/modules/chimney/derivation/types/allSpec.scala
+++ b/modules/refined4s-chimney/shared/src/test/scala/refined4s/modules/chimney/derivation/types/allSpec.scala
@@ -1,0 +1,23 @@
+package refined4s.modules.chimney.derivation.types
+
+import hedgehog.*
+import hedgehog.runner.*
+
+/** @author Kevin Lee
+  * @since 2024-08-10
+  */
+object allSpec extends Properties {
+
+  object numericSpecWithAll extends numericSpec {
+    override protected val numericTypeClasses: numeric = refined4s.modules.chimney.derivation.types.all
+  }
+  object stringsSpecWithAll extends stringsSpec {
+    override protected val stringsTypeClasses: strings = refined4s.modules.chimney.derivation.types.all
+  }
+  object networkSpecWithAll extends networkSpec {
+    override protected val networkTypeClasses: network = refined4s.modules.chimney.derivation.types.all
+  }
+
+  override def tests: List[Test] = numericSpec.allTests ++ stringsSpec.allTests ++ networkSpec.allTests
+
+}

--- a/modules/refined4s-chimney/shared/src/test/scala/refined4s/modules/chimney/derivation/types/networkSpec.scala
+++ b/modules/refined4s-chimney/shared/src/test/scala/refined4s/modules/chimney/derivation/types/networkSpec.scala
@@ -10,8 +10,13 @@ import refined4s.types.networkGens
 /** @author Kevin Lee
   * @since 2024-08-06
   */
-object networkSpec extends Properties {
-  override def tests: List[Test] = List(
+trait networkSpec {
+
+  protected val networkTypeClasses: refined4s.modules.chimney.derivation.types.network
+
+  import networkTypeClasses.given
+
+  def allTests: List[Test] = List(
     // Uri
     property("test from Uri to String", testFromUri),
     property("test from String to Uri", testToUri),
@@ -34,8 +39,6 @@ object networkSpec extends Properties {
     property("test from DynamicPortNumber to Int", testFromDynamicPortNumber),
     property("test from Int to DynamicPortNumber", testToDynamicPortNumber),
   )
-
-  import refined4s.modules.chimney.derivation.types.network.given
 
   def testFromUri: Property =
     for {
@@ -225,5 +228,13 @@ object networkSpec extends Properties {
 
       actual ==== expected
     }
+
+}
+object networkSpec extends Properties, networkSpec {
+
+  override protected val networkTypeClasses: refined4s.modules.chimney.derivation.types.network =
+    refined4s.modules.chimney.derivation.types.network
+
+  override def tests: List[Prop] = allTests
 
 }

--- a/modules/refined4s-chimney/shared/src/test/scala/refined4s/modules/chimney/derivation/types/numericSpec.scala
+++ b/modules/refined4s-chimney/shared/src/test/scala/refined4s/modules/chimney/derivation/types/numericSpec.scala
@@ -13,8 +13,11 @@ import io.scalaland.chimney.dsl.*
 /** @author Kevin Lee
   * @since 2024-08-09
   */
-object numericSpec extends Properties {
-  override def tests: List[Test] = List(
+trait numericSpec {
+
+  protected val numericTypeClasses: refined4s.modules.chimney.derivation.types.numeric
+
+  def allTests: List[Test] = List(
     property("test Transformer[NegInt, Int]", testTransformerNegInt),
     property("test PartialTransformer[Int, NegInt]", testPartialTransformerNegInt),
     //
@@ -112,7 +115,7 @@ object numericSpec extends Properties {
     property("test PartialTransformer[BigDecimal, NonPosBigDecimal]", testPartialTransformerNonPosBigDecimal),
   )
 
-  import refined4s.modules.chimney.derivation.types.numeric.given
+  import numericTypeClasses.given
 
   def testTransformerNegInt: Property =
     for {
@@ -945,5 +948,13 @@ object numericSpec extends Properties {
     }
 
   //
+
+}
+object numericSpec extends Properties, numericSpec {
+
+  override protected val numericTypeClasses: refined4s.modules.chimney.derivation.types.numeric =
+    refined4s.modules.chimney.derivation.types.numeric
+
+  override def tests: List[Prop] = allTests
 
 }

--- a/modules/refined4s-chimney/shared/src/test/scala/refined4s/modules/chimney/derivation/types/stringsSpec.scala
+++ b/modules/refined4s-chimney/shared/src/test/scala/refined4s/modules/chimney/derivation/types/stringsSpec.scala
@@ -11,8 +11,13 @@ import refined4s.types.strings.*
 /** @author Kevin Lee
   * @since 2024-08-06
   */
-object stringsSpec extends Properties {
-  override def tests: List[Test] = List(
+trait stringsSpec {
+
+  protected val stringsTypeClasses: refined4s.modules.chimney.derivation.types.strings
+
+  import stringsTypeClasses.given
+
+  def allTests: List[Test] = List(
     // NonEmptyString
     property("test from NonEmptyString to String", testFromNonEmptyString),
     property("test from String to NonEmptyString", testToNonEmptyString),
@@ -44,7 +49,6 @@ object stringsSpec extends Properties {
 
       val expected = chimney.partial.Result.fromValue(s)
 
-      import refined4s.modules.chimney.derivation.types.strings.derivedStringToNonEmptyStringPartialTransformer
       val actual = input.intoPartial[NonEmptyString].transform
 
       actual ==== expected
@@ -72,7 +76,6 @@ object stringsSpec extends Properties {
 
       val expected = chimney.partial.Result.fromValue(s)
 
-      import refined4s.modules.chimney.derivation.types.strings.derivedStringToNonBlankStringPartialTransformer
       val actual = input.intoPartial[NonBlankString].transform
 
       actual ==== expected
@@ -100,10 +103,17 @@ object stringsSpec extends Properties {
 
       val expected = chimney.partial.Result.fromValue(uuid)
 
-      import refined4s.modules.chimney.derivation.types.strings.derivedStringToUuidPartialTransformer
       val actual = input.intoPartial[Uuid].transform
 
       actual ==== expected
     }
+
+}
+object stringsSpec extends Properties, stringsSpec {
+
+  override protected val stringsTypeClasses: refined4s.modules.chimney.derivation.types.strings =
+    refined4s.modules.chimney.derivation.types.strings
+
+  override def tests: List[Test] = allTests
 
 }


### PR DESCRIPTION
Close #334 - [`refined4s-chimney`] Add `refined4s.modules.chimney.derivation.types.all` to support Chimney for pre-defined refined types in `refined4s.types.all`