### PR TITLE
Close #361 - [`refined4s-circe`] Add `KeyEncoder` and `KeyDecoder` for pre-defined refined types

### DIFF
--- a/modules/refined4s-circe/shared/src/main/scala/refined4s/modules/circe/derivation/types/network.scala
+++ b/modules/refined4s-circe/shared/src/main/scala/refined4s/modules/circe/derivation/types/network.scala
@@ -1,6 +1,7 @@
 package refined4s.modules.circe.derivation.types
 
-import io.circe.{Decoder, Encoder}
+import io.circe.{Decoder, Encoder, KeyDecoder, KeyEncoder}
+import refined4s.types
 import refined4s.types.all.*
 
 /** @author Kevin Lee
@@ -8,26 +9,82 @@ import refined4s.types.all.*
   */
 trait network {
 
+  /* Uri */
   inline given derivedUriEncoder: Encoder[Uri] = Encoder[String].contramap[Uri](_.value)
   inline given derivedUriDecoder: Decoder[Uri] = Decoder[String].emap(Uri.from)
 
+  inline given derivedUriKeyEncoder: KeyEncoder[Uri] with {
+    override def apply(key: Uri): String = key.value
+  }
+  inline given derivedUriKeyDecoder: KeyDecoder[Uri] with {
+    override def apply(key: String): Option[Uri] = Uri.from(key).toOption
+  }
+
+  /* Url */
   inline given derivedUrlEncoder: Encoder[Url] = Encoder[String].contramap[Url](_.value)
   inline given derivedUrlDecoder: Decoder[Url] = Decoder[String].emap(Url.from)
 
+  inline given derivedUrlKeyEncoder: KeyEncoder[Url] with {
+    override def apply(key: Url): String = key.value
+  }
+  inline given derivedUrlKeyDecoder: KeyDecoder[Url] with {
+    override def apply(key: String): Option[Url] = Url.from(key).toOption
+  }
+
+  /* PortNumber */
   inline given derivedPortNumberEncoder: Encoder[PortNumber] = Encoder[Int].contramap[PortNumber](_.value)
   inline given derivedPortNumberDecoder: Decoder[PortNumber] = Decoder[Int].emap(PortNumber.from)
 
+  inline given derivedPortNumberKeyEncoder: KeyEncoder[PortNumber] with {
+    override def apply(key: PortNumber): String = key.value.toString
+  }
+  inline given derivedPortNumberKeyDecoder: KeyDecoder[PortNumber] with {
+    override def apply(key: String): Option[PortNumber] = key.toIntOption.flatMap(PortNumber.from(_).toOption)
+  }
+
+  /* SystemPortNumber */
   inline given derivedSystemPortNumberEncoder: Encoder[SystemPortNumber] = Encoder[Int].contramap[SystemPortNumber](_.value)
   inline given derivedSystemPortNumberDecoder: Decoder[SystemPortNumber] = Decoder[Int].emap(SystemPortNumber.from)
 
+  inline given derivedSystemPortNumberKeyEncoder: KeyEncoder[SystemPortNumber] with {
+    override def apply(key: SystemPortNumber): String = key.value.toString
+  }
+  inline given derivedSystemPortNumberKeyDecoder: KeyDecoder[SystemPortNumber] with {
+    override def apply(key: String): Option[SystemPortNumber] = key.toIntOption.flatMap(SystemPortNumber.from(_).toOption)
+  }
+
+  /* NonSystemPortNumber */
   inline given derivedNonSystemPortNumberEncoder: Encoder[NonSystemPortNumber] = Encoder[Int].contramap[NonSystemPortNumber](_.value)
   inline given derivedNonSystemPortNumberDecoder: Decoder[NonSystemPortNumber] = Decoder[Int].emap(NonSystemPortNumber.from)
 
+  inline given derivedNonSystemPortNumberKeyEncoder: KeyEncoder[NonSystemPortNumber] with {
+    override def apply(key: NonSystemPortNumber): String = key.value.toString
+  }
+  inline given derivedNonSystemPortNumberKeyDecoder: KeyDecoder[NonSystemPortNumber] with {
+    override def apply(key: String): Option[NonSystemPortNumber] = key.toIntOption.flatMap(NonSystemPortNumber.from(_).toOption)
+  }
+
+  /* UserPortNumber */
   inline given derivedUserPortNumberEncoder: Encoder[UserPortNumber] = Encoder[Int].contramap[UserPortNumber](_.value)
   inline given derivedUserPortNumberDecoder: Decoder[UserPortNumber] = Decoder[Int].emap(UserPortNumber.from)
 
+  inline given derivedUserPortNumberKeyEncoder: KeyEncoder[UserPortNumber] with {
+    override def apply(key: UserPortNumber): String = key.value.toString
+  }
+  inline given derivedUserPortNumberKeyDecoder: KeyDecoder[UserPortNumber] with {
+    override def apply(key: String): Option[UserPortNumber] = key.toIntOption.flatMap(UserPortNumber.from(_).toOption)
+  }
+
+  /* DynamicPortNumber */
   inline given derivedDynamicPortNumberEncoder: Encoder[DynamicPortNumber] = Encoder[Int].contramap[DynamicPortNumber](_.value)
   inline given derivedDynamicPortNumberDecoder: Decoder[DynamicPortNumber] = Decoder[Int].emap(DynamicPortNumber.from)
+
+  inline given derivedDynamicPortNumberKeyEncoder: KeyEncoder[DynamicPortNumber] with {
+    override def apply(key: DynamicPortNumber): String = key.value.toString
+  }
+  inline given derivedDynamicPortNumberKeyDecoder: KeyDecoder[DynamicPortNumber] with {
+    override def apply(key: String): Option[DynamicPortNumber] = key.toIntOption.flatMap(DynamicPortNumber.from(_).toOption)
+  }
 
 }
 object network extends network

--- a/modules/refined4s-circe/shared/src/main/scala/refined4s/modules/circe/derivation/types/numeric.scala
+++ b/modules/refined4s-circe/shared/src/main/scala/refined4s/modules/circe/derivation/types/numeric.scala
@@ -1,6 +1,7 @@
 package refined4s.modules.circe.derivation.types
 
