### PR TITLE
refined4s v0.17.0

### DIFF
--- a/changelogs/0.17.0.md
+++ b/changelogs/0.17.0.md
@@ -1,0 +1,159 @@
+## [0.17.0](https://github.com/kevin-lee/refined4s/issues?q=is%3Aissue+is%3Aclosed+-label%3Ainvalid+-label%3Awontfix+milestone%3Am17) - 2024-08-11
+
+
+### New Features
+
+#### Add `refined4s-chimney`
+
+* Add a module to support [Chimney](https://github.com/scalalandio/chimney) (#320)
+***
+
+#### `refined4s.modules.chimney.derivation.generic.auto`
+* [`refined4s-chimney`] Add `refined4s.modules.chimney.derivation.generic.auto` for auto derivation for Chimney (#325)
+
+```scala 3
+import io.scalaland.chimney
+import refined4s.modules.chimney.derivation.generic.auto.given
+import refined4s.types.all.PosInt
+import refined4s.{Newtype, Refined}
+
+val emailRegEx =
+  """([a-zA-Z0-9]+([-_\.\+]+[a-zA-Z0-9]+)*@[a-zA-Z0-9]+([-_]+[a-zA-Z0-9]+)*(?:[.][a-zA-Z0-9]+([-_]+[a-zA-Z0-9]+)*)+)""".r
+
+final case class Foo(id: Foo.Id, baz: Foo.Baz)
+object Foo {
+  type Id = Id.Type
+  object Id extends Newtype[PosInt]
+
+  type Name = Name.Type
+  object Name extends Newtype[String]
+
+  type Email = Email.Type
+  object Email extends Refined[String] {
+
+    override def invalidReason(a: String): String = s"Invalid email: $a"
+
+    override def predicate(a: String): Boolean = emailRegEx.findFirstMatchIn(a).isDefined
+  }
+
+  final case class Baz(name: Name, email: Email)
+}
+
+final case class Bar(id: Bar.Code, baz: Bar.Baz)
+object Bar {
+  type Code = Code.Type
+  object Code extends Newtype[PosInt]
+
+  type Label = Label.Type
+  object Label extends Newtype[String]
+
+  type Email = Email.Type
+  object Email extends Refined[String] {
+
+    override def invalidReason(a: String): String = s"Invalid email: $a"
+
+    override def predicate(a: String): Boolean = emailRegEx.findFirstMatchIn(a).isDefined
+  }
+
+  final case class Baz(name: Label, email: Email)
+}
+
+val id = Foo.Id(PosInt(123))
+id.into[Bar.Code].transform
+// Bar.Code(PosInt(123))
+
+val name = Foo.Name("Kevin")
+name.into[Bar.Label].transform
+// Bar.Label("Kevin")
+
+val email = Foo.Email("aaa@aaa.aa")
+email.intoPartial[Bar.Email].transform
+// Result[Bar.Email] = Value(Bar.Email("aaa@aaa.aa"))
+
+Foo(id, Foo.Baz(name, email).intoPartial[Bar].transform
+// Result[Bar] = Value(Bar(id = Code(PosInt(123)), Bar.Baz(name = Bar.Label("Kevin"), Bar.Email("aaa@aaa.aa"))))
+
+```
+***
+
+#### `refined4s.modules.chimney.derivation.ChimneyNewtype`
+
+* [`refined4s-chimney`] Add `refined4s.modules.chimney.derivation.ChimneyNewtype` for `Newtype` derivation for Chimney (#326)
+
+```scala 3
+import refined4s.Newtype
+import refined4s.types.all.PosInt
+
+import refined4s.modules.chimney.derivation.*
+
+type Id = Id.Type
+object Id extends Newtype[PosInt], ChimneyNewtype[PosInt]
+
+type Name = Name.Type
+object Name extends Newtype[String], ChimneyNewtype[String]
+```
+***
+
+#### `refined4s.modules.chimney.derivation.ChimneyRefined`
+
+* [`refined4s-chimney`] Add `refined4s.modules.chimney.derivation.ChimneyRefined` for `Refined` derivation for Chimney (#327)
+
+
+```scala 3
+import refined4s.types.all.*
+import refined4s.Refined
+
+import refined4s.modules.chimney.derivation.*
+
+type Email = Email.Type
+object Email extends Refined[String], ChimneyRefined[String] {
+  val emailRegEx =
+    """([a-zA-Z0-9]+([-_\.\+]+[a-zA-Z0-9]+)*@[a-zA-Z0-9]+([-_]+[a-zA-Z0-9]+)*(?:[.][a-zA-Z0-9]+([-_]+[a-zA-Z0-9]+)*)+)""".r
+
+  override def invalidReason(a: String): String = s"Invalid email: $a"
+
+  override def predicate(a: String): Boolean = emailRegEx.findFirstMatchIn(a).isDefined
+}
+```
+***
+
+#### `refined4s.modules.chimney.derivation.types.strings`
+
+* [`refined4s-chimney`] Add `refined4s.modules.chimney.derivation.types.strings` to support Chimney for pre-defined refined types in `refined4s.types.strings` (#331)
+
+```scala 3
+import refined4s.modules.chimney.derivation.types.strings.given
+```
+***
+
+#### `refined4s.modules.chimney.derivation.types.numeric`
+
+* [`refined4s-chimney`] Add `refined4s.modules.chimney.derivation.types.numeric` to support Chimney for pre-defined refined types in `refined4s.types.numeric` (#332)
+
+```scala 3
+import refined4s.modules.chimney.derivation.types.numeric.given
+```
+***
+
+#### `refined4s.modules.chimney.derivation.types.network`
+
+* [`refined4s-chimney`] Add `refined4s.modules.chimney.derivation.types.network` to support Chimney for pre-defined refined types in `refined4s.types.network` (#333)
+
+```scala 3
+import refined4s.modules.chimney.derivation.types.network.given
+```
+***
+
+#### `refined4s.modules.chimney.derivation.types.all`
+
+* [`refined4s-chimney`] Add `refined4s.modules.chimney.derivation.types.all` to support Chimney for pre-defined refined types in `refined4s.types.all` (#334)
+
+It's for all pre-defined types in `strings`, `numeric` and `network`.
+```scala 3
+import refined4s.modules.chimney.derivation.types.all.given
+```
+***
+
+### Internal Housekeeping
+
+* Bump Scala to 3.3.3, the latest Long-Term Support (LTS) version (#319)


### PR DESCRIPTION
# refined4s v0.17.0
## [0.17.0](https://github.com/kevin-lee/refined4s/issues?q=is%3Aissue+is%3Aclosed+-label%3Ainvalid+-label%3Awontfix+milestone%3Am17) - 2024-08-11


### New Features

#### Add `refined4s-chimney`

* Add a module to support [Chimney](https://github.com/scalalandio/chimney) (#320)
***

#### `refined4s.modules.chimney.derivation.generic.auto`
* [`refined4s-chimney`] Add `refined4s.modules.chimney.derivation.generic.auto` for auto derivation for Chimney (#325)

```scala 3
import io.scalaland.chimney
import refined4s.modules.chimney.derivation.generic.auto.given
import refined4s.types.all.PosInt
import refined4s.{Newtype, Refined}

val emailRegEx =
  """([a-zA-Z0-9]+([-_\.\+]+[a-zA-Z0-9]+)*@[a-zA-Z0-9]+([-_]+[a-zA-Z0-9]+)*(?:[.][a-zA-Z0-9]+([-_]+[a-zA-Z0-9]+)*)+)""".r

final case class Foo(id: Foo.Id, baz: Foo.Baz)
object Foo {
  type Id = Id.Type
  object Id extends Newtype[PosInt]

  type Name = Name.Type
  object Name extends Newtype[String]

  type Email = Email.Type
  object Email extends Refined[String] {

    override def invalidReason(a: String): String = s"Invalid email: $a"

    override def predicate(a: String): Boolean = emailRegEx.findFirstMatchIn(a).isDefined
  }

  final case class Baz(name: Name, email: Email)
}

final case class Bar(id: Bar.Code, baz: Bar.Baz)
object Bar {
  type Code = Code.Type
  object Code extends Newtype[PosInt]

  type Label = Label.Type
  object Label extends Newtype[String]

  type Email = Email.Type
  object Email extends Refined[String] {

    override def invalidReason(a: String): String = s"Invalid email: $a"

    override def predicate(a: String): Boolean = emailRegEx.findFirstMatchIn(a).isDefined
  }

  final case class Baz(name: Label, email: Email)
}

val id = Foo.Id(PosInt(123))
id.into[Bar.Code].transform
// Bar.Code(PosInt(123))

val name = Foo.Name("Kevin")
name.into[Bar.Label].transform
// Bar.Label("Kevin")

val email = Foo.Email("aaa@aaa.aa")
email.intoPartial[Bar.Email].transform
// Result[Bar.Email] = Value(Bar.Email("aaa@aaa.aa"))

Foo(id, Foo.Baz(name, email).intoPartial[Bar].transform
// Result[Bar] = Value(Bar(id = Code(PosInt(123)), Bar.Baz(name = Bar.Label("Kevin"), Bar.Email("aaa@aaa.aa"))))

```
***

#### `refined4s.modules.chimney.derivation.ChimneyNewtype`

* [`refined4s-chimney`] Add `refined4s.modules.chimney.derivation.ChimneyNewtype` for `Newtype` derivation for Chimney (#326)

```scala 3
import refined4s.Newtype
import refined4s.types.all.PosInt

import refined4s.modules.chimney.derivation.*

type Id = Id.Type
object Id extends Newtype[PosInt], ChimneyNewtype[PosInt]

type Name = Name.Type
object Name extends Newtype[String], ChimneyNewtype[String]
```
***

#### `refined4s.modules.chimney.derivation.ChimneyRefined`

* [`refined4s-chimney`] Add `refined4s.modules.chimney.derivation.ChimneyRefined` for `Refined` derivation for Chimney (#327)


```scala 3
import refined4s.types.all.*
import refined4s.Refined

import refined4s.modules.chimney.derivation.*

type Email = Email.Type
object Email extends Refined[String], ChimneyRefined[String] {
  val emailRegEx =
    """([a-zA-Z0-9]+([-_\.\+]+[a-zA-Z0-9]+)*@[a-zA-Z0-9]+([-_]+[a-zA-Z0-9]+)*(?:[.][a-zA-Z0-9]+([-_]+[a-zA-Z0-9]+)*)+)""".r

  override def invalidReason(a: String): String = s"Invalid email: $a"

  override def predicate(a: String): Boolean = emailRegEx.findFirstMatchIn(a).isDefined
}
```
***

#### `refined4s.modules.chimney.derivation.types.strings`

* [`refined4s-chimney`] Add `refined4s.modules.chimney.derivation.types.strings` to support Chimney for pre-defined refined types in `refined4s.types.strings` (#331)

```scala 3
import refined4s.modules.chimney.derivation.types.strings.given
```
***

#### `refined4s.modules.chimney.derivation.types.numeric`

* [`refined4s-chimney`] Add `refined4s.modules.chimney.derivation.types.numeric` to support Chimney for pre-defined refined types in `refined4s.types.numeric` (#332)

```scala 3
import refined4s.modules.chimney.derivation.types.numeric.given
```
***

#### `refined4s.modules.chimney.derivation.types.network`

* [`refined4s-chimney`] Add `refined4s.modules.chimney.derivation.types.network` to support Chimney for pre-defined refined types in `refined4s.types.network` (#333)

```scala 3
import refined4s.modules.chimney.derivation.types.network.given
```
***

#### `refined4s.modules.chimney.derivation.types.all`

* [`refined4s-chimney`] Add `refined4s.modules.chimney.derivation.types.all` to support Chimney for pre-defined refined types in `refined4s.types.all` (#334)

It's for all pre-defined types in `strings`, `numeric` and `network`.
```scala 3
import refined4s.modules.chimney.derivation.types.all.given
```
***

### Internal Housekeeping

* Bump Scala to 3.3.3, the latest Long-Term Support (LTS) version (#319)
