### PR TITLE
Close #372 - Update sbt plugins

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -29,7 +29,7 @@ ThisBuild / licenses := props.licenses
 
 ThisBuild / resolvers += props.SonatypeSnapshots
 
-ThisBuild / scalafixDependencies += "com.github.xuwei-k" %% "scalafix-rules" % "0.3.0"
+ThisBuild / scalafixDependencies += "com.github.xuwei-k" %% "scalafix-rules" % "0.4.5"
 
 ThisBuild / scalafixConfig := (
   if (scalaVersion.value.startsWith("3"))
@@ -37,20 +37,6 @@ ThisBuild / scalafixConfig := (
   else
     ((ThisBuild / baseDirectory).value / ".scalafix-scala2.conf").some
 )
-
-ThisBuild / scalafixScalaBinaryVersion := {
-  val log        = sLog.value
-  val newVersion = if (scalaVersion.value.startsWith("3")) {
-    (ThisBuild / scalafixScalaBinaryVersion).value
-  } else {
-    CrossVersion.binaryScalaVersion(scalaVersion.value)
-  }
-
-  log.info(
-    s">> Change ThisBuild / scalafixScalaBinaryVersion from ${(ThisBuild / scalafixScalaBinaryVersion).value} to $newVersion"
-  )
-  newVersion
-}
 
 lazy val refined4s = (project in file("."))
   .enablePlugins(DevOopsGitHubReleasePlugin)
@@ -229,7 +215,7 @@ lazy val docs = (project in file("docs-gen-tmp/docs"))
   .settings(
     scalaVersion := props.Scala3Version,
     name := prefixedProjectName("docs"),
-    scalacOptions ~= (ops => ops.filter(_ != "-Wunused:imports")),
+    scalacOptions ~= (ops => ops.filter(op => !op.startsWith("-Wunused:imports") && op != "-Wnonunit-statement")),
     mdocIn := file("docs"),
     mdocOut := file("generated-docs/docs"),
     cleanFiles += file("generated-docs/docs"),

--- a/modules/refined4s-core/shared/src/test/scala/refined4s/InlinedRefinedSpec.scala
+++ b/modules/refined4s-core/shared/src/test/scala/refined4s/InlinedRefinedSpec.scala
@@ -63,7 +63,7 @@ object InlinedInlinedRefinedSpec extends Properties {
   def testUnsafeFromInvalid: Result = {
     val expected = "Invalid value: []. It has to be a non-empty String but got \"\""
     try {
-      MyType.unsafeFrom("")
+      val _ = MyType.unsafeFrom("")
       Result.failure.log("""IllegalArgumentException was expected from MyType.unsafeFrom(""), but it was not thrown.""")
     } catch {
       case ex: IllegalArgumentException =>

--- a/modules/refined4s-core/shared/src/test/scala/refined4s/InlinedRefinedType.scala
+++ b/modules/refined4s-core/shared/src/test/scala/refined4s/InlinedRefinedType.scala
@@ -14,7 +14,7 @@ object InlinedRefinedType {
       a.asTerm match {
         case Inlined(_, _, Literal(IntConstant(num))) =>
           try {
-            validate(num)
+            val _ = validate(num)
             Expr(true)
           } catch {
             case _: Throwable => Expr(false)
@@ -35,7 +35,7 @@ object InlinedRefinedType {
 
     override def predicate(a: Int): Boolean =
       try {
-        validate(a)
+        val _ = validate(a)
         true
       } catch {
         case _: Throwable => false

--- a/modules/refined4s-core/shared/src/test/scala/refined4s/RefinedSpec.scala
+++ b/modules/refined4s-core/shared/src/test/scala/refined4s/RefinedSpec.scala
@@ -62,7 +62,7 @@ object RefinedSpec extends Properties {
   def testUnsafeFromInvalid: Result = {
     val expected = "Invalid value: []. It has to be non-empty String but got \"\""
     try {
-      MyType.unsafeFrom("")
+      val _ = MyType.unsafeFrom("")
       Result.failure.log("""IllegalArgumentException was expected from MyType.unsafeFrom(""), but it was not thrown.""")
     } catch {
       case ex: IllegalArgumentException =>

--- a/modules/refined4s-core/shared/src/test/scala/refined4s/types/networkSpec.scala
+++ b/modules/refined4s-core/shared/src/test/scala/refined4s/types/networkSpec.scala
@@ -181,7 +181,7 @@ object networkSpec extends Properties {
       val expected = s"Invalid value: [$input]. It must be a URI String"
 
       try {
-        Uri.unsafeFrom(input)
+        val _ = Uri.unsafeFrom(input)
         Result
           .failure
           .log(
@@ -408,7 +408,7 @@ object networkSpec extends Properties {
       val expected = s"Invalid value: [$input]. It must be a URL String"
 
       try {
-        Url.unsafeFrom(input)
+        val _ = Url.unsafeFrom(input)
         Result
           .failure
           .log(
@@ -586,7 +586,7 @@ object networkSpec extends Properties {
       val expected = s"Invalid value: [$p]. It has to be Int between 0 and 65535 (0 <= PortNumber <= 65535)"
 
       try {
-        PortNumber.unsafeFrom(p)
+        val _ = PortNumber.unsafeFrom(p)
         Result
           .failure
           .log(
@@ -696,7 +696,7 @@ object networkSpec extends Properties {
       val expected = s"Invalid value: [$p]. It has to be Int between 0 and 1023 (0 <= SystemPortNumber <= 1023)"
 
       try {
-        SystemPortNumber.unsafeFrom(p)
+        val _ = SystemPortNumber.unsafeFrom(p)
         Result
           .failure
           .log(
@@ -807,7 +807,7 @@ object networkSpec extends Properties {
       val expected = s"Invalid value: [$p]. It has to be Int between 1024 and 65535 (1024 <= NonSystemPortNumber <= 65535)"
 
       try {
-        NonSystemPortNumber.unsafeFrom(p)
+        val _ = NonSystemPortNumber.unsafeFrom(p)
         Result
           .failure
           .log(
@@ -917,7 +917,7 @@ object networkSpec extends Properties {
       val expected = s"Invalid value: [$p]. It has to be Int between 1024 and 49151 (1024 <= UserPortNumber <= 49151)"
 
       try {
-        UserPortNumber.unsafeFrom(p)
+        val _ = UserPortNumber.unsafeFrom(p)
         Result
           .failure
           .log(
@@ -1027,7 +1027,7 @@ object networkSpec extends Properties {
       val expected = s"Invalid value: [$p]. It has to be Int between 49152 and 65535 (49152 <= DynamicPortNumber <= 65535)"
 
       try {
-        DynamicPortNumber.unsafeFrom(p)
+        val _ = DynamicPortNumber.unsafeFrom(p)
         Result
           .failure
           .log(

--- a/modules/refined4s-core/shared/src/test/scala/refined4s/types/numericSpec.scala
+++ b/modules/refined4s-core/shared/src/test/scala/refined4s/types/numericSpec.scala
@@ -77,7 +77,7 @@ object numericSpec extends Properties {
       } yield {
         val expected = s"Invalid value: [$n]. It must be a negative Int"
         try {
-          NegInt.unsafeFrom(n)
+          val _ = NegInt.unsafeFrom(n)
           Result
             .failure
             .log(
@@ -217,7 +217,7 @@ object numericSpec extends Properties {
       } yield {
         val expected = s"Invalid value: [$n]. It must be a non-negative Int"
         try {
-          NonNegInt.unsafeFrom(n)
+          val _ = NonNegInt.unsafeFrom(n)
           Result
             .failure
             .log(
@@ -357,7 +357,7 @@ object numericSpec extends Properties {
       } yield {
         val expected = s"Invalid value: [$n]. It must be a positive Int"
         try {
-          PosInt.unsafeFrom(n)
+          val _ = PosInt.unsafeFrom(n)
           Result
             .failure
             .log(
@@ -503,7 +503,7 @@ object numericSpec extends Properties {
       } yield {
         val expected = s"Invalid value: [$n]. It must be a non-positive Int"
         try {
-          NonPosInt.unsafeFrom(n)
+          val _ = NonPosInt.unsafeFrom(n)
           Result
             .failure
             .log(
@@ -642,7 +642,7 @@ object numericSpec extends Properties {
       } yield {
         val expected = s"Invalid value: [$n]. It must be a negative Long"
         try {
-          NegLong.unsafeFrom(n)
+          val _ = NegLong.unsafeFrom(n)
           Result
             .failure
             .log(
@@ -789,7 +789,7 @@ object numericSpec extends Properties {
       } yield {
         val expected = s"Invalid value: [$n]. It must be a non-negative Long"
         try {
-          NonNegLong.unsafeFrom(n)
+          val _ = NonNegLong.unsafeFrom(n)
           Result
             .failure
             .log(
@@ -929,7 +929,7 @@ object numericSpec extends Properties {
       } yield {
         val expected = s"Invalid value: [$n]. It must be a positive Long"
         try {
-          PosLong.unsafeFrom(n)
+          val _ = PosLong.unsafeFrom(n)
           Result
             .failure
             .log(
@@ -1076,7 +1076,7 @@ object numericSpec extends Properties {
       } yield {
         val expected = s"Invalid value: [$n]. It must be a non-positive Long"
         try {
-          NonPosLong.unsafeFrom(n)
+          val _ = NonPosLong.unsafeFrom(n)
           Result
             .failure
             .log(
@@ -1216,7 +1216,7 @@ object numericSpec extends Properties {
       } yield {
         val expected = s"Invalid value: [$n]. It must be a negative Short"
         try {
-          NegShort.unsafeFrom(n)
+          val _ = NegShort.unsafeFrom(n)
           Result
             .failure
             .log(
@@ -1356,7 +1356,7 @@ object numericSpec extends Properties {
       } yield {
         val expected = s"Invalid value: [$n]. It must be a non-negative Short"
         try {
-          NonNegShort.unsafeFrom(n)
+          val _ = NonNegShort.unsafeFrom(n)
           Result
             .failure
             .log(
@@ -1496,7 +1496,7 @@ object numericSpec extends Properties {
       } yield {
         val expected = s"Invalid value: [$n]. It must be a positive Short"
         try {
-          PosShort.unsafeFrom(n)
+          val _ = PosShort.unsafeFrom(n)
           Result
             .failure
             .log(
@@ -1643,7 +1643,7 @@ object numericSpec extends Properties {
       } yield {
         val expected = s"Invalid value: [$n]. It must be a non-positive Short"
         try {
-          NonPosShort.unsafeFrom(n)
+          val _ = NonPosShort.unsafeFrom(n)
           Result
             .failure
             .log(
@@ -1783,7 +1783,7 @@ object numericSpec extends Properties {
       } yield {
         val expected = s"Invalid value: [$n]. It must be a negative Byte"
         try {
-          NegByte.unsafeFrom(n)
+          val _ = NegByte.unsafeFrom(n)
           Result
             .failure
             .log(
@@ -1923,7 +1923,7 @@ object numericSpec extends Properties {
       } yield {
         val expected = s"Invalid value: [$n]. It must be a non-negative Byte"
         try {
-          NonNegByte.unsafeFrom(n)
+          val _ = NonNegByte.unsafeFrom(n)
           Result
             .failure
             .log(
@@ -2063,7 +2063,7 @@ object numericSpec extends Properties {
       } yield {
         val expected = s"Invalid value: [$n]. It must be a positive Byte"
         try {
-          PosByte.unsafeFrom(n)
+          val _ = PosByte.unsafeFrom(n)
           Result
             .failure
             .log(
@@ -2210,7 +2210,7 @@ object numericSpec extends Properties {
       } yield {
         val expected = s"Invalid value: [$n]. It must be a non-positive Byte"
         try {
-          NonPosByte.unsafeFrom(n)
+          val _ = NonPosByte.unsafeFrom(n)
           Result
             .failure
             .log(
@@ -2350,7 +2350,7 @@ object numericSpec extends Properties {
       } yield {
         val expected = s"Invalid value: [$n]. It must be a negative Float"
         try {
-          NegFloat.unsafeFrom(n)
+          val _ = NegFloat.unsafeFrom(n)
           Result
             .failure
             .log(
@@ -2490,7 +2490,7 @@ object numericSpec extends Properties {
       } yield {
         val expected = s"Invalid value: [$n]. It must be a non-negative Float"
         try {
-          NonNegFloat.unsafeFrom(n)
+          val _ = NonNegFloat.unsafeFrom(n)
           Result
             .failure
             .log(
@@ -2630,7 +2630,7 @@ object numericSpec extends Properties {
       } yield {
         val expected = s"Invalid value: [$n]. It must be a positive Float"
         try {
-          PosFloat.unsafeFrom(n)
+          val _ = PosFloat.unsafeFrom(n)
           Result
             .failure
             .log(
@@ -2779,7 +2779,7 @@ object numericSpec extends Properties {
       } yield {
         val expected = s"Invalid value: [$n]. It must be a non-positive Float"
         try {
-          NonPosFloat.unsafeFrom(n)
+          val _ = NonPosFloat.unsafeFrom(n)
           Result
             .failure
             .log(
@@ -2919,7 +2919,7 @@ object numericSpec extends Properties {
       } yield {
         val expected = s"Invalid value: [$n]. It must be a negative Double"
         try {
-          NegDouble.unsafeFrom(n)
+          val _ = NegDouble.unsafeFrom(n)
           Result
             .failure
             .log(
@@ -3059,7 +3059,7 @@ object numericSpec extends Properties {
       } yield {
         val expected = s"Invalid value: [$n]. It must be a non-negative Double"
         try {
-          NonNegDouble.unsafeFrom(n)
+          val _ = NonNegDouble.unsafeFrom(n)
           Result
             .failure
             .log(
@@ -3199,7 +3199,7 @@ object numericSpec extends Properties {
       } yield {
         val expected = s"Invalid value: [$n]. It must be a positive Double"
         try {
-          PosDouble.unsafeFrom(n)
+          val _ = PosDouble.unsafeFrom(n)
           Result
             .failure
             .log(
@@ -3348,7 +3348,7 @@ object numericSpec extends Properties {
       } yield {
         val expected = s"Invalid value: [$n]. It must be a non-positive Double"
         try {
-          NonPosDouble.unsafeFrom(n)
+          val _ = NonPosDouble.unsafeFrom(n)
           Result
             .failure
             .log(
@@ -3536,7 +3536,7 @@ object numericSpec extends Properties {
       } yield {
         val expected = s"Invalid value: [$n]. It must be a negative BigInt"
         try {
-          NegBigInt.unsafeFrom(n)
+          val _ = NegBigInt.unsafeFrom(n)
           Result
             .failure
             .log(
@@ -3697,7 +3697,7 @@ object numericSpec extends Properties {
       } yield {
         val expected = s"Invalid value: [$n]. It must be a non-negative BigInt"
         try {
-          NonNegBigInt.unsafeFrom(n)
+          val _ = NonNegBigInt.unsafeFrom(n)
           Result
             .failure
             .log(
@@ -3858,7 +3858,7 @@ object numericSpec extends Properties {
       } yield {
         val expected = s"Invalid value: [$n]. It must be a positive BigInt"
         try {
-          PosBigInt.unsafeFrom(n)
+          val _ = PosBigInt.unsafeFrom(n)
           Result
             .failure
             .log(
@@ -4019,7 +4019,7 @@ object numericSpec extends Properties {
       } yield {
         val expected = s"Invalid value: [$n]. It must be a non-positive BigInt"
         try {
-          NonPosBigInt.unsafeFrom(n)
+          val _ = NonPosBigInt.unsafeFrom(n)
           Result
             .failure
             .log(
@@ -4205,7 +4205,7 @@ object numericSpec extends Properties {
       } yield {
         val expected = s"Invalid value: [$n]. It must be a negative BigDecimal"
         try {
-          NegBigDecimal.unsafeFrom(n)
+          val _ = NegBigDecimal.unsafeFrom(n)
           Result
             .failure
             .log(
@@ -4390,7 +4390,7 @@ object numericSpec extends Properties {
       } yield {
         val expected = s"Invalid value: [$n]. It must be a non-negative BigDecimal"
         try {
-          NonNegBigDecimal.unsafeFrom(n)
+          val _ = NonNegBigDecimal.unsafeFrom(n)
           Result
             .failure
             .log(
@@ -4575,7 +4575,7 @@ object numericSpec extends Properties {
       } yield {
         val expected = s"Invalid value: [$n]. It must be a positive BigDecimal"
         try {
-          PosBigDecimal.unsafeFrom(n)
+          val _ = PosBigDecimal.unsafeFrom(n)
           Result
             .failure
             .log(
@@ -4760,7 +4760,7 @@ object numericSpec extends Properties {
       } yield {
         val expected = s"Invalid value: [$n]. It must be a non-positive BigDecimal"
         try {
-          NonPosBigDecimal.unsafeFrom(n)
+          val _ = NonPosBigDecimal.unsafeFrom(n)
           Result
             .failure
             .log(

--- a/modules/refined4s-core/shared/src/test/scala/refined4s/types/stringsSpec.scala
+++ b/modules/refined4s-core/shared/src/test/scala/refined4s/types/stringsSpec.scala
@@ -62,7 +62,7 @@ object stringsSpec extends Properties {
     def testUnsafeFromInvalid: Result = {
       val expected = "Invalid value: []. It must be a non-empty String"
       try {
-        NonEmptyString.unsafeFrom("")
+        val _ = NonEmptyString.unsafeFrom("")
         Result
           .failure
           .log("""IllegalArgumentException was expected from NonEmptyString.unsafeFrom(""), but it was not thrown.""")
@@ -309,7 +309,7 @@ object stringsSpec extends Properties {
           s"Invalid value: [$s], unicode=[${s.map(c => "\\u%04x".format(c.toInt)).mkString}]. " +
             "It must be not all whitespace non-empty String"
         try {
-          NonBlankString.unsafeFrom(s)
+          val _ = NonBlankString.unsafeFrom(s)
           Result
             .failure
             .log("""IllegalArgumentException was expected from NonBlankString.unsafeFrom(""), but it was not thrown.""")
@@ -587,7 +587,7 @@ object stringsSpec extends Properties {
     def testUnsafeFromInvalid: Result = {
       val expected = "Invalid value: [blah]. It must be UUID"
       try {
-        Uuid.unsafeFrom("blah")
+        val _ = Uuid.unsafeFrom("blah")
         Result
           .failure
           .log("""IllegalArgumentException was expected from Uuid.unsafeFrom("blah"), but it was not thrown.""")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,12 +1,12 @@
-addSbtPlugin("com.github.sbt" % "sbt-ci-release" % "1.5.10")
+addSbtPlugin("com.github.sbt" % "sbt-ci-release" % "1.6.1")
 
-addSbtPlugin("org.wartremover" % "sbt-wartremover" % "3.1.6")
+addSbtPlugin("org.wartremover" % "sbt-wartremover" % "3.2.0")
 
-addSbtPlugin("ch.epfl.scala" % "sbt-scalafix"  % "0.11.0")
-addSbtPlugin("org.scalameta" % "sbt-scalafmt"  % "2.5.0")
-addSbtPlugin("org.scoverage" % "sbt-scoverage" % "2.0.7")
-addSbtPlugin("org.scalameta" % "sbt-mdoc"      % "2.3.7")
-addSbtPlugin("io.kevinlee"   % "sbt-docusaur"  % "0.15.0")
+addSbtPlugin("ch.epfl.scala" % "sbt-scalafix"  % "0.12.1")
+addSbtPlugin("org.scalameta" % "sbt-scalafmt"  % "2.5.2")
+addSbtPlugin("org.scoverage" % "sbt-scoverage" % "2.1.1")
+addSbtPlugin("org.scalameta" % "sbt-mdoc"      % "2.5.4")
+addSbtPlugin("io.kevinlee"   % "sbt-docusaur"  % "0.16.0")
 
 addSbtPlugin("org.scala-js"       % "sbt-scalajs"              % "1.16.0")
 addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject" % "1.3.2")
@@ -18,4 +18,4 @@ addSbtPlugin("io.kevinlee" % "sbt-devoops-github"    % sbtDevOopsVersion)
 
 addSbtPlugin("io.kevinlee" % "sbt-devoops-starter" % sbtDevOopsVersion)
 
-addSbtPlugin("org.typelevel" % "sbt-tpolecat" % "0.5.0")
+addSbtPlugin("org.typelevel" % "sbt-tpolecat" % "0.5.2")


### PR DESCRIPTION
Close #372 - Update sbt plugins
* `sbt-ci-release` to `1.6.1`
* `sbt-wartremover` to `3.2.0`
* `sbt-scalafix` to `0.12.1`
* `sbt-scalafmt` to `2.5.2`
* `sbt-scoverage` to `2.1.1`
* `sbt-mdoc` to `2.5.4`
* `sbt-docusaur` to `0.16.0`
* `sbt-tpolecat` to `0.5.2`
* `com.github.xuwei-k:scalafix-rules` to `0.4.5`