### PR TITLE
refined4s v0.19.0

### DIFF
--- a/changelogs/0.19.0.md
+++ b/changelogs/0.19.0.md
@@ -1,0 +1,58 @@
+## [0.19.0](https://github.com/kevin-lee/refined4s/issues?q=is%3Aissue+is%3Aclosed+-label%3Ainvalid+-label%3Awontfix+milestone%3Am19) - 2024-09-01
+
+
+### New Features
+
+* [`refined4s-circe`] Add `KeyEncoder`, `KeyDecoder` and `KeyCodec` for `Newtype` and `Refined` (#355)
+***
+
+* [`refined4s-core`] Add `toUrl` to `Uri`, and add `toUri` to `toUrl` (#356)
+
+  ```scala 3
+  Uri("https://www.google.com").toUrl
+  // Url("https://www.google.com")
+  
+  Url("https://www.google.com").toUri
+  // Uri("https://www.google.com")
+  ```
+***
+
+* [`refined4s-core`] Add `toURL` to `Uri`, and add `toURI` to `toUrl` (#358)
+
+  ```scala 3
+  Uri("https://www.google.com").toURL
+  // java.net.URL("https://www.google.com")
+  
+  Url("https://www.google.com").toURI
+  // java.net.URI("https://www.google.com")
+  ```
+***
+
+* [`refined4s-circe`] Add `KeyEncoder` and `KeyDecoder` for pre-defined refined types (#361)
+***
+
+* [`refined4s-circe`] Add `KeyEncoder` and `KeyDecoder` to `refined4s.modules.circe.derivation.generic.auto` (#369)
+***
+
+* Update sbt plugins (#372)
+
+  * `sbt-ci-release` to `1.6.1`
+  * `sbt-wartremover` to `3.2.0`
+  * `sbt-scalafix` to `0.12.1`
+  * `sbt-scalafmt` to `2.5.2`
+  * `sbt-scoverage` to `2.1.1`
+  * `sbt-mdoc` to `2.5.4`
+  * `sbt-docusaur` to `0.16.0`
+  * `sbt-tpolecat` to `0.5.2`
+  * `com.github.xuwei-k:scalafix-rules` to `0.4.5`
+***
+
+* Update GitHub Actions: Update `javaOptions` (#376)
+  ```yml
+  env:
+    GH_SBT_OPTS: "-Xss64m -Xms1024m -Xmx8G -XX:MaxMetaspaceSize=2G -XX:-UseGCOverheadLimit -XX:MaxInlineLevel=18 -XX:+UnlockExperimentalVMOptions"
+    GH_JVM_OPTS: "-Xss64m -Xms1024m -Xmx8G -XX:MaxMetaspaceSize=2G -XX:-UseGCOverheadLimit -XX:MaxInlineLevel=18 -XX:+UnlockExperimentalVMOptions -XX:+UseJVMCICompiler"
+  ```
+***
+
+* [`refined4s-refined-compat-scala2`] Bump Scala `2.12` to `2.12.16` (#379)


### PR DESCRIPTION
# refined4s v0.19.0
## [0.19.0](https://github.com/kevin-lee/refined4s/issues?q=is%3Aissue+is%3Aclosed+-label%3Ainvalid+-label%3Awontfix+milestone%3Am19) - 2024-09-01


### New Features

* [`refined4s-circe`] Add `KeyEncoder`, `KeyDecoder` and `KeyCodec` for `Newtype` and `Refined` (#355)
***

* [`refined4s-core`] Add `toUrl` to `Uri`, and add `toUri` to `toUrl` (#356)

  ```scala 3
  Uri("https://www.google.com").toUrl
  // Url("https://www.google.com")
  
  Url("https://www.google.com").toUri
  // Uri("https://www.google.com")
  ```
***

* [`refined4s-core`] Add `toURL` to `Uri`, and add `toURI` to `toUrl` (#358)

  ```scala 3
  Uri("https://www.google.com").toURL
  // java.net.URL("https://www.google.com")
  
  Url("https://www.google.com").toURI
  // java.net.URI("https://www.google.com")
  ```
***

* [`refined4s-circe`] Add `KeyEncoder` and `KeyDecoder` for pre-defined refined types (#361)
***

* [`refined4s-circe`] Add `KeyEncoder` and `KeyDecoder` to `refined4s.modules.circe.derivation.generic.auto` (#369)
***

* Update sbt plugins (#372)

  * `sbt-ci-release` to `1.6.1`
  * `sbt-wartremover` to `3.2.0`
  * `sbt-scalafix` to `0.12.1`
  * `sbt-scalafmt` to `2.5.2`
  * `sbt-scoverage` to `2.1.1`
  * `sbt-mdoc` to `2.5.4`
  * `sbt-docusaur` to `0.16.0`
  * `sbt-tpolecat` to `0.5.2`
  * `com.github.xuwei-k:scalafix-rules` to `0.4.5`
***

* Update GitHub Actions: Update `javaOptions` (#376)
  ```yml
  env:
    GH_SBT_OPTS: "-Xss64m -Xms1024m -Xmx8G -XX:MaxMetaspaceSize=2G -XX:-UseGCOverheadLimit -XX:MaxInlineLevel=18 -XX:+UnlockExperimentalVMOptions"
    GH_JVM_OPTS: "-Xss64m -Xms1024m -Xmx8G -XX:MaxMetaspaceSize=2G -XX:-UseGCOverheadLimit -XX:MaxInlineLevel=18 -XX:+UnlockExperimentalVMOptions -XX:+UseJVMCICompiler"
  ```
***

* [`refined4s-refined-compat-scala2`] Bump Scala `2.12` to `2.12.16` (#379)