-import io.circe.{Decoder, Encoder}
+import io.circe.{Decoder, Encoder, KeyDecoder, KeyEncoder}
+import refined4s.types
 import refined4s.types.all.*
 
 /** @author Kevin Lee
@@ -8,99 +9,263 @@ import refined4s.types.all.*
   */
 trait numeric {
 
+  /* NegInt */
   inline given derivedNegIntEncoder: Encoder[NegInt] = Encoder[Int].contramap[NegInt](_.value)
   inline given derivedNegIntDecoder: Decoder[NegInt] = Decoder[Int].emap(NegInt.from)
 
+  inline given derivedNegIntKeyEncoder: KeyEncoder[NegInt] = KeyEncoder[Int].contramap[NegInt](_.value)
+  inline given derivedNegIntKeyDecoder: KeyDecoder[NegInt] with {
+    override def apply(key: String): Option[NegInt] =
+      KeyDecoder[Int].apply(key).flatMap(NegInt.from(_).toOption)
+  }
+
+  /* NonNegInt */
   inline given derivedNonNegIntEncoder: Encoder[NonNegInt] = Encoder[Int].contramap[NonNegInt](_.value)
   inline given derivedNonNegIntDecoder: Decoder[NonNegInt] = Decoder[Int].emap(NonNegInt.from)
 
+  inline given derivedNonNegIntKeyEncoder: KeyEncoder[NonNegInt] = KeyEncoder[Int].contramap[NonNegInt](_.value)
+  inline given derivedNonNegIntKeyDecoder: KeyDecoder[NonNegInt] with {
+    override def apply(key: String): Option[NonNegInt] =
+      KeyDecoder[Int].apply(key).flatMap(NonNegInt.from(_).toOption)
+  }
+
+  /* PosInt */
   inline given derivedPosIntEncoder: Encoder[PosInt] = Encoder[Int].contramap[PosInt](_.value)
   inline given derivedPosIntDecoder: Decoder[PosInt] = Decoder[Int].emap(PosInt.from)
 
+  inline given derivedPosIntKeyEncoder: KeyEncoder[PosInt] = KeyEncoder[Int].contramap[PosInt](_.value)
+  inline given derivedPosIntKeyDecoder: KeyDecoder[PosInt] with {
+    override def apply(key: String): Option[PosInt] =
+      KeyDecoder[Int].apply(key).flatMap(PosInt.from(_).toOption)
+  }
+
+  /* NonPosInt */
   inline given derivedNonPosIntEncoder: Encoder[NonPosInt] = Encoder[Int].contramap[NonPosInt](_.value)
   inline given derivedNonPosIntDecoder: Decoder[NonPosInt] = Decoder[Int].emap(NonPosInt.from)
 
+  inline given derivedNonPosIntKeyEncoder: KeyEncoder[NonPosInt] = KeyEncoder[Int].contramap[NonPosInt](_.value)
+  inline given derivedNonPosIntKeyDecoder: KeyDecoder[NonPosInt] with {
+    override def apply(key: String): Option[NonPosInt] =
+      KeyDecoder[Int].apply(key).flatMap(NonPosInt.from(_).toOption)
+  }
+
+  /* NegLong */
   inline given derivedNegLongEncoder: Encoder[NegLong] = Encoder[Long].contramap[NegLong](_.value)
   inline given derivedNegLongDecoder: Decoder[NegLong] = Decoder[Long].emap(NegLong.from)
 
+  inline given derivedNegLongKeyEncoder: KeyEncoder[NegLong] = KeyEncoder[Long].contramap[NegLong](_.value)
+  inline given derivedNegLongKeyDecoder: KeyDecoder[NegLong] with {
+    override def apply(key: String): Option[NegLong] =
+      KeyDecoder[Long].apply(key).flatMap(NegLong.from(_).toOption)
+  }
+
+  /* NonNegLong */
   inline given derivedNonNegLongEncoder: Encoder[NonNegLong] = Encoder[Long].contramap[NonNegLong](_.value)
   inline given derivedNonNegLongDecoder: Decoder[NonNegLong] = Decoder[Long].emap(NonNegLong.from)
 
+  inline given derivedNonNegLongKeyEncoder: KeyEncoder[NonNegLong] = KeyEncoder[Long].contramap[NonNegLong](_.value)
+  inline given derivedNonNegLongKeyDecoder: KeyDecoder[NonNegLong] with {
+    override def apply(key: String): Option[NonNegLong] =
+      KeyDecoder[Long].apply(key).flatMap(NonNegLong.from(_).toOption)
+  }
+
+  /* PosLong */
   inline given derivedPosLongEncoder: Encoder[PosLong] = Encoder[Long].contramap[PosLong](_.value)
   inline given derivedPosLongDecoder: Decoder[PosLong] = Decoder[Long].emap(PosLong.from)
 
+  inline given derivedPosLongKeyEncoder: KeyEncoder[PosLong] = KeyEncoder[Long].contramap[PosLong](_.value)
+  inline given derivedPosLongKeyDecoder: KeyDecoder[PosLong] with {
+    override def apply(key: String): Option[PosLong] =
+      KeyDecoder[Long].apply(key).flatMap(PosLong.from(_).toOption)
+  }
+
+  /* NonPosLong */
   inline given derivedNonPosLongEncoder: Encoder[NonPosLong] = Encoder[Long].contramap[NonPosLong](_.value)
   inline given derivedNonPosLongDecoder: Decoder[NonPosLong] = Decoder[Long].emap(NonPosLong.from)
 
+  inline given derivedNonPosLongKeyEncoder: KeyEncoder[NonPosLong] = KeyEncoder[Long].contramap[NonPosLong](_.value)
+  inline given derivedNonPosLongKeyDecoder: KeyDecoder[NonPosLong] with {
+    override def apply(key: String): Option[NonPosLong] =
+      KeyDecoder[Long].apply(key).flatMap(NonPosLong.from(_).toOption)
+  }
+
+  /* NegShort */
   inline given derivedNegShortEncoder: Encoder[NegShort] = Encoder[Short].contramap[NegShort](_.value)
   inline given derivedNegShortDecoder: Decoder[NegShort] = Decoder[Short].emap(NegShort.from)
 
+  inline given derivedNegShortKeyEncoder: KeyEncoder[NegShort] = KeyEncoder[Short].contramap[NegShort](_.value)
+  inline given derivedNegShortKeyDecoder: KeyDecoder[NegShort] with {
+    override def apply(key: String): Option[NegShort] =
+      KeyDecoder[Short].apply(key).flatMap(NegShort.from(_).toOption)
+  }
+
+  /* NonNegShort */
   inline given derivedNonNegShortEncoder: Encoder[NonNegShort] = Encoder[Short].contramap[NonNegShort](_.value)
   inline given derivedNonNegShortDecoder: Decoder[NonNegShort] = Decoder[Short].emap(NonNegShort.from)
 
+  inline given derivedNonNegShortKeyEncoder: KeyEncoder[NonNegShort] = KeyEncoder[Short].contramap[NonNegShort](_.value)
+  inline given derivedNonNegShortKeyDecoder: KeyDecoder[NonNegShort] with {
+    override def apply(key: String): Option[NonNegShort] =
+      KeyDecoder[Short].apply(key).flatMap(NonNegShort.from(_).toOption)
+  }
+
+  /* PosShort */
   inline given derivedPosShortEncoder: Encoder[PosShort] = Encoder[Short].contramap[PosShort](_.value)
   inline given derivedPosShortDecoder: Decoder[PosShort] = Decoder[Short].emap(PosShort.from)
 
+  inline given derivedPosShortKeyEncoder: KeyEncoder[PosShort] = KeyEncoder[Short].contramap[PosShort](_.value)
+  inline given derivedPosShortKeyDecoder: KeyDecoder[PosShort] with {
+    override def apply(key: String): Option[PosShort] =
+      KeyDecoder[Short].apply(key).flatMap(PosShort.from(_).toOption)
+  }
+
+  /* NonPosShort */
   inline given derivedNonPosShortEncoder: Encoder[NonPosShort] = Encoder[Short].contramap[NonPosShort](_.value)
   inline given derivedNonPosShortDecoder: Decoder[NonPosShort] = Decoder[Short].emap(NonPosShort.from)
 
+  inline given derivedNonPosShortKeyEncoder: KeyEncoder[NonPosShort] = KeyEncoder[Short].contramap[NonPosShort](_.value)
+  inline given derivedNonPosShortKeyDecoder: KeyDecoder[NonPosShort] with {
+    override def apply(key: String): Option[NonPosShort] =
+      KeyDecoder[Short].apply(key).flatMap(NonPosShort.from(_).toOption)
+  }
+
+  /* NegByte */
   inline given derivedNegByteEncoder: Encoder[NegByte] = Encoder[Byte].contramap[NegByte](_.value)
   inline given derivedNegByteDecoder: Decoder[NegByte] = Decoder[Byte].emap(NegByte.from)
 
+  inline given derivedNegByteKeyEncoder: KeyEncoder[NegByte] = KeyEncoder[Byte].contramap[NegByte](_.value)
+  inline given derivedNegByteKeyDecoder: KeyDecoder[NegByte] with {
+    override def apply(key: String): Option[NegByte] =
+      KeyDecoder[Byte].apply(key).flatMap(NegByte.from(_).toOption)
+  }
+
+  /* NonNegByte */
   inline given derivedNonNegByteEncoder: Encoder[NonNegByte] = Encoder[Byte].contramap[NonNegByte](_.value)
   inline given derivedNonNegByteDecoder: Decoder[NonNegByte] = Decoder[Byte].emap(NonNegByte.from)
 
+  inline given derivedNonNegByteKeyEncoder: KeyEncoder[NonNegByte] = KeyEncoder[Byte].contramap[NonNegByte](_.value)
+  inline given derivedNonNegByteKeyDecoder: KeyDecoder[NonNegByte] with {
+    override def apply(key: String): Option[NonNegByte] =
+      KeyDecoder[Byte].apply(key).flatMap(NonNegByte.from(_).toOption)
+  }
+
+  /* PosByte */
   inline given derivedPosByteEncoder: Encoder[PosByte] = Encoder[Byte].contramap[PosByte](_.value)
   inline given derivedPosByteDecoder: Decoder[PosByte] = Decoder[Byte].emap(PosByte.from)
 
+  inline given derivedPosByteKeyEncoder: KeyEncoder[PosByte] = KeyEncoder[Byte].contramap[PosByte](_.value)
+  inline given derivedPosByteKeyDecoder: KeyDecoder[PosByte] with {
+    override def apply(key: String): Option[PosByte] =
+      KeyDecoder[Byte].apply(key).flatMap(PosByte.from(_).toOption)
+  }
+
+  /* NonPosByte */
   inline given derivedNonPosByteEncoder: Encoder[NonPosByte] = Encoder[Byte].contramap[NonPosByte](_.value)
   inline given derivedNonPosByteDecoder: Decoder[NonPosByte] = Decoder[Byte].emap(NonPosByte.from)
 
+  inline given derivedNonPosByteKeyEncoder: KeyEncoder[NonPosByte] = KeyEncoder[Byte].contramap[NonPosByte](_.value)
+  inline given derivedNonPosByteKeyDecoder: KeyDecoder[NonPosByte] with {
+    override def apply(key: String): Option[NonPosByte] =
+      KeyDecoder[Byte].apply(key).flatMap(NonPosByte.from(_).toOption)
+  }
+
+  /* NegFloat */
   inline given derivedNegFloatEncoder: Encoder[NegFloat] = Encoder[Float].contramap[NegFloat](_.value)
   inline given derivedNegFloatDecoder: Decoder[NegFloat] = Decoder[Float].emap(NegFloat.from)
 
+  /* NonNegFloat */
   inline given derivedNonNegFloatEncoder: Encoder[NonNegFloat] = Encoder[Float].contramap[NonNegFloat](_.value)
   inline given derivedNonNegFloatDecoder: Decoder[NonNegFloat] = Decoder[Float].emap(NonNegFloat.from)
 
+  /* PosFloat */
   inline given derivedPosFloatEncoder: Encoder[PosFloat] = Encoder[Float].contramap[PosFloat](_.value)
   inline given derivedPosFloatDecoder: Decoder[PosFloat] = Decoder[Float].emap(PosFloat.from)
 
+  /* NonPosFloat */
   inline given derivedNonPosFloatEncoder: Encoder[NonPosFloat] = Encoder[Float].contramap[NonPosFloat](_.value)
   inline given derivedNonPosFloatDecoder: Decoder[NonPosFloat] = Decoder[Float].emap(NonPosFloat.from)
 
+  /* NegDouble */
   inline given derivedNegDoubleEncoder: Encoder[NegDouble] = Encoder[Double].contramap[NegDouble](_.value)
   inline given derivedNegDoubleDecoder: Decoder[NegDouble] = Decoder[Double].emap(NegDouble.from)
 
+  /* NonNegDouble */
   inline given derivedNonNegDoubleEncoder: Encoder[NonNegDouble] = Encoder[Double].contramap[NonNegDouble](_.value)
   inline given derivedNonNegDoubleDecoder: Decoder[NonNegDouble] = Decoder[Double].emap(NonNegDouble.from)
 
+  /* PosDouble */
   inline given derivedPosDoubleEncoder: Encoder[PosDouble] = Encoder[Double].contramap[PosDouble](_.value)
   inline given derivedPosDoubleDecoder: Decoder[PosDouble] = Decoder[Double].emap(PosDouble.from)
 
+  /* NonPosDouble */
   inline given derivedNonPosDoubleEncoder: Encoder[NonPosDouble] = Encoder[Double].contramap[NonPosDouble](_.value)
   inline given derivedNonPosDoubleDecoder: Decoder[NonPosDouble] = Decoder[Double].emap(NonPosDouble.from)
 
+  /* NegBigInt */
   inline given derivedNegBigIntEncoder: Encoder[NegBigInt] = Encoder[BigInt].contramap[NegBigInt](_.value)
   inline given derivedNegBigIntDecoder: Decoder[NegBigInt] = Decoder[BigInt].emap(NegBigInt.from)
 
+  inline given derivedNegBigIntKeyEncoder: KeyEncoder[NegBigInt] with {
+    @SuppressWarnings(Array("org.wartremover.warts.ToString"))
+    override def apply(key: NegBigInt): String = key.value.toString
+  }
+  inline given derivedNegBigIntKeyDecoder: KeyDecoder[NegBigInt] with {
+    override def apply(key: String): Option[NegBigInt] =
+      scala.util.Try(BigInt(key)).toOption.flatMap(NegBigInt.from(_).toOption)
+  }
+
+  /* NonNegBigInt */
   inline given derivedNonNegBigIntEncoder: Encoder[NonNegBigInt] = Encoder[BigInt].contramap[NonNegBigInt](_.value)
   inline given derivedNonNegBigIntDecoder: Decoder[NonNegBigInt] = Decoder[BigInt].emap(NonNegBigInt.from)
 
+  inline given derivedNonNegBigIntKeyEncoder: KeyEncoder[NonNegBigInt] with {
+    @SuppressWarnings(Array("org.wartremover.warts.ToString"))
+    override def apply(key: NonNegBigInt): String = key.value.toString
+  }
+  inline given derivedNonNegBigIntKeyDecoder: KeyDecoder[NonNegBigInt] with {
+    override def apply(key: String): Option[NonNegBigInt] =
+      scala.util.Try(BigInt(key)).toOption.flatMap(NonNegBigInt.from(_).toOption)
+  }
+
+  /* PosBigInt */
   inline given derivedPosBigIntEncoder: Encoder[PosBigInt] = Encoder[BigInt].contramap[PosBigInt](_.value)
   inline given derivedPosBigIntDecoder: Decoder[PosBigInt] = Decoder[BigInt].emap(PosBigInt.from)
 
+  inline given derivedPosBigIntKeyEncoder: KeyEncoder[PosBigInt] with {
+    @SuppressWarnings(Array("org.wartremover.warts.ToString"))
+    override def apply(key: PosBigInt): String = key.value.toString
+  }
+  inline given derivedPosBigIntKeyDecoder: KeyDecoder[PosBigInt] with {
+    override def apply(key: String): Option[PosBigInt] =
+      scala.util.Try(BigInt(key)).toOption.flatMap(PosBigInt.from(_).toOption)
+  }
+
+  /* NonPosBigInt */
   inline given derivedNonPosBigIntEncoder: Encoder[NonPosBigInt] = Encoder[BigInt].contramap[NonPosBigInt](_.value)
   inline given derivedNonPosBigIntDecoder: Decoder[NonPosBigInt] = Decoder[BigInt].emap(NonPosBigInt.from)
 
+  inline given derivedNonPosBigIntKeyEncoder: KeyEncoder[NonPosBigInt] with {
+    @SuppressWarnings(Array("org.wartremover.warts.ToString"))
+    override def apply(key: NonPosBigInt): String = key.value.toString
+  }
+  inline given derivedNonPosBigIntKeyDecoder: KeyDecoder[NonPosBigInt] with {
+    override def apply(key: String): Option[NonPosBigInt] =
+      scala.util.Try(BigInt(key)).toOption.flatMap(NonPosBigInt.from(_).toOption)
+  }
+
+  /* NegBigDecimal */
   inline given derivedNegBigDecimalEncoder: Encoder[NegBigDecimal] = Encoder[BigDecimal].contramap[NegBigDecimal](_.value)
   inline given derivedNegBigDecimalDecoder: Decoder[NegBigDecimal] = Decoder[BigDecimal].emap(NegBigDecimal.from)
 
+  /* NonNegBigDecimal */
   inline given derivedNonNegBigDecimalEncoder: Encoder[NonNegBigDecimal] = Encoder[BigDecimal].contramap[NonNegBigDecimal](_.value)
   inline given derivedNonNegBigDecimalDecoder: Decoder[NonNegBigDecimal] = Decoder[BigDecimal].emap(NonNegBigDecimal.from)
 
+  /* PosBigDecimal */
   inline given derivedPosBigDecimalEncoder: Encoder[PosBigDecimal] = Encoder[BigDecimal].contramap[PosBigDecimal](_.value)
   inline given derivedPosBigDecimalDecoder: Decoder[PosBigDecimal] = Decoder[BigDecimal].emap(PosBigDecimal.from)
 
+  /* NonPosBigDecimal */
   inline given derivedNonPosBigDecimalEncoder: Encoder[NonPosBigDecimal] = Encoder[BigDecimal].contramap[NonPosBigDecimal](_.value)
   inline given derivedNonPosBigDecimalDecoder: Decoder[NonPosBigDecimal] = Decoder[BigDecimal].emap(NonPosBigDecimal.from)
 

--- a/modules/refined4s-circe/shared/src/main/scala/refined4s/modules/circe/derivation/types/strings.scala
+++ b/modules/refined4s-circe/shared/src/main/scala/refined4s/modules/circe/derivation/types/strings.scala
@@ -1,6 +1,7 @@
 package refined4s.modules.circe.derivation.types
 
-import io.circe.{Decoder, Encoder}
+import io.circe.{Decoder, Encoder, KeyDecoder, KeyEncoder}
+import refined4s.types
 import refined4s.types.all.*
 
 /** @author Kevin Lee
@@ -8,14 +9,38 @@ import refined4s.types.all.*
   */
 trait strings {
 
+  /* NonEmptyString */
   inline given derivedNonEmptyStringEncoder: Encoder[NonEmptyString] = Encoder[String].contramap[NonEmptyString](_.value)
   inline given derivedNonEmptyStringDecoder: Decoder[NonEmptyString] = Decoder[String].emap(NonEmptyString.from)
 
+  inline given derivedNonEmptyStringKeyEncoder: KeyEncoder[NonEmptyString] with {
+    override def apply(key: NonEmptyString): String = key.value
+  }
+  inline given derivedNonEmptyStringKeyDecoder: KeyDecoder[NonEmptyString] with {
+    override def apply(key: String): Option[NonEmptyString] = NonEmptyString.from(key).toOption
+  }
+
+  /* NonBlankString */
   inline given derivedNonBlankStringEncoder: Encoder[NonBlankString] = Encoder[String].contramap[NonBlankString](_.value)
   inline given derivedNonBlankStringDecoder: Decoder[NonBlankString] = Decoder[String].emap(NonBlankString.from)
 
+  inline given derivedNonBlankStringKeyEncoder: KeyEncoder[NonBlankString] with {
+    override def apply(key: NonBlankString): String = key.value
+  }
+  inline given derivedNonBlankStringKeyDecoder: KeyDecoder[NonBlankString] with {
+    override def apply(key: String): Option[NonBlankString] = NonBlankString.from(key).toOption
+  }
+
+  /* Uuid */
   inline given derivedUuidEncoder: Encoder[Uuid] = Encoder[String].contramap[Uuid](_.value)
   inline given derivedUuidDecoder: Decoder[Uuid] = Decoder[String].emap(Uuid.from)
+
+  inline given derivedUuidKeyEncoder: KeyEncoder[Uuid] with {
+    override def apply(key: Uuid): String = key.value
+  }
+  inline given derivedUuidKeyDecoder: KeyDecoder[Uuid] with {
+    override def apply(key: String): Option[Uuid] = Uuid.from(key).toOption
+  }
 
 }
 object strings extends strings

--- a/modules/refined4s-circe/shared/src/test/scala/refined4s/modules/circe/derivation/types/networkSpec.scala
+++ b/modules/refined4s-circe/shared/src/test/scala/refined4s/modules/circe/derivation/types/networkSpec.scala
@@ -1,5 +1,6 @@
 package refined4s.modules.circe.derivation.types
 
+import cats.syntax.all.*
 import hedgehog.*
 import hedgehog.runner.*
 import io.circe.*
@@ -20,24 +21,38 @@ trait networkSpec {
   def allTests: List[Test] = List(
     property("test Encoder[Uri]", testEncoderUri),
     property("test Decoder[Uri]", testDecoderUri),
+    property("test KeyEncoder[Uri]", testKeyEncoderUri),
+    property("test KeyDecoder[Uri]", testKeyDecoderUri),
     //
     property("test Encoder[Url]", testEncoderUrl),
     property("test Decoder[Url]", testDecoderUrl),
+    property("test KeyEncoder[Url]", testKeyEncoderUrl),
+    property("test KeyDecoder[Url]", testKeyDecoderUrl),
     //
     property("test Encoder[PortNumber]", testEncoderPortNumber),
     property("test Decoder[PortNumber]", testDecoderPortNumber),
+    property("test KeyEncoder[PortNumber]", testKeyEncoderPortNumber),
+    property("test KeyDecoder[PortNumber]", testKeyDecoderPortNumber),
     //
     property("test Encoder[SystemPortNumber]", testEncoderSystemPortNumber),
     property("test Decoder[SystemPortNumber]", testDecoderSystemPortNumber),
+    property("test KeyEncoder[SystemPortNumber]", testKeyEncoderSystemPortNumber),
+    property("test KeyDecoder[SystemPortNumber]", testKeyDecoderSystemPortNumber),
     //
     property("test Encoder[NonSystemPortNumber]", testEncoderNonSystemPortNumber),
     property("test Decoder[NonSystemPortNumber]", testDecoderNonSystemPortNumber),
+    property("test KeyEncoder[NonSystemPortNumber]", testKeyEncoderNonSystemPortNumber),
+    property("test KeyDecoder[NonSystemPortNumber]", testKeyDecoderNonSystemPortNumber),
     //
     property("test Encoder[UserPortNumber]", testEncoderUserPortNumber),
     property("test Decoder[UserPortNumber]", testDecoderUserPortNumber),
+    property("test KeyEncoder[UserPortNumber]", testKeyEncoderUserPortNumber),
+    property("test KeyDecoder[UserPortNumber]", testKeyDecoderUserPortNumber),
     //
     property("test Encoder[DynamicPortNumber]", testEncoderDynamicPortNumber),
     property("test Decoder[DynamicPortNumber]", testDecoderDynamicPortNumber),
+    property("test KeyEncoder[DynamicPortNumber]", testKeyEncoderDynamicPortNumber),
+    property("test KeyDecoder[DynamicPortNumber]", testKeyDecoderDynamicPortNumber),
   )
 
   def testEncoderUri: Property =
@@ -68,6 +83,38 @@ trait networkSpec {
       val actual   = decode[Uri](input.noSpaces)
 
       actual ==== expected
+    }
+
+  def testKeyEncoderUri: Property =
+    for {
+      uris  <- networkGens.genUriString.list(Range.linear(1, 10)).log("uris")
+      ns2   <- Gen.int(Range.linear(0, Int.MaxValue)).list(Range.singleton(uris.length)).log("ns2")
+      map   <- Gen.constant(uris.zip(ns2).toMap).log("map")
+      input <- Gen.constant(map.map { case (key, value) => Uri.unsafeFrom(key) -> value }).log("input")
+    } yield {
+      val expected = Json.fromFields(map.map { case (key, value) => key -> value.asJson })
+
+      val actual = input.asJson
+
+      Result.all(
+        List(
+          actual ==== expected,
+          actual.noSpaces ==== expected.noSpaces,
+        )
+      )
+    }
+
+  def testKeyDecoderUri: Property =
+    for {
+      uris     <- networkGens.genUriString.list(Range.linear(1, 10)).log("uris")
+      ns2      <- Gen.int(Range.linear(0, Int.MaxValue)).list(Range.singleton(uris.length)).log("ns2")
+      map      <- Gen.constant(uris.zip(ns2).toMap).log("map")
+      expected <- Gen.constant(map.map { case (key, value) => Uri.unsafeFrom(key) -> value }).log("expected")
+    } yield {
+      val input  = Json.fromFields(map.map { case (key, value) => key -> value.asJson })
+      val actual = decode[Map[Uri, Int]](input.noSpaces)
+
+      actual ==== expected.asRight
     }
 
   //
@@ -102,6 +149,38 @@ trait networkSpec {
       actual ==== expected
     }
 
+  def testKeyEncoderUrl: Property =
+    for {
+      urls  <- networkGens.genUrlString.list(Range.linear(1, 10)).log("urls")
+      ns2   <- Gen.int(Range.linear(0, Int.MaxValue)).list(Range.singleton(urls.length)).log("ns2")
+      map   <- Gen.constant(urls.zip(ns2).toMap).log("map")
+      input <- Gen.constant(map.map { case (key, value) => Url.unsafeFrom(key) -> value }).log("input")
+    } yield {
+      val expected = Json.fromFields(map.map { case (key, value) => key -> value.asJson })
+
+      val actual = input.asJson
+
+      Result.all(
+        List(
+          actual ==== expected,
+          actual.noSpaces ==== expected.noSpaces,
+        )
+      )
+    }
+
+  def testKeyDecoderUrl: Property =
+    for {
+      urls     <- networkGens.genUrlString.list(Range.linear(1, 10)).log("urls")
+      ns2      <- Gen.int(Range.linear(0, Int.MaxValue)).list(Range.singleton(urls.length)).log("ns2")
+      map      <- Gen.constant(urls.zip(ns2).toMap).log("map")
+      expected <- Gen.constant(map.map { case (key, value) => Url.unsafeFrom(key) -> value }).log("expected")
+    } yield {
+      val input  = Json.fromFields(map.map { case (key, value) => key -> value.asJson })
+      val actual = decode[Map[Url, Int]](input.noSpaces)
+
+      actual ==== expected.asRight
+    }
+
   //
 
   def testEncoderPortNumber: Property =
@@ -134,6 +213,40 @@ trait networkSpec {
       actual ==== expected
     }
 
+  def testKeyEncoderPortNumber: Property =
+    for {
+      portNumbers <- networkGens.genPortNumberInt.list(Range.linear(1, 10)).log("portNumbers")
+      ns2         <- Gen.int(Range.linear(0, Int.MaxValue)).list(Range.singleton(portNumbers.length)).log("ns2")
+      map         <- Gen.constant(portNumbers.zip(ns2).toMap).log("map")
+      input       <- Gen.constant(map.map { case (key, value) => PortNumber.unsafeFrom(key) -> value }).log("input")
+    } yield {
+      val expected = Json.fromFields(map.map { case (key, value) => key.toString -> value.asJson })
+
+      val actual = input.asJson
+
+      Result.all(
+        List(
+          actual ==== expected,
+          actual.noSpacesSortKeys ==== expected.noSpacesSortKeys,
+        )
+      )
+    }
+
+  def testKeyDecoderPortNumber: Property =
+    for {
+      portNumbers <- networkGens.genPortNumberInt.list(Range.linear(1, 10)).log("portNumbers")
+      ns2         <- Gen.int(Range.linear(0, Int.MaxValue)).list(Range.singleton(portNumbers.length)).log("ns2")
+      map         <- Gen.constant(portNumbers.zip(ns2).toMap).log("map")
+      expected    <- Gen.constant(map.map { case (key, value) => PortNumber.unsafeFrom(key) -> value }).log("expected")
+    } yield {
+      val input  = Json.fromFields(map.map { case (key, value) => key.toString -> value.asJson })
+      val actual = decode[Map[PortNumber, Int]](input.noSpaces)
+
+      actual ==== expected.asRight
+    }
+
+  //
+
   def testEncoderSystemPortNumber: Property =
     for {
       systemPortNumber <- networkGens.genSystemPortNumberInt.log("systemPortNumber")
@@ -163,6 +276,40 @@ trait networkSpec {
 
       actual ==== expected
     }
+
+  def testKeyEncoderSystemPortNumber: Property =
+    for {
+      systemPortNumbers <- networkGens.genSystemPortNumberInt.list(Range.linear(1, 10)).log("systemPortNumbers")
+      ns2               <- Gen.int(Range.linear(0, Int.MaxValue)).list(Range.singleton(systemPortNumbers.length)).log("ns2")
+      map               <- Gen.constant(systemPortNumbers.zip(ns2).toMap).log("map")
+      input             <- Gen.constant(map.map { case (key, value) => SystemPortNumber.unsafeFrom(key) -> value }).log("input")
+    } yield {
+      val expected = Json.fromFields(map.map { case (key, value) => key.toString -> value.asJson })
+
+      val actual = input.asJson
+
+      Result.all(
+        List(
+          actual ==== expected,
+          actual.noSpacesSortKeys ==== expected.noSpacesSortKeys,
+        )
+      )
+    }
+
+  def testKeyDecoderSystemPortNumber: Property =
+    for {
+      systemPortNumbers <- networkGens.genSystemPortNumberInt.list(Range.linear(1, 10)).log("systemPortNumbers")
+      ns2               <- Gen.int(Range.linear(0, Int.MaxValue)).list(Range.singleton(systemPortNumbers.length)).log("ns2")
+      map               <- Gen.constant(systemPortNumbers.zip(ns2).toMap).log("map")
+      expected          <- Gen.constant(map.map { case (key, value) => SystemPortNumber.unsafeFrom(key) -> value }).log("expected")
+    } yield {
+      val input  = Json.fromFields(map.map { case (key, value) => key.toString -> value.asJson })
+      val actual = decode[Map[SystemPortNumber, Int]](input.noSpaces)
+
+      actual ==== expected.asRight
+    }
+
+  //
 
   def testEncoderNonSystemPortNumber: Property =
     for {
@@ -194,6 +341,40 @@ trait networkSpec {
       actual ==== expected
     }
 
+  def testKeyEncoderNonSystemPortNumber: Property =
+    for {
+      nonSystemPortNumbers <- networkGens.genNonSystemPortNumberInt.list(Range.linear(1, 10)).log("nonSystemPortNumbers")
+      ns2                  <- Gen.int(Range.linear(0, Int.MaxValue)).list(Range.singleton(nonSystemPortNumbers.length)).log("ns2")
+      map                  <- Gen.constant(nonSystemPortNumbers.zip(ns2).toMap).log("map")
+      input                <- Gen.constant(map.map { case (key, value) => NonSystemPortNumber.unsafeFrom(key) -> value }).log("input")
+    } yield {
+      val expected = Json.fromFields(map.map { case (key, value) => key.toString -> value.asJson })
+
+      val actual = input.asJson
+
+      Result.all(
+        List(
+          actual ==== expected,
+          actual.noSpacesSortKeys ==== expected.noSpacesSortKeys,
+        )
+      )
+    }
+
+  def testKeyDecoderNonSystemPortNumber: Property =
+    for {
+      nonSystemPortNumbers <- networkGens.genNonSystemPortNumberInt.list(Range.linear(1, 10)).log("nonSystemPortNumbers")
+      ns2                  <- Gen.int(Range.linear(0, Int.MaxValue)).list(Range.singleton(nonSystemPortNumbers.length)).log("ns2")
+      map                  <- Gen.constant(nonSystemPortNumbers.zip(ns2).toMap).log("map")
+      expected             <- Gen.constant(map.map { case (key, value) => NonSystemPortNumber.unsafeFrom(key) -> value }).log("expected")
+    } yield {
+      val input  = Json.fromFields(map.map { case (key, value) => key.toString -> value.asJson })
+      val actual = decode[Map[NonSystemPortNumber, Int]](input.noSpaces)
+
+      actual ==== expected.asRight
+    }
+
+  //
+
   def testEncoderUserPortNumber: Property =
     for {
       userPortNumber <- networkGens.genUserPortNumberInt.log("userPortNumber")
@@ -224,6 +405,40 @@ trait networkSpec {
       actual ==== expected
     }
 
+  def testKeyEncoderUserPortNumber: Property =
+    for {
+      userPortNumbers <- networkGens.genUserPortNumberInt.list(Range.linear(1, 10)).log("userPortNumbers")
+      ns2             <- Gen.int(Range.linear(0, Int.MaxValue)).list(Range.singleton(userPortNumbers.length)).log("ns2")
+      map             <- Gen.constant(userPortNumbers.zip(ns2).toMap).log("map")
+      input           <- Gen.constant(map.map { case (key, value) => UserPortNumber.unsafeFrom(key) -> value }).log("input")
+    } yield {
+      val expected = Json.fromFields(map.map { case (key, value) => key.toString -> value.asJson })
+
+      val actual = input.asJson
+
+      Result.all(
+        List(
+          actual ==== expected,
+          actual.noSpacesSortKeys ==== expected.noSpacesSortKeys,
+        )
+      )
+    }
+
+  def testKeyDecoderUserPortNumber: Property =
+    for {
+      userPortNumbers <- networkGens.genUserPortNumberInt.list(Range.linear(1, 10)).log("userPortNumbers")
+      ns2             <- Gen.int(Range.linear(0, Int.MaxValue)).list(Range.singleton(userPortNumbers.length)).log("ns2")
+      map             <- Gen.constant(userPortNumbers.zip(ns2).toMap).log("map")
+      expected        <- Gen.constant(map.map { case (key, value) => UserPortNumber.unsafeFrom(key) -> value }).log("expected")
+    } yield {
+      val input  = Json.fromFields(map.map { case (key, value) => key.toString -> value.asJson })
+      val actual = decode[Map[UserPortNumber, Int]](input.noSpaces)
+
+      actual ==== expected.asRight
+    }
+
+  //
+
   def testEncoderDynamicPortNumber: Property =
     for {
       dynamicPortNumber <- networkGens.genDynamicPortNumberInt.log("dynamicPortNumber")
@@ -252,6 +467,38 @@ trait networkSpec {
       val actual   = decode[DynamicPortNumber](input.noSpaces)
 
       actual ==== expected
+    }
+
+  def testKeyEncoderDynamicPortNumber: Property =
+    for {
+      dynamicPortNumbers <- networkGens.genDynamicPortNumberInt.list(Range.linear(1, 10)).log("dynamicPortNumbers")
+      ns2                <- Gen.int(Range.linear(0, Int.MaxValue)).list(Range.singleton(dynamicPortNumbers.length)).log("ns2")
+      map                <- Gen.constant(dynamicPortNumbers.zip(ns2).toMap).log("map")
+      input              <- Gen.constant(map.map { case (key, value) => DynamicPortNumber.unsafeFrom(key) -> value }).log("input")
+    } yield {
+      val expected = Json.fromFields(map.map { case (key, value) => key.toString -> value.asJson })
+
+      val actual = input.asJson
+
+      Result.all(
+        List(
+          actual ==== expected,
+          actual.noSpacesSortKeys ==== expected.noSpacesSortKeys,
+        )
+      )
+    }
+
+  def testKeyDecoderDynamicPortNumber: Property =
+    for {
+      dynamicPortNumbers <- networkGens.genDynamicPortNumberInt.list(Range.linear(1, 10)).log("dynamicPortNumbers")
+      ns2                <- Gen.int(Range.linear(0, Int.MaxValue)).list(Range.singleton(dynamicPortNumbers.length)).log("ns2")
+      map                <- Gen.constant(dynamicPortNumbers.zip(ns2).toMap).log("map")
+      expected           <- Gen.constant(map.map { case (key, value) => DynamicPortNumber.unsafeFrom(key) -> value }).log("expected")
+    } yield {
+      val input  = Json.fromFields(map.map { case (key, value) => key.toString -> value.asJson })
+      val actual = decode[Map[DynamicPortNumber, Int]](input.noSpaces)
+
+      actual ==== expected.asRight
     }
 
 }

--- a/modules/refined4s-circe/shared/src/test/scala/refined4s/modules/circe/derivation/types/numericSpec.scala
+++ b/modules/refined4s-circe/shared/src/test/scala/refined4s/modules/circe/derivation/types/numericSpec.scala
@@ -2,6 +2,7 @@ package refined4s.modules.circe.derivation.types
 
 import hedgehog.*
 import hedgehog.runner.*
+import cats.syntax.all.*
 import io.circe.*
 import io.circe.parser.*
 import io.circe.syntax.*
@@ -17,51 +18,83 @@ trait numericSpec {
   def allTests: List[Test] = List(
     property("test Encoder[NegInt]", testEncoderNegInt),
     property("test Decoder[NegInt]", testDecoderNegInt),
+    property("test KeyEncoder[NegInt]", testKeyEncoderNegInt),
+    property("test KeyDecoder[NegInt]", testKeyDecoderNegInt),
     //
     property("test Encoder[NonNegInt]", testEncoderNonNegInt),
     property("test Decoder[NonNegInt]", testDecoderNonNegInt),
+    property("test KeyEncoder[NonNegInt]", testKeyEncoderNonNegInt),
+    property("test KeyDecoder[NonNegInt]", testKeyDecoderNonNegInt),
     //
     property("test Encoder[PosInt]", testEncoderPosInt),
     property("test Decoder[PosInt]", testDecoderPosInt),
+    property("test KeyEncoder[PosInt]", testKeyEncoderPosInt),
+    property("test KeyDecoder[PosInt]", testKeyDecoderPosInt),
     //
     property("test Encoder[NonPosInt]", testEncoderNonPosInt),
     property("test Decoder[NonPosInt]", testDecoderNonPosInt),
+    property("test KeyEncoder[NonPosInt]", testKeyEncoderNonPosInt),
+    property("test KeyDecoder[NonPosInt]", testKeyDecoderNonPosInt),
     //
     property("test Encoder[NegLong]", testEncoderNegLong),
     property("test Decoder[NegLong]", testDecoderNegLong),
+    property("test KeyEncoder[NegLong]", testKeyEncoderNegLong),
+    property("test KeyDecoder[NegLong]", testKeyDecoderNegLong),
     //
     property("test Encoder[NonNegLong]", testEncoderNonNegLong),
     property("test Decoder[NonNegLong]", testDecoderNonNegLong),
+    property("test KeyEncoder[NonNegLong]", testKeyEncoderNonNegLong),
+    property("test KeyDecoder[NonNegLong]", testKeyDecoderNonNegLong),
     //
     property("test Encoder[PosLong]", testEncoderPosLong),
     property("test Decoder[PosLong]", testDecoderPosLong),
+    property("test KeyEncoder[PosLong]", testKeyEncoderPosLong),
+    property("test KeyDecoder[PosLong]", testKeyDecoderPosLong),
     //
     property("test Encoder[NonPosLong]", testEncoderNonPosLong),
     property("test Decoder[NonPosLong]", testDecoderNonPosLong),
+    property("test KeyEncoder[NonPosLong]", testKeyEncoderNonPosLong),
+    property("test KeyDecoder[NonPosLong]", testKeyDecoderNonPosLong),
     //
     property("test Encoder[NegShort]", testEncoderNegShort),
     property("test Decoder[NegShort]", testDecoderNegShort),
+    property("test KeyEncoder[NegShort]", testKeyEncoderNegShort),
+    property("test KeyDecoder[NegShort]", testKeyDecoderNegShort),
     //
     property("test Encoder[NonNegShort]", testEncoderNonNegShort),
     property("test Decoder[NonNegShort]", testDecoderNonNegShort),
+    property("test KeyEncoder[NonNegShort]", testKeyEncoderNonNegShort),
+    property("test KeyDecoder[NonNegShort]", testKeyDecoderNonNegShort),
     //
     property("test Encoder[PosShort]", testEncoderPosShort),
     property("test Decoder[PosShort]", testDecoderPosShort),
+    property("test KeyEncoder[PosShort]", testKeyEncoderPosShort),
+    property("test KeyDecoder[PosShort]", testKeyDecoderPosShort),
     //
     property("test Encoder[NonPosShort]", testEncoderNonPosShort),
     property("test Decoder[NonPosShort]", testDecoderNonPosShort),
+    property("test KeyEncoder[NonPosShort]", testKeyEncoderNonPosShort),
+    property("test KeyDecoder[NonPosShort]", testKeyDecoderNonPosShort),
     //
     property("test Encoder[NegByte]", testEncoderNegByte),
     property("test Decoder[NegByte]", testDecoderNegByte),
+    property("test KeyEncoder[NegByte]", testKeyEncoderNegByte),
+    property("test KeyDecoder[NegByte]", testKeyDecoderNegByte),
     //
     property("test Encoder[NonNegByte]", testEncoderNonNegByte),
     property("test Decoder[NonNegByte]", testDecoderNonNegByte),
+    property("test KeyEncoder[NonNegByte]", testKeyEncoderNonNegByte),
+    property("test KeyDecoder[NonNegByte]", testKeyDecoderNonNegByte),
     //
     property("test Encoder[PosByte]", testEncoderPosByte),
     property("test Decoder[PosByte]", testDecoderPosByte),
+    property("test KeyEncoder[PosByte]", testKeyEncoderPosByte),
+    property("test KeyDecoder[PosByte]", testKeyDecoderPosByte),
     //
     property("test Encoder[NonPosByte]", testEncoderNonPosByte),
     property("test Decoder[NonPosByte]", testDecoderNonPosByte),
+    property("test KeyEncoder[NonPosByte]", testKeyEncoderNonPosByte),
+    property("test KeyDecoder[NonPosByte]", testKeyDecoderNonPosByte),
     //
     property("test Encoder[NegFloat]", testEncoderNegFloat),
     property("test Decoder[NegFloat]", testDecoderNegFloat),
@@ -89,15 +122,23 @@ trait numericSpec {
     //
     property("test Encoder[NegBigInt]", testEncoderNegBigInt),
     property("test Decoder[NegBigInt]", testDecoderNegBigInt),
+    property("test KeyEncoder[NegBigInt]", testKeyEncoderNegBigInt),
+    property("test KeyDecoder[NegBigInt]", testKeyDecoderNegBigInt),
     //
     property("test Encoder[NonNegBigInt]", testEncoderNonNegBigInt),
     property("test Decoder[NonNegBigInt]", testDecoderNonNegBigInt),
+    property("test KeyEncoder[NonNegBigInt]", testKeyEncoderNonNegBigInt),
+    property("test KeyDecoder[NonNegBigInt]", testKeyDecoderNonNegBigInt),
     //
     property("test Encoder[PosBigInt]", testEncoderPosBigInt),
     property("test Decoder[PosBigInt]", testDecoderPosBigInt),
+    property("test KeyEncoder[PosBigInt]", testKeyEncoderPosBigInt),
+    property("test KeyDecoder[PosBigInt]", testKeyDecoderPosBigInt),
     //
     property("test Encoder[NonPosBigInt]", testEncoderNonPosBigInt),
     property("test Decoder[NonPosBigInt]", testDecoderNonPosBigInt),
+    property("test KeyEncoder[NonPosBigInt]", testKeyEncoderNonPosBigInt),
+    property("test KeyDecoder[NonPosBigInt]", testKeyDecoderNonPosBigInt),
     //
     property("test Encoder[NegBigDecimal]", testEncoderNegBigDecimal),
     property("test Decoder[NegBigDecimal]", testDecoderNegBigDecimal),
@@ -142,6 +183,37 @@ trait numericSpec {
       actual ==== expected
     }
 
+  def testKeyEncoderNegInt: Property =
+    for {
+      ns1   <- Gen.int(Range.linear(-1, Int.MinValue)).list(Range.linear(1, 10)).log("ns1")
+      ns2   <- Gen.int(Range.linear(0, Int.MaxValue)).list(Range.singleton(ns1.length)).log("ns2")
+      map   <- Gen.constant(ns1.zip(ns2).toMap).log("map")
+      input <- Gen.constant(map.map { case (key, value) => NegInt.unsafeFrom(key) -> value }).log("input")
+    } yield {
+      val expected = Json.fromFields(map.map { case (key, value) => key.toString -> value.asJson })
+
+      val actual = input.asJson
+      Result.all(
+        List(
+          actual ==== expected,
+          actual.noSpacesSortKeys ==== expected.noSpacesSortKeys,
+        )
+      )
+    }
+
+  def testKeyDecoderNegInt: Property =
+    for {
+      ns1      <- Gen.int(Range.linear(-1, Int.MinValue)).list(Range.linear(1, 10)).log("ns1")
+      ns2      <- Gen.int(Range.linear(0, Int.MaxValue)).list(Range.singleton(ns1.length)).log("ns2")
+      map      <- Gen.constant(ns1.zip(ns2).toMap).log("map")
+      expected <- Gen.constant(map.map { case (key, value) => NegInt.unsafeFrom(key) -> value }).log("expected")
+    } yield {
+      val input  = Json.fromFields(map.map { case (key, value) => key.toString -> value.asJson })
+      val actual = decode[Map[NegInt, Int]](input.noSpaces)
+
+      actual ==== expected.asRight
+    }
+
   //
 
   def testEncoderNonNegInt: Property =
@@ -169,6 +241,37 @@ trait numericSpec {
       val expected = NonNegInt.from(n)
       val actual   = decode[NonNegInt](input.noSpaces)
       actual ==== expected
+    }
+
+  def testKeyEncoderNonNegInt: Property =
+    for {
+      ns1   <- Gen.int(Range.linear(0, Int.MaxValue)).list(Range.linear(1, 10)).log("ns1")
+      ns2   <- Gen.int(Range.linear(0, Int.MaxValue)).list(Range.singleton(ns1.length)).log("ns2")
+      map   <- Gen.constant(ns1.zip(ns2).toMap).log("map")
+      input <- Gen.constant(map.map { case (key, value) => NonNegInt.unsafeFrom(key) -> value }).log("input")
+    } yield {
+      val expected = Json.fromFields(map.map { case (key, value) => key.toString -> value.asJson })
+
+      val actual = input.asJson
+      Result.all(
+        List(
+          actual ==== expected,
+          actual.noSpacesSortKeys ==== expected.noSpacesSortKeys,
+        )
+      )
+    }
+
+  def testKeyDecoderNonNegInt: Property =
+    for {
+      ns1      <- Gen.int(Range.linear(0, Int.MaxValue)).list(Range.linear(1, 10)).log("ns1")
+      ns2      <- Gen.int(Range.linear(0, Int.MaxValue)).list(Range.singleton(ns1.length)).log("ns2")
+      map      <- Gen.constant(ns1.zip(ns2).toMap).log("map")
+      expected <- Gen.constant(map.map { case (key, value) => NonNegInt.unsafeFrom(key) -> value }).log("expected")
+    } yield {
+      val input  = Json.fromFields(map.map { case (key, value) => key.toString -> value.asJson })
+      val actual = decode[Map[NonNegInt, Int]](input.noSpaces)
+
+      actual ==== expected.asRight
     }
 
   //
@@ -200,6 +303,37 @@ trait numericSpec {
       actual ==== expected
     }
 
+  def testKeyEncoderPosInt: Property =
+    for {
+      ns1   <- Gen.int(Range.linear(1, Int.MaxValue)).list(Range.linear(1, 10)).log("ns1")
+      ns2   <- Gen.int(Range.linear(0, Int.MaxValue)).list(Range.singleton(ns1.length)).log("ns2")
+      map   <- Gen.constant(ns1.zip(ns2).toMap).log("map")
+      input <- Gen.constant(map.map { case (key, value) => PosInt.unsafeFrom(key) -> value }).log("input")
+    } yield {
+      val expected = Json.fromFields(map.map { case (key, value) => key.toString -> value.asJson })
+
+      val actual = input.asJson
+      Result.all(
+        List(
+          actual ==== expected,
+          actual.noSpacesSortKeys ==== expected.noSpacesSortKeys,
+        )
+      )
+    }
+
+  def testKeyDecoderPosInt: Property =
+    for {
+      ns1      <- Gen.int(Range.linear(1, Int.MaxValue)).list(Range.linear(1, 10)).log("ns1")
+      ns2      <- Gen.int(Range.linear(0, Int.MaxValue)).list(Range.singleton(ns1.length)).log("ns2")
+      map      <- Gen.constant(ns1.zip(ns2).toMap).log("map")
+      expected <- Gen.constant(map.map { case (key, value) => PosInt.unsafeFrom(key) -> value }).log("expected")
+    } yield {
+      val input  = Json.fromFields(map.map { case (key, value) => key.toString -> value.asJson })
+      val actual = decode[Map[PosInt, Int]](input.noSpaces)
+
+      actual ==== expected.asRight
+    }
+
   //
 
   def testEncoderNonPosInt: Property =
@@ -227,6 +361,37 @@ trait numericSpec {
       val expected = NonPosInt.from(n)
       val actual   = decode[NonPosInt](input.noSpaces)
       actual ==== expected
+    }
+
+  def testKeyEncoderNonPosInt: Property =
+    for {
+      ns1   <- Gen.int(Range.linear(0, Int.MinValue)).list(Range.linear(1, 10)).log("ns1")
+      ns2   <- Gen.int(Range.linear(0, Int.MaxValue)).list(Range.singleton(ns1.length)).log("ns2")
+      map   <- Gen.constant(ns1.zip(ns2).toMap).log("map")
+      input <- Gen.constant(map.map { case (key, value) => NonPosInt.unsafeFrom(key) -> value }).log("input")
+    } yield {
+      val expected = Json.fromFields(map.map { case (key, value) => key.toString -> value.asJson })
+
+      val actual = input.asJson
+      Result.all(
+        List(
+          actual ==== expected,
+          actual.noSpacesSortKeys ==== expected.noSpacesSortKeys,
+        )
+      )
+    }
+
+  def testKeyDecoderNonPosInt: Property =
+    for {
+      ns1      <- Gen.int(Range.linear(0, Int.MinValue)).list(Range.linear(1, 10)).log("ns1")
+      ns2      <- Gen.int(Range.linear(0, Int.MaxValue)).list(Range.singleton(ns1.length)).log("ns2")
+      map      <- Gen.constant(ns1.zip(ns2).toMap).log("map")
+      expected <- Gen.constant(map.map { case (key, value) => NonPosInt.unsafeFrom(key) -> value }).log("expected")
+    } yield {
+      val input  = Json.fromFields(map.map { case (key, value) => key.toString -> value.asJson })
+      val actual = decode[Map[NonPosInt, Int]](input.noSpaces)
+
+      actual ==== expected.asRight
     }
 
   //
@@ -258,6 +423,37 @@ trait numericSpec {
       actual ==== expected
     }
 
+  def testKeyEncoderNegLong: Property =
+    for {
+      ns1   <- Gen.long(Range.linear(-1L, Long.MinValue)).list(Range.linear(1, 10)).log("ns1")
+      ns2   <- Gen.int(Range.linear(0, Int.MaxValue)).list(Range.singleton(ns1.length)).log("ns2")
+      map   <- Gen.constant(ns1.zip(ns2).toMap).log("map")
+      input <- Gen.constant(map.map { case (key, value) => NegLong.unsafeFrom(key) -> value }).log("input")
+    } yield {
+      val expected = Json.fromFields(map.map { case (key, value) => key.toString -> value.asJson })
+
+      val actual = input.asJson
+      Result.all(
+        List(
+          actual ==== expected,
+          actual.noSpacesSortKeys ==== expected.noSpacesSortKeys,
+        )
+      )
+    }
+
+  def testKeyDecoderNegLong: Property =
+    for {
+      ns1      <- Gen.long(Range.linear(-1L, Long.MinValue)).list(Range.linear(1, 10)).log("ns1")
+      ns2      <- Gen.int(Range.linear(0, Int.MaxValue)).list(Range.singleton(ns1.length)).log("ns2")
+      map      <- Gen.constant(ns1.zip(ns2).toMap).log("map")
+      expected <- Gen.constant(map.map { case (key, value) => NegLong.unsafeFrom(key) -> value }).log("expected")
+    } yield {
+      val input  = Json.fromFields(map.map { case (key, value) => key.toString -> value.asJson })
+      val actual = decode[Map[NegLong, Int]](input.noSpaces)
+
+      actual ==== expected.asRight
+    }
+
   //
 
   def testEncoderNonNegLong: Property =
@@ -285,6 +481,37 @@ trait numericSpec {
       val expected = NonNegLong.from(n)
       val actual   = decode[NonNegLong](input.noSpaces)
       actual ==== expected
+    }
+
+  def testKeyEncoderNonNegLong: Property =
+    for {
+      ns1   <- Gen.long(Range.linear(0L, Long.MaxValue)).list(Range.linear(1, 10)).log("ns1")
+      ns2   <- Gen.int(Range.linear(0, Int.MaxValue)).list(Range.singleton(ns1.length)).log("ns2")
+      map   <- Gen.constant(ns1.zip(ns2).toMap).log("map")
+      input <- Gen.constant(map.map { case (key, value) => NonNegLong.unsafeFrom(key) -> value }).log("input")
+    } yield {
+      val expected = Json.fromFields(map.map { case (key, value) => key.toString -> value.asJson })
+
+      val actual = input.asJson
+      Result.all(
+        List(
+          actual ==== expected,
+          actual.noSpacesSortKeys ==== expected.noSpacesSortKeys,
+        )
+      )
+    }
+
+  def testKeyDecoderNonNegLong: Property =
+    for {
+      ns1      <- Gen.long(Range.linear(0L, Long.MaxValue)).list(Range.linear(1, 10)).log("ns1")
+      ns2      <- Gen.int(Range.linear(0, Int.MaxValue)).list(Range.singleton(ns1.length)).log("ns2")
+      map      <- Gen.constant(ns1.zip(ns2).toMap).log("map")
+      expected <- Gen.constant(map.map { case (key, value) => NonNegLong.unsafeFrom(key) -> value }).log("expected")
+    } yield {
+      val input  = Json.fromFields(map.map { case (key, value) => key.toString -> value.asJson })
+      val actual = decode[Map[NonNegLong, Int]](input.noSpaces)
+
+      actual ==== expected.asRight
     }
 
   //
@@ -316,6 +543,37 @@ trait numericSpec {
       actual ==== expected
     }
 
+  def testKeyEncoderPosLong: Property =
+    for {
+      ns1   <- Gen.long(Range.linear(1L, Long.MaxValue)).list(Range.linear(1, 10)).log("ns1")
+      ns2   <- Gen.int(Range.linear(0, Int.MaxValue)).list(Range.singleton(ns1.length)).log("ns2")
+      map   <- Gen.constant(ns1.zip(ns2).toMap).log("map")
+      input <- Gen.constant(map.map { case (key, value) => PosLong.unsafeFrom(key) -> value }).log("input")
+    } yield {
+      val expected = Json.fromFields(map.map { case (key, value) => key.toString -> value.asJson })
+
+      val actual = input.asJson
+      Result.all(
+        List(
+          actual ==== expected,
+          actual.noSpacesSortKeys ==== expected.noSpacesSortKeys,
+        )
+      )
+    }
+
+  def testKeyDecoderPosLong: Property =
+    for {
+      ns1      <- Gen.long(Range.linear(1L, Long.MaxValue)).list(Range.linear(1, 10)).log("ns1")
+      ns2      <- Gen.int(Range.linear(0, Int.MaxValue)).list(Range.singleton(ns1.length)).log("ns2")
+      map      <- Gen.constant(ns1.zip(ns2).toMap).log("map")
+      expected <- Gen.constant(map.map { case (key, value) => PosLong.unsafeFrom(key) -> value }).log("expected")
+    } yield {
+      val input  = Json.fromFields(map.map { case (key, value) => key.toString -> value.asJson })
+      val actual = decode[Map[PosLong, Int]](input.noSpaces)
+
+      actual ==== expected.asRight
+    }
+
   //
 
   def testEncoderNonPosLong: Property =
@@ -343,6 +601,37 @@ trait numericSpec {
       val expected = NonPosLong.from(n)
       val actual   = decode[NonPosLong](input.noSpaces)
       actual ==== expected
+    }
+
+  def testKeyEncoderNonPosLong: Property =
+    for {
+      ns1   <- Gen.long(Range.linear(0L, Long.MinValue)).list(Range.linear(1, 10)).log("ns1")
+      ns2   <- Gen.int(Range.linear(0, Int.MaxValue)).list(Range.singleton(ns1.length)).log("ns2")
+      map   <- Gen.constant(ns1.zip(ns2).toMap).log("map")
+      input <- Gen.constant(map.map { case (key, value) => NonPosLong.unsafeFrom(key) -> value }).log("input")
+    } yield {
+      val expected = Json.fromFields(map.map { case (key, value) => key.toString -> value.asJson })
+
+      val actual = input.asJson
+      Result.all(
+        List(
+          actual ==== expected,
+          actual.noSpacesSortKeys ==== expected.noSpacesSortKeys,
+        )
+      )
+    }
+
+  def testKeyDecoderNonPosLong: Property =
+    for {
+      ns1      <- Gen.long(Range.linear(0L, Long.MinValue)).list(Range.linear(1, 10)).log("ns1")
+      ns2      <- Gen.int(Range.linear(0, Int.MaxValue)).list(Range.singleton(ns1.length)).log("ns2")
+      map      <- Gen.constant(ns1.zip(ns2).toMap).log("map")
+      expected <- Gen.constant(map.map { case (key, value) => NonPosLong.unsafeFrom(key) -> value }).log("expected")
+    } yield {
+      val input  = Json.fromFields(map.map { case (key, value) => key.toString -> value.asJson })
+      val actual = decode[Map[NonPosLong, Int]](input.noSpaces)
+
+      actual ==== expected.asRight
     }
 
   //
@@ -374,6 +663,37 @@ trait numericSpec {
       actual ==== expected
     }
 
+  def testKeyEncoderNegShort: Property =
+    for {
+      ns1   <- Gen.short(Range.linear(-1, Short.MinValue)).list(Range.linear(1, 10)).log("ns1")
+      ns2   <- Gen.int(Range.linear(0, Int.MaxValue)).list(Range.singleton(ns1.length)).log("ns2")
+      map   <- Gen.constant(ns1.zip(ns2).toMap).log("map")
+      input <- Gen.constant(map.map { case (key, value) => NegShort.unsafeFrom(key) -> value }).log("input")
+    } yield {
+      val expected = Json.fromFields(map.map { case (key, value) => key.toString -> value.asJson })
+
+      val actual = input.asJson
+      Result.all(
+        List(
+          actual ==== expected,
+          actual.noSpacesSortKeys ==== expected.noSpacesSortKeys,
+        )
+      )
+    }
+
+  def testKeyDecoderNegShort: Property =
+    for {
+      ns1      <- Gen.short(Range.linear(-1, Short.MinValue)).list(Range.linear(1, 10)).log("ns1")
+      ns2      <- Gen.int(Range.linear(0, Int.MaxValue)).list(Range.singleton(ns1.length)).log("ns2")
+      map      <- Gen.constant(ns1.zip(ns2).toMap).log("map")
+      expected <- Gen.constant(map.map { case (key, value) => NegShort.unsafeFrom(key) -> value }).log("expected")
+    } yield {
+      val input  = Json.fromFields(map.map { case (key, value) => key.toString -> value.asJson })
+      val actual = decode[Map[NegShort, Int]](input.noSpaces)
+
+      actual ==== expected.asRight
+    }
+
   //
 
   def testEncoderNonNegShort: Property =
@@ -401,6 +721,37 @@ trait numericSpec {
       val expected = NonNegShort.from(n)
       val actual   = decode[NonNegShort](input.noSpaces)
       actual ==== expected
+    }
+
+  def testKeyEncoderNonNegShort: Property =
+    for {
+      ns1   <- Gen.short(Range.linear(0, Short.MaxValue)).list(Range.linear(1, 10)).log("ns1")
+      ns2   <- Gen.int(Range.linear(0, Int.MaxValue)).list(Range.singleton(ns1.length)).log("ns2")
+      map   <- Gen.constant(ns1.zip(ns2).toMap).log("map")
+      input <- Gen.constant(map.map { case (key, value) => NonNegShort.unsafeFrom(key) -> value }).log("input")
+    } yield {
+      val expected = Json.fromFields(map.map { case (key, value) => key.toString -> value.asJson })
+
+      val actual = input.asJson
+      Result.all(
+        List(
+          actual ==== expected,
+          actual.noSpacesSortKeys ==== expected.noSpacesSortKeys,
+        )
+      )
+    }
+
+  def testKeyDecoderNonNegShort: Property =
+    for {
+      ns1      <- Gen.short(Range.linear(0, Short.MaxValue)).list(Range.linear(1, 10)).log("ns1")
+      ns2      <- Gen.int(Range.linear(0, Int.MaxValue)).list(Range.singleton(ns1.length)).log("ns2")
+      map      <- Gen.constant(ns1.zip(ns2).toMap).log("map")
+      expected <- Gen.constant(map.map { case (key, value) => NonNegShort.unsafeFrom(key) -> value }).log("expected")
+    } yield {
+      val input  = Json.fromFields(map.map { case (key, value) => key.toString -> value.asJson })
+      val actual = decode[Map[NonNegShort, Int]](input.noSpaces)
+
+      actual ==== expected.asRight
     }
 
   //
@@ -432,6 +783,37 @@ trait numericSpec {
       actual ==== expected
     }
 
+  def testKeyEncoderPosShort: Property =
+    for {
+      ns1   <- Gen.short(Range.linear(1, Short.MaxValue)).list(Range.linear(1, 10)).log("ns1")
+      ns2   <- Gen.int(Range.linear(0, Int.MaxValue)).list(Range.singleton(ns1.length)).log("ns2")
+      map   <- Gen.constant(ns1.zip(ns2).toMap).log("map")
+      input <- Gen.constant(map.map { case (key, value) => PosShort.unsafeFrom(key) -> value }).log("input")
+    } yield {
+      val expected = Json.fromFields(map.map { case (key, value) => key.toString -> value.asJson })
+
+      val actual = input.asJson
+      Result.all(
+        List(
+          actual ==== expected,
+          actual.noSpacesSortKeys ==== expected.noSpacesSortKeys,
+        )
+      )
+    }
+
+  def testKeyDecoderPosShort: Property =
+    for {
+      ns1      <- Gen.short(Range.linear(1, Short.MaxValue)).list(Range.linear(1, 10)).log("ns1")
+      ns2      <- Gen.int(Range.linear(0, Int.MaxValue)).list(Range.singleton(ns1.length)).log("ns2")
+      map      <- Gen.constant(ns1.zip(ns2).toMap).log("map")
+      expected <- Gen.constant(map.map { case (key, value) => PosShort.unsafeFrom(key) -> value }).log("expected")
+    } yield {
+      val input  = Json.fromFields(map.map { case (key, value) => key.toString -> value.asJson })
+      val actual = decode[Map[PosShort, Int]](input.noSpaces)
+
+      actual ==== expected.asRight
+    }
+
   //
 
   def testEncoderNonPosShort: Property =
@@ -459,6 +841,37 @@ trait numericSpec {
       val expected = NonPosShort.from(n)
       val actual   = decode[NonPosShort](input.noSpaces)
       actual ==== expected
+    }
+
+  def testKeyEncoderNonPosShort: Property =
+    for {
+      ns1   <- Gen.short(Range.linear(0, Short.MinValue)).list(Range.linear(1, 10)).log("ns1")
+      ns2   <- Gen.int(Range.linear(0, Int.MaxValue)).list(Range.singleton(ns1.length)).log("ns2")
+      map   <- Gen.constant(ns1.zip(ns2).toMap).log("map")
+      input <- Gen.constant(map.map { case (key, value) => NonPosShort.unsafeFrom(key) -> value }).log("input")
+    } yield {
+      val expected = Json.fromFields(map.map { case (key, value) => key.toString -> value.asJson })
+
+      val actual = input.asJson
+      Result.all(
+        List(
+          actual ==== expected,
+          actual.noSpacesSortKeys ==== expected.noSpacesSortKeys,
+        )
+      )
+    }
+
+  def testKeyDecoderNonPosShort: Property =
+    for {
+      ns1      <- Gen.short(Range.linear(0, Short.MinValue)).list(Range.linear(1, 10)).log("ns1")
+      ns2      <- Gen.int(Range.linear(0, Int.MaxValue)).list(Range.singleton(ns1.length)).log("ns2")
+      map      <- Gen.constant(ns1.zip(ns2).toMap).log("map")
+      expected <- Gen.constant(map.map { case (key, value) => NonPosShort.unsafeFrom(key) -> value }).log("expected")
+    } yield {
+      val input  = Json.fromFields(map.map { case (key, value) => key.toString -> value.asJson })
+      val actual = decode[Map[NonPosShort, Int]](input.noSpaces)
+
+      actual ==== expected.asRight
     }
 
   //
@@ -490,6 +903,37 @@ trait numericSpec {
       actual ==== expected
     }
 
+  def testKeyEncoderNegByte: Property =
+    for {
+      ns1   <- Gen.byte(Range.linear(-1, Byte.MinValue)).list(Range.linear(1, 10)).log("ns1")
+      ns2   <- Gen.int(Range.linear(0, Int.MaxValue)).list(Range.singleton(ns1.length)).log("ns2")
+      map   <- Gen.constant(ns1.zip(ns2).toMap).log("map")
+      input <- Gen.constant(map.map { case (key, value) => NegByte.unsafeFrom(key) -> value }).log("input")
+    } yield {
+      val expected = Json.fromFields(map.map { case (key, value) => key.toString -> value.asJson })
+
+      val actual = input.asJson
+      Result.all(
+        List(
+          actual ==== expected,
+          actual.noSpacesSortKeys ==== expected.noSpacesSortKeys,
+        )
+      )
+    }
+
+  def testKeyDecoderNegByte: Property =
+    for {
+      ns1      <- Gen.byte(Range.linear(-1, Byte.MinValue)).list(Range.linear(1, 10)).log("ns1")
+      ns2      <- Gen.int(Range.linear(0, Int.MaxValue)).list(Range.singleton(ns1.length)).log("ns2")
+      map      <- Gen.constant(ns1.zip(ns2).toMap).log("map")
+      expected <- Gen.constant(map.map { case (key, value) => NegByte.unsafeFrom(key) -> value }).log("expected")
+    } yield {
+      val input  = Json.fromFields(map.map { case (key, value) => key.toString -> value.asJson })
+      val actual = decode[Map[NegByte, Int]](input.noSpaces)
+
+      actual ==== expected.asRight
+    }
+
   //
 
   def testEncoderNonNegByte: Property =
@@ -517,6 +961,37 @@ trait numericSpec {
       val expected = NonNegByte.from(n)
       val actual   = decode[NonNegByte](input.noSpaces)
       actual ==== expected
+    }
+
+  def testKeyEncoderNonNegByte: Property =
+    for {
+      ns1   <- Gen.byte(Range.linear(0, Byte.MaxValue)).list(Range.linear(1, 10)).log("ns1")
+      ns2   <- Gen.int(Range.linear(0, Int.MaxValue)).list(Range.singleton(ns1.length)).log("ns2")
+      map   <- Gen.constant(ns1.zip(ns2).toMap).log("map")
+      input <- Gen.constant(map.map { case (key, value) => NonNegByte.unsafeFrom(key) -> value }).log("input")
+    } yield {
+      val expected = Json.fromFields(map.map { case (key, value) => key.toString -> value.asJson })
+
+      val actual = input.asJson
+      Result.all(
+        List(
+          actual ==== expected,
+          actual.noSpacesSortKeys ==== expected.noSpacesSortKeys,
+        )
+      )
+    }
+
+  def testKeyDecoderNonNegByte: Property =
+    for {
+      ns1      <- Gen.byte(Range.linear(0, Byte.MaxValue)).list(Range.linear(1, 10)).log("ns1")
+      ns2      <- Gen.int(Range.linear(0, Int.MaxValue)).list(Range.singleton(ns1.length)).log("ns2")
+      map      <- Gen.constant(ns1.zip(ns2).toMap).log("map")
+      expected <- Gen.constant(map.map { case (key, value) => NonNegByte.unsafeFrom(key) -> value }).log("expected")
+    } yield {
+      val input  = Json.fromFields(map.map { case (key, value) => key.toString -> value.asJson })
+      val actual = decode[Map[NonNegByte, Int]](input.noSpaces)
+
+      actual ==== expected.asRight
     }
 
   //
@@ -548,6 +1023,37 @@ trait numericSpec {
       actual ==== expected
     }
 
+  def testKeyEncoderPosByte: Property =
+    for {
+      ns1   <- Gen.byte(Range.linear(1, Byte.MaxValue)).list(Range.linear(1, 10)).log("ns1")
+      ns2   <- Gen.int(Range.linear(0, Int.MaxValue)).list(Range.singleton(ns1.length)).log("ns2")
+      map   <- Gen.constant(ns1.zip(ns2).toMap).log("map")
+      input <- Gen.constant(map.map { case (key, value) => PosByte.unsafeFrom(key) -> value }).log("input")
+    } yield {
+      val expected = Json.fromFields(map.map { case (key, value) => key.toString -> value.asJson })
+
+      val actual = input.asJson
+      Result.all(
+        List(
+          actual ==== expected,
+          actual.noSpacesSortKeys ==== expected.noSpacesSortKeys,
+        )
+      )
+    }
+
+  def testKeyDecoderPosByte: Property =
+    for {
+      ns1      <- Gen.byte(Range.linear(1, Byte.MaxValue)).list(Range.linear(1, 10)).log("ns1")
+      ns2      <- Gen.int(Range.linear(0, Int.MaxValue)).list(Range.singleton(ns1.length)).log("ns2")
+      map      <- Gen.constant(ns1.zip(ns2).toMap).log("map")
+      expected <- Gen.constant(map.map { case (key, value) => PosByte.unsafeFrom(key) -> value }).log("expected")
+    } yield {
+      val input  = Json.fromFields(map.map { case (key, value) => key.toString -> value.asJson })
+      val actual = decode[Map[PosByte, Int]](input.noSpaces)
+
+      actual ==== expected.asRight
+    }
+
   //
 
   def testEncoderNonPosByte: Property =
@@ -575,6 +1081,37 @@ trait numericSpec {
       val expected = NonPosByte.from(n)
       val actual   = decode[NonPosByte](input.noSpaces)
       actual ==== expected
+    }
+
+  def testKeyEncoderNonPosByte: Property =
+    for {
+      ns1   <- Gen.byte(Range.linear(0, Byte.MinValue)).list(Range.linear(1, 10)).log("ns1")
+      ns2   <- Gen.int(Range.linear(0, Int.MaxValue)).list(Range.singleton(ns1.length)).log("ns2")
+      map   <- Gen.constant(ns1.zip(ns2).toMap).log("map")
+      input <- Gen.constant(map.map { case (key, value) => NonPosByte.unsafeFrom(key) -> value }).log("input")
+    } yield {
+      val expected = Json.fromFields(map.map { case (key, value) => key.toString -> value.asJson })
+
+      val actual = input.asJson
+      Result.all(
+        List(
+          actual ==== expected,
+          actual.noSpacesSortKeys ==== expected.noSpacesSortKeys,
+        )
+      )
+    }
+
+  def testKeyDecoderNonPosByte: Property =
+    for {
+      ns1      <- Gen.byte(Range.linear(0, Byte.MinValue)).list(Range.linear(1, 10)).log("ns1")
+      ns2      <- Gen.int(Range.linear(0, Int.MaxValue)).list(Range.singleton(ns1.length)).log("ns2")
+      map      <- Gen.constant(ns1.zip(ns2).toMap).log("map")
+      expected <- Gen.constant(map.map { case (key, value) => NonPosByte.unsafeFrom(key) -> value }).log("expected")
+    } yield {
+      val input  = Json.fromFields(map.map { case (key, value) => key.toString -> value.asJson })
+      val actual = decode[Map[NonPosByte, Int]](input.noSpaces)
+
+      actual ==== expected.asRight
     }
 
   //
@@ -838,6 +1375,38 @@ trait numericSpec {
       actual ==== expected
     }
 
+  def testKeyEncoderNegBigInt: Property =
+    for {
+      ns1   <- Gen.long(Range.linear(-1L, Long.MinValue)).list(Range.linear(1, 10)).log("ns1")
+      ns2   <- Gen.int(Range.linear(0, Int.MaxValue)).list(Range.singleton(ns1.length)).log("ns2")
+      map   <- Gen.constant(ns1.zip(ns2).toMap).log("map")
+      input <- Gen.constant(map.map { case (key, value) => NegBigInt.unsafeFrom(key) -> value }).log("input")
+    } yield {
+      val expected = Json.fromFields(map.map { case (key, value) => key.toString -> value.asJson })
+
+      val actual = input.asJson
+      Result.all(
+        List(
+          actual ==== expected,
+          actual.noSpacesSortKeys ==== expected.noSpacesSortKeys,
+        )
+      )
+    }
+
+  @SuppressWarnings(Array("org.wartremover.warts.ToString"))
+  def testKeyDecoderNegBigInt: Property =
+    for {
+      ns1      <- Gen.long(Range.linear(-1L, Long.MinValue)).map(BigInt(_)).list(Range.linear(1, 10)).log("ns1")
+      ns2      <- Gen.int(Range.linear(0, Int.MaxValue)).list(Range.singleton(ns1.length)).log("ns2")
+      map      <- Gen.constant(ns1.zip(ns2).toMap).log("map")
+      expected <- Gen.constant(map.map { case (key, value) => NegBigInt.unsafeFrom(key) -> value }).log("expected")
+    } yield {
+      val input  = Json.fromFields(map.map { case (key, value) => key.toString -> value.asJson })
+      val actual = decode[Map[NegBigInt, Int]](input.noSpaces)
+
+      actual ==== expected.asRight
+    }
+
   //
 
   def testEncoderNonNegBigInt: Property =
@@ -865,6 +1434,39 @@ trait numericSpec {
       val expected = NonNegBigInt.from(n)
       val actual   = decode[NonNegBigInt](input.noSpaces)
       actual ==== expected
+    }
+
+  @SuppressWarnings(Array("org.wartremover.warts.ToString"))
+  def testKeyEncoderNonNegBigInt: Property =
+    for {
+      ns1   <- Gen.long(Range.linear(0L, Long.MaxValue)).map(BigInt(_)).list(Range.linear(1, 10)).log("ns1")
+      ns2   <- Gen.int(Range.linear(0, Int.MaxValue)).list(Range.singleton(ns1.length)).log("ns2")
+      map   <- Gen.constant(ns1.zip(ns2).toMap).log("map")
+      input <- Gen.constant(map.map { case (key, value) => NonNegBigInt.unsafeFrom(key) -> value }).log("input")
+    } yield {
+      val expected = Json.fromFields(map.map { case (key, value) => key.toString -> value.asJson })
+
+      val actual = input.asJson
+      Result.all(
+        List(
+          actual ==== expected,
+          actual.noSpacesSortKeys ==== expected.noSpacesSortKeys,
+        )
+      )
+    }
+
+  @SuppressWarnings(Array("org.wartremover.warts.ToString"))
+  def testKeyDecoderNonNegBigInt: Property =
+    for {
+      ns1      <- Gen.long(Range.linear(0L, Long.MaxValue)).map(BigInt(_)).list(Range.linear(1, 10)).log("ns1")
+      ns2      <- Gen.int(Range.linear(0, Int.MaxValue)).list(Range.singleton(ns1.length)).log("ns2")
+      map      <- Gen.constant(ns1.zip(ns2).toMap).log("map")
+      expected <- Gen.constant(map.map { case (key, value) => NonNegBigInt.unsafeFrom(key) -> value }).log("expected")
+    } yield {
+      val input  = Json.fromFields(map.map { case (key, value) => key.toString -> value.asJson })
+      val actual = decode[Map[NonNegBigInt, Int]](input.noSpaces)
+
+      actual ==== expected.asRight
     }
 
   //
@@ -896,6 +1498,39 @@ trait numericSpec {
       actual ==== expected
     }
 
+  @SuppressWarnings(Array("org.wartremover.warts.ToString"))
+  def testKeyEncoderPosBigInt: Property =
+    for {
+      ns1   <- Gen.long(Range.linear(1L, Long.MaxValue)).map(BigInt(_)).list(Range.linear(1, 10)).log("ns1")
+      ns2   <- Gen.int(Range.linear(0, Int.MaxValue)).list(Range.singleton(ns1.length)).log("ns2")
+      map   <- Gen.constant(ns1.zip(ns2).toMap).log("map")
+      input <- Gen.constant(map.map { case (key, value) => PosBigInt.unsafeFrom(key) -> value }).log("input")
+    } yield {
+      val expected = Json.fromFields(map.map { case (key, value) => key.toString -> value.asJson })
+
+      val actual = input.asJson
+      Result.all(
+        List(
+          actual ==== expected,
+          actual.noSpacesSortKeys ==== expected.noSpacesSortKeys,
+        )
+      )
+    }
+
+  @SuppressWarnings(Array("org.wartremover.warts.ToString"))
+  def testKeyDecoderPosBigInt: Property =
+    for {
+      ns1      <- Gen.long(Range.linear(1L, Long.MaxValue)).map(BigInt(_)).list(Range.linear(1, 10)).log("ns1")
+      ns2      <- Gen.int(Range.linear(0, Int.MaxValue)).list(Range.singleton(ns1.length)).log("ns2")
+      map      <- Gen.constant(ns1.zip(ns2).toMap).log("map")
+      expected <- Gen.constant(map.map { case (key, value) => PosBigInt.unsafeFrom(key) -> value }).log("expected")
+    } yield {
+      val input  = Json.fromFields(map.map { case (key, value) => key.toString -> value.asJson })
+      val actual = decode[Map[PosBigInt, Int]](input.noSpaces)
+
+      actual ==== expected.asRight
+    }
+
   //
 
   def testEncoderNonPosBigInt: Property =
@@ -923,6 +1558,39 @@ trait numericSpec {
       val expected = NonPosBigInt.from(n)
       val actual   = decode[NonPosBigInt](input.noSpaces)
       actual ==== expected
+    }
+
+  @SuppressWarnings(Array("org.wartremover.warts.ToString"))
+  def testKeyEncoderNonPosBigInt: Property =
+    for {
+      ns1   <- Gen.long(Range.linear(0L, Long.MinValue)).map(BigInt(_)).list(Range.linear(1, 10)).log("ns1")
+      ns2   <- Gen.int(Range.linear(0, Int.MaxValue)).list(Range.singleton(ns1.length)).log("ns2")
+      map   <- Gen.constant(ns1.zip(ns2).toMap).log("map")
+      input <- Gen.constant(map.map { case (key, value) => NonPosBigInt.unsafeFrom(key) -> value }).log("input")
+    } yield {
+      val expected = Json.fromFields(map.map { case (key, value) => key.toString -> value.asJson })
+
+      val actual = input.asJson
+      Result.all(
+        List(
+          actual ==== expected,
+          actual.noSpacesSortKeys ==== expected.noSpacesSortKeys,
+        )
+      )
+    }
+
+  @SuppressWarnings(Array("org.wartremover.warts.ToString"))
+  def testKeyDecoderNonPosBigInt: Property =
+    for {
+      ns1      <- Gen.long(Range.linear(0L, Long.MinValue)).map(BigInt(_)).list(Range.linear(1, 10)).log("ns1")
+      ns2      <- Gen.int(Range.linear(0, Int.MaxValue)).list(Range.singleton(ns1.length)).log("ns2")
+      map      <- Gen.constant(ns1.zip(ns2).toMap).log("map")
+      expected <- Gen.constant(map.map { case (key, value) => NonPosBigInt.unsafeFrom(key) -> value }).log("expected")
+    } yield {
+      val input  = Json.fromFields(map.map { case (key, value) => key.toString -> value.asJson })
+      val actual = decode[Map[NonPosBigInt, Int]](input.noSpaces)
+
+      actual ==== expected.asRight
     }
 
   //

--- a/modules/refined4s-circe/shared/src/test/scala/refined4s/modules/circe/derivation/types/stringsSpec.scala
+++ b/modules/refined4s-circe/shared/src/test/scala/refined4s/modules/circe/derivation/types/stringsSpec.scala
@@ -1,5 +1,6 @@
 package refined4s.modules.circe.derivation.types
 
+import cats.syntax.all.*
 import hedgehog.*
 import hedgehog.runner.*
 import io.circe.*
@@ -21,12 +22,18 @@ trait stringsSpec {
   def allTests: List[Test] = List(
     property("test Encoder[NonEmptyString]", testEncoderNonEmptyString),
     property("test Decoder[NonEmptyString]", testDecoderNonEmptyString),
+    property("test KeyEncoder[NonEmptyString]", testKeyEncoderNonEmptyString),
+    property("test KeyDecoder[NonEmptyString]", testKeyDecoderNonEmptyString),
     //
     property("test Encoder[NonBlankString]", testEncoderNonBlankString),
     property("test Decoder[NonBlankString]", testDecoderNonBlankString),
+    property("test KeyEncoder[NonBlankString]", testKeyEncoderNonBlankString),
+    property("test KeyDecoder[NonBlankString]", testKeyDecoderNonBlankString),
     //
     property("test Encoder[Uuid]", testEncoderUuid),
     property("test Decoder[Uuid]", testDecoderUuid),
+    property("test KeyEncoder[Uuid]", testKeyEncoderUuid),
+    property("test KeyDecoder[Uuid]", testKeyDecoderUuid),
     //
   )
 
@@ -57,6 +64,38 @@ trait stringsSpec {
       val actual   = decode[NonEmptyString](input.noSpaces)
 
       actual ==== expected
+    }
+
+  def testKeyEncoderNonEmptyString: Property =
+    for {
+      ss    <- Gen.string(Gen.unicode, Range.linear(1, 10)).list(Range.linear(1, 10)).log("ss")
+      ns2   <- Gen.int(Range.linear(0, Int.MaxValue)).list(Range.singleton(ss.length)).log("ns2")
+      map   <- Gen.constant(ss.zip(ns2).toMap).log("map")
+      input <- Gen.constant(map.map { case (key, value) => NonEmptyString.unsafeFrom(key) -> value }).log("input")
+    } yield {
+      val expected = Json.fromFields(map.map { case (key, value) => key -> value.asJson })
+
+      val actual = input.asJson
+
+      Result.all(
+        List(
+          actual ==== expected,
+          actual.noSpaces ==== expected.noSpaces,
+        )
+      )
+    }
+
+  def testKeyDecoderNonEmptyString: Property =
+    for {
+      ss       <- Gen.string(Gen.unicode, Range.linear(1, 10)).list(Range.linear(1, 10)).log("ss")
+      ns2      <- Gen.int(Range.linear(0, Int.MaxValue)).list(Range.singleton(ss.length)).log("ns2")
+      map      <- Gen.constant(ss.zip(ns2).toMap).log("map")
+      expected <- Gen.constant(map.map { case (key, value) => NonEmptyString.unsafeFrom(key) -> value }).log("expected")
+    } yield {
+      val input  = Json.fromFields(map.map { case (key, value) => key -> value.asJson })
+      val actual = decode[Map[NonEmptyString, Int]](input.noSpaces)
+
+      actual ==== expected.asRight
     }
 
   //
@@ -106,6 +145,60 @@ trait stringsSpec {
       actual ==== expected
     }
 
+  def testKeyEncoderNonBlankString: Property =
+    for {
+      nonWhitespaceString <- Gen.string(hedgehog.extra.Gens.genNonWhitespaceChar, Range.linear(1, 10)).log("nonWhitespaceString")
+      whitespaceString    <- Gen
+                               .string(
+                                 hedgehog.extra.Gens.genCharByRange(refined4s.types.strings.WhitespaceCharRange),
+                                 Range.linear(1, 10),
+                               )
+                               .log("whitespaceString")
+
+      ss    <- Gen
+                 .constant(scala.util.Random.shuffle((nonWhitespaceString + whitespaceString).toList).mkString)
+                 .list(Range.linear(1, 10))
+                 .log("ss")
+      ns2   <- Gen.int(Range.linear(0, Int.MaxValue)).list(Range.singleton(ss.length)).log("ns2")
+      map   <- Gen.constant(ss.zip(ns2).toMap).log("map")
+      input <- Gen.constant(map.map { case (key, value) => NonBlankString.unsafeFrom(key) -> value }).log("input")
+    } yield {
+      val expected = Json.fromFields(map.map { case (key, value) => key -> value.asJson })
+
+      val actual = input.asJson
+
+      Result.all(
+        List(
+          actual ==== expected,
+          actual.noSpaces ==== expected.noSpaces,
+        )
+      )
+    }
+
+  def testKeyDecoderNonBlankString: Property =
+    for {
+      nonWhitespaceString <- Gen.string(hedgehog.extra.Gens.genNonWhitespaceChar, Range.linear(1, 10)).log("nonWhitespaceString")
+      whitespaceString    <- Gen
+                               .string(
+                                 hedgehog.extra.Gens.genCharByRange(refined4s.types.strings.WhitespaceCharRange),
+                                 Range.linear(1, 10),
+                               )
+                               .log("whitespaceString")
+
+      ss       <- Gen
+                    .constant(scala.util.Random.shuffle((nonWhitespaceString + whitespaceString).toList).mkString)
+                    .list(Range.linear(1, 10))
+                    .log("ss")
+      ns2      <- Gen.int(Range.linear(0, Int.MaxValue)).list(Range.singleton(ss.length)).log("ns2")
+      map      <- Gen.constant(ss.zip(ns2).toMap).log("map")
+      expected <- Gen.constant(map.map { case (key, value) => NonBlankString.unsafeFrom(key) -> value }).log("expected")
+    } yield {
+      val input  = Json.fromFields(map.map { case (key, value) => key -> value.asJson })
+      val actual = decode[Map[NonBlankString, Int]](input.noSpaces)
+
+      actual ==== expected.asRight
+    }
+
   //
 
   @SuppressWarnings(Array("org.wartremover.warts.ToString"))
@@ -139,6 +232,40 @@ trait stringsSpec {
       val actual   = decode[Uuid](input.noSpaces)
 
       actual ==== expected
+    }
+
+  @SuppressWarnings(Array("org.wartremover.warts.ToString"))
+  def testKeyEncoderUuid: Property =
+    for {
+      uuids <- Gen.constant(UUID.randomUUID()).list(Range.linear(1, 10)).log("uuids")
+      ns2   <- Gen.int(Range.linear(0, Int.MaxValue)).list(Range.singleton(uuids.length)).log("ns2")
+      map   <- Gen.constant(uuids.zip(ns2).toMap).log("map")
+      input <- Gen.constant(map.map { case (key, value) => Uuid(key) -> value }).log("input")
+    } yield {
+      val expected = Json.fromFields(map.map { case (key, value) => key.toString -> value.asJson })
+
+      val actual = input.asJson
+
+      Result.all(
+        List(
+          actual ==== expected,
+          actual.noSpaces ==== expected.noSpaces,
+        )
+      )
+    }
+
+  @SuppressWarnings(Array("org.wartremover.warts.ToString"))
+  def testKeyDecoderUuid: Property =
+    for {
+      uuids    <- Gen.constant(UUID.randomUUID()).list(Range.linear(1, 10)).log("uuids")
+      ns2      <- Gen.int(Range.linear(0, Int.MaxValue)).list(Range.singleton(uuids.length)).log("ns2")
+      map      <- Gen.constant(uuids.zip(ns2).toMap).log("map")
+      expected <- Gen.constant(map.map { case (key, value) => Uuid(key) -> value }).log("expected")
+    } yield {
+      val input  = Json.fromFields(map.map { case (key, value) => key.toString -> value.asJson })
+      val actual = decode[Map[Uuid, Int]](input.noSpaces)
+
+      actual ==== expected.asRight
     }
 
   //


### PR DESCRIPTION
Close #361 - [`refined4s-circe`] Add `KeyEncoder` and `KeyDecoder` for pre-defined refined types