### PR TITLE
Fix #370 - Scala.js support is broken

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,3 @@
-import just.semver.SemVer
 import sbtcrossproject.CrossProject
 
 ThisBuild / scalaVersion := props.ProjectScalaVersion
@@ -50,11 +49,8 @@ lazy val refined4s = (project in file("."))
     circeJvm,
     circeJs,
     pureconfigJvm,
-    pureconfigJs,
     doobieCe2Jvm,
-    doobieCe2Js,
     doobieCe3Jvm,
-    doobieCe3Js,
     extrasRenderJvm,
     extrasRenderJs,
     refinedCompatScala2Jvm,
@@ -64,24 +60,33 @@ lazy val refined4s = (project in file("."))
     tapirJvm,
     tapirJs,
     chimneyJvm,
-    chimneyJs,
+//    chimneyJs,
   )
 
 lazy val core    = module("core", crossProject(JVMPlatform, JSPlatform))
   .settings(
+    scalacOptions ++= List("-Xprint-suspension"),
     libraryDependencies ++= List(
-      libs.extrasTypeInfo % Test,
-      libs.cats           % Test,
-    )
+      libs.extrasTypeInfo.value % Test,
+      libs.cats.value           % Test,
+    ),
   )
 lazy val coreJvm = core.jvm
-lazy val coreJs  = core.js.settings(jsSettingsForFuture)
+lazy val coreJs  = core
+  .js
+  .settings(jsSettingsForFuture)
+  .settings(
+    libraryDependencies ++= List(
+      libs.scalajsJavaSecurerandom.value,
+      libs.scalaJavaTime.value,
+    )
+  )
 
 lazy val cats    = module("cats", crossProject(JVMPlatform, JSPlatform))
   .settings(
     libraryDependencies ++= List(
-      libs.cats,
-      libs.extrasTypeInfo % Test,
+      libs.cats.value,
+      libs.extrasTypeInfo.value % Test,
     )
   )
   .dependsOn(core % props.IncludeTest)
@@ -91,11 +96,11 @@ lazy val catsJs  = cats.js.settings(jsSettingsForFuture)
 lazy val circe    = module("circe", crossProject(JVMPlatform, JSPlatform))
   .settings(
     libraryDependencies ++= List(
-      libs.circeCore,
-      libs.circeParser         % Test,
-      libs.circeLiteral        % Test,
-      libs.extrasTypeInfo      % Test,
-      libs.extrasHedgehogCirce % Test,
+      libs.circeCore.value,
+      libs.circeParser.value         % Test,
+      libs.circeLiteral.value        % Test,
+      libs.extrasTypeInfo.value      % Test,
+      libs.extrasHedgehogCirce.value % Test,
     )
   )
   .dependsOn(
@@ -105,25 +110,24 @@ lazy val circe    = module("circe", crossProject(JVMPlatform, JSPlatform))
 lazy val circeJvm = circe.jvm
 lazy val circeJs  = circe.js.settings(jsSettingsForFuture)
 
-lazy val pureconfig    = module("pureconfig", crossProject(JVMPlatform, JSPlatform))
+lazy val pureconfig    = module("pureconfig", crossProject(JVMPlatform))
   .settings(
     libraryDependencies ++= List(
       libs.pureconfigCore,
-      libs.extrasTypeInfo % Test,
+      libs.extrasTypeInfo.value % Test,
     )
   )
   .dependsOn(core % props.IncludeTest)
 lazy val pureconfigJvm = pureconfig.jvm
-lazy val pureconfigJs  = pureconfig.js.settings(jsSettingsForFuture)
 
-lazy val doobieCe2    = module("doobie-ce2", crossProject(JVMPlatform, JSPlatform))
+lazy val doobieCe2    = module("doobie-ce2", crossProject(JVMPlatform))
   .settings(
     libraryDependencies ++= List(
       libs.doobieCoreCe2,
-      libs.embeddedPostgres     % Test,
-      libs.effectieCe2          % Test,
-      libs.extrasDoobieToolsCe2 % Test,
-      libs.logback              % Test,
+      libs.embeddedPostgres           % Test,
+      libs.effectieCe2.value          % Test,
+      libs.extrasDoobieToolsCe2.value % Test,
+      libs.logback                    % Test,
 //      libs.kittens              % Test,
     )
   )
@@ -132,16 +136,15 @@ lazy val doobieCe2    = module("doobie-ce2", crossProject(JVMPlatform, JSPlatfor
     cats,
   )
 lazy val doobieCe2Jvm = doobieCe2.jvm
-lazy val doobieCe2Js  = doobieCe2.js.settings(jsSettingsForFuture)
 
-lazy val doobieCe3    = module("doobie-ce3", crossProject(JVMPlatform, JSPlatform))
+lazy val doobieCe3    = module("doobie-ce3", crossProject(JVMPlatform))
   .settings(
     libraryDependencies ++= List(
       libs.doobieCoreCe3,
-      libs.embeddedPostgres     % Test,
-      libs.effectieCe3          % Test,
-      libs.extrasDoobieToolsCe3 % Test,
-      libs.logback              % Test,
+      libs.embeddedPostgres           % Test,
+      libs.effectieCe3.value          % Test,
+      libs.extrasDoobieToolsCe3.value % Test,
+      libs.logback                    % Test,
 //      libs.kittens              % Test,
     )
   )
@@ -150,12 +153,11 @@ lazy val doobieCe3    = module("doobie-ce3", crossProject(JVMPlatform, JSPlatfor
     cats,
   )
 lazy val doobieCe3Jvm = doobieCe3.jvm
-lazy val doobieCe3Js  = doobieCe3.js.settings(jsSettingsForFuture)
 
 lazy val extrasRender    = module("extras-render", crossProject(JVMPlatform, JSPlatform))
   .settings(
     libraryDependencies ++= List(
-      libs.extrasRender
+      libs.extrasRender.value
     )
   )
   .dependsOn(
@@ -164,10 +166,12 @@ lazy val extrasRender    = module("extras-render", crossProject(JVMPlatform, JSP
 lazy val extrasRenderJvm = extrasRender.jvm
 lazy val extrasRenderJs  = extrasRender.js.settings(jsSettingsForFuture)
 
-lazy val chimney    = module("chimney", crossProject(JVMPlatform, JSPlatform))
+//lazy val chimney    = module("chimney", crossProject(JVMPlatform, JSPlatform))
+lazy val chimney    = module("chimney", crossProject(JVMPlatform))
   .settings(
     libraryDependencies ++= List(
-      libs.chimney,
+      libs.chimney.value,
+      libs.tests.hedgehogExtraCore.value,
       libs.tests.hedgehogExtraRefined4s,
     )
   )
@@ -175,7 +179,7 @@ lazy val chimney    = module("chimney", crossProject(JVMPlatform, JSPlatform))
     core % props.IncludeTest
   )
 lazy val chimneyJvm = chimney.jvm
-lazy val chimneyJs  = chimney.js.settings(jsSettingsForFuture)
+//lazy val chimneyJs  = chimney.js.settings(jsSettingsForFuture)
 
 lazy val refinedCompatScala2    = module("refined-compat-scala2", crossProject(JVMPlatform, JSPlatform))
   .settings(
@@ -185,7 +189,7 @@ lazy val refinedCompatScala2    = module("refined-compat-scala2", crossProject(J
         if (isScala3(scalaVersion.value))
           List.empty
         else
-          List("eu.timepit" %% "refined" % "0.9.29")
+          List("eu.timepit" %%% "refined" % "0.9.29")
       ),
   )
 lazy val refinedCompatScala2Jvm = refinedCompatScala2.jvm
@@ -201,7 +205,7 @@ lazy val refinedCompatScala3Js  = refinedCompatScala3.js.settings(jsSettingsForF
 lazy val tapir    = module("tapir", crossProject(JVMPlatform, JSPlatform))
   .settings(
     libraryDependencies ++= List(
-      libs.tapirCore
+      libs.tapirCore.value
     )
   )
   .dependsOn(
@@ -226,17 +230,17 @@ lazy val docs = (project in file("docs-gen-tmp/docs"))
       val latestVersion = s"git describe --tags $tag".!!.trim.stripPrefix("v")
 
       List(
-        "io.kevinlee" %% "refined4s-core"          % latestVersion,
-        "io.kevinlee" %% "refined4s-cats"          % latestVersion,
-        "io.kevinlee" %% "refined4s-chimney"       % latestVersion,
-        "io.kevinlee" %% "refined4s-circe"         % latestVersion,
-        "io.kevinlee" %% "refined4s-pureconfig"    % latestVersion,
-        "io.kevinlee" %% "refined4s-doobie-ce2"    % latestVersion,
-        "io.kevinlee" %% "refined4s-extras-render" % latestVersion,
-        "io.kevinlee" %% "refined4s-tapir"         % latestVersion,
-        libs.circeCore,
-        libs.circeLiteral,
-        libs.circeParser,
+        "io.kevinlee" %%% "refined4s-core"          % latestVersion,
+        "io.kevinlee" %%% "refined4s-cats"          % latestVersion,
+        "io.kevinlee" %%% "refined4s-chimney"       % latestVersion,
+        "io.kevinlee" %%% "refined4s-circe"         % latestVersion,
+        "io.kevinlee" %%% "refined4s-pureconfig"    % latestVersion,
+        "io.kevinlee" %%% "refined4s-doobie-ce2"    % latestVersion,
+        "io.kevinlee" %%% "refined4s-extras-render" % latestVersion,
+        "io.kevinlee" %%% "refined4s-tapir"         % latestVersion,
+        libs.circeCore.value,
+        libs.circeLiteral.value,
+        libs.circeParser.value,
       )
     },
     mdocVariables := Map(
@@ -283,7 +287,7 @@ lazy val props =
     val IncludeTest = "compile->compile;test->test"
 
     val HedgehogVersion      = "0.10.1"
-    val HedgehogExtraVersion = "0.9.0"
+    val HedgehogExtraVersion = "0.10.0"
 
     val ExtrasVersion = "0.44.0"
 
@@ -307,23 +311,27 @@ lazy val props =
     val TapirVersion = "1.0.6"
 
     val ChimneyVersion = "1.3.0"
+
+    val ScalajsJavaSecurerandomVersion = "1.0.0"
+
+    val ScalaJavaTimeVersion = "2.6.0"
   }
 
 lazy val libs = new {
 
-  lazy val extrasTypeInfo       = "io.kevinlee" %% "extras-type-info"        % props.ExtrasVersion
-  lazy val extrasHedgehogCirce  = "io.kevinlee" %% "extras-hedgehog-circe"   % props.ExtrasVersion
-  lazy val extrasDoobieToolsCe2 = "io.kevinlee" %% "extras-doobie-tools-ce2" % props.ExtrasVersion
-  lazy val extrasDoobieToolsCe3 = "io.kevinlee" %% "extras-doobie-tools-ce3" % props.ExtrasVersion
-  lazy val extrasRender         = "io.kevinlee" %% "extras-render"           % props.ExtrasVersion
+  lazy val extrasTypeInfo       = Def.setting("io.kevinlee" %%% "extras-type-info" % props.ExtrasVersion)
+  lazy val extrasHedgehogCirce  = Def.setting("io.kevinlee" %%% "extras-hedgehog-circe" % props.ExtrasVersion)
+  lazy val extrasDoobieToolsCe2 = Def.setting("io.kevinlee" %%% "extras-doobie-tools-ce2" % props.ExtrasVersion)
+  lazy val extrasDoobieToolsCe3 = Def.setting("io.kevinlee" %%% "extras-doobie-tools-ce3" % props.ExtrasVersion)
+  lazy val extrasRender         = Def.setting("io.kevinlee" %%% "extras-render" % props.ExtrasVersion)
 
-  lazy val cats = "org.typelevel" %% "cats-core" % props.CatsVersion
+  lazy val cats = Def.setting("org.typelevel" %%% "cats-core" % props.CatsVersion)
 
-  lazy val kittens = "org.typelevel" %% "kittens" % props.KittensVersion
+  lazy val kittens = Def.setting("org.typelevel" %%% "kittens" % props.KittensVersion)
 
-  lazy val circeCore    = "io.circe" %% "circe-core"    % props.CirceVersion
-  lazy val circeParser  = "io.circe" %% "circe-parser"  % props.CirceVersion
-  lazy val circeLiteral = "io.circe" %% "circe-literal" % props.CirceVersion
+  lazy val circeCore    = Def.setting("io.circe" %%% "circe-core" % props.CirceVersion)
+  lazy val circeParser  = Def.setting("io.circe" %%% "circe-parser" % props.CirceVersion)
+  lazy val circeLiteral = Def.setting("io.circe" %%% "circe-literal" % props.CirceVersion)
 
   lazy val pureconfigCore    = "com.github.pureconfig" %% "pureconfig-core"    % props.PureconfigVersion
   lazy val pureconfigGeneric = "com.github.pureconfig" %% "pureconfig-generic" % props.PureconfigVersion
@@ -333,31 +341,33 @@ lazy val libs = new {
 
   lazy val embeddedPostgres = "io.zonky.test" % "embedded-postgres" % props.EmbeddedPostgresVersion
 
-  lazy val effectieCore   = "io.kevinlee" %% "effectie-core"         % props.EffectieVersion
-  lazy val effectieSyntax = "io.kevinlee" %% "effectie-syntax"       % props.EffectieVersion
-  lazy val effectieCe2    = "io.kevinlee" %% "effectie-cats-effect2" % props.EffectieVersion
-  lazy val effectieCe3    = "io.kevinlee" %% "effectie-cats-effect3" % props.EffectieVersion
+  lazy val effectieCore   = Def.setting("io.kevinlee" %%% "effectie-core" % props.EffectieVersion)
+  lazy val effectieSyntax = Def.setting("io.kevinlee" %%% "effectie-syntax" % props.EffectieVersion)
+  lazy val effectieCe2    = Def.setting("io.kevinlee" %%% "effectie-cats-effect2" % props.EffectieVersion)
+  lazy val effectieCe3    = Def.setting("io.kevinlee" %%% "effectie-cats-effect3" % props.EffectieVersion)
 
   lazy val logback = "ch.qos.logback" % "logback-classic" % props.LogbackVersion
 
-  lazy val hedgehogCore   = "qa.hedgehog" %% "hedgehog-core"   % props.HedgehogVersion
-  lazy val hedgehogRunner = "qa.hedgehog" %% "hedgehog-runner" % props.HedgehogVersion
-  lazy val hedgehogSbt    = "qa.hedgehog" %% "hedgehog-sbt"    % props.HedgehogVersion
+  lazy val tapirCore = Def.setting("com.softwaremill.sttp.tapir" %%% "tapir-core" % props.TapirVersion)
 
-  lazy val tapirCore = "com.softwaremill.sttp.tapir" %% "tapir-core" % props.TapirVersion
+  lazy val chimney = Def.setting("io.scalaland" %%% "chimney" % props.ChimneyVersion)
 
-  lazy val chimney = "io.scalaland" %% "chimney" % props.ChimneyVersion
+  lazy val scalajsJavaSecurerandom =
+    Def.setting(("org.scala-js" %%% "scalajs-java-securerandom" % props.ScalajsJavaSecurerandomVersion).cross(CrossVersion.for3Use2_13))
+
+  lazy val scalaJavaTime = Def.setting("io.github.cquiroz" %%% "scala-java-time" % props.ScalaJavaTimeVersion)
 
   lazy val tests = new {
 
-    lazy val hedgehog: List[ModuleID] =
+    lazy val hedgehog = Def.setting {
       List(
-        hedgehogCore,
-        hedgehogRunner,
-        hedgehogSbt,
+        "qa.hedgehog" %%% "hedgehog-core"   % props.HedgehogVersion,
+        "qa.hedgehog" %%% "hedgehog-runner" % props.HedgehogVersion,
+        "qa.hedgehog" %%% "hedgehog-sbt"    % props.HedgehogVersion,
       ).map(_ % Test)
+    }
 
-    lazy val hedgehogExtraCore = "io.kevinlee" %% "hedgehog-extra-core" % props.HedgehogExtraVersion % Test
+    lazy val hedgehogExtraCore = Def.setting("io.kevinlee" %%% "hedgehog-extra-core" % props.HedgehogExtraVersion % Test)
 
     lazy val hedgehogExtraRefined4s = "io.kevinlee" %% "hedgehog-extra-refined4s" % props.HedgehogExtraVersion % Test
   }
@@ -393,7 +403,7 @@ def module(projectName: String, crossProject: CrossProject.Builder): CrossProjec
       ),
       scalacOptions ++= (if (isScala3(scalaVersion.value)) List("-no-indent") else List("-Xsource:3")),
 //      scalacOptions ~= (ops => ops.filter(_ != "UTF-8")),
-      libraryDependencies ++= libs.tests.hedgehog ++ List(libs.tests.hedgehogExtraCore),
+      libraryDependencies ++= libs.tests.hedgehog.value ++ List(libs.tests.hedgehogExtraCore.value),
       wartremoverErrors ++= Warts.allBut(Wart.Any, Wart.Nothing, Wart.ImplicitConversion, Wart.ImplicitParameter),
       Compile / console / scalacOptions :=
         (console / scalacOptions)
@@ -433,4 +443,5 @@ lazy val jsSettingsForFuture: SettingsDefinition = List(
                             else List("-P:scalajs:nowarnGlobalExecutionContext")),
   Test / compile / scalacOptions ++= (if (scalaVersion.value.startsWith("3")) List.empty
                                       else List("-P:scalajs:nowarnGlobalExecutionContext")),
+  coverageEnabled := false,
 )

--- a/modules/refined4s-circe/js/src/test/scala/refined4s/modules/circe/derivation/types/NumericTestValues.scala
+++ b/modules/refined4s-circe/js/src/test/scala/refined4s/modules/circe/derivation/types/NumericTestValues.scala
@@ -1,0 +1,15 @@
+package refined4s.modules.circe.derivation.types
+
+/** @author Kevin Lee
+  * @since 2024-10-28
+  */
+trait NumericTestValues {
+
+  /** From JavaScript's Number.MIN_SAFE_INTEGER
+    */
+  val MinLongValue: Long = -9007199254740991L
+
+  /** From JavaScript's Number.MAX_SAFE_INTEGER
+    */
+  val MaxLongValue: Long = 9007199254740991L
+}

--- a/modules/refined4s-circe/jvm/src/test/scala/refined4s/modules/circe/derivation/types/NumericTestValues.scala
+++ b/modules/refined4s-circe/jvm/src/test/scala/refined4s/modules/circe/derivation/types/NumericTestValues.scala
@@ -1,0 +1,9 @@
+package refined4s.modules.circe.derivation.types
+
+/** @author Kevin Lee
+  * @since 2024-10-28
+  */
+trait NumericTestValues {
+  val MinLongValue: Long = Long.MinValue
+  val MaxLongValue: Long = Long.MaxValue
+}

--- a/modules/refined4s-circe/shared/src/test/scala/refined4s/modules/circe/derivation/generic/numericSpec.scala
+++ b/modules/refined4s-circe/shared/src/test/scala/refined4s/modules/circe/derivation/generic/numericSpec.scala
@@ -6,12 +6,13 @@ import cats.syntax.all.*
 import io.circe.*
 import io.circe.parser.*
 import io.circe.syntax.*
+import refined4s.modules.circe.derivation.types.NumericTestValues
 import refined4s.types.all.*
 
 /** @author Kevin Lee
   * @since 2024-08-23
   */
-object numericSpec {
+object numericSpec extends NumericTestValues {
 
   import refined4s.modules.circe.derivation.generic.auto.given
 
@@ -401,7 +402,7 @@ object numericSpec {
 
   def testEncoderNegLong: Property =
     for {
-      n <- Gen.long(Range.linear(-1L, Long.MinValue)).log("n")
+      n <- Gen.long(Range.linear(-1L, MinLongValue)).log("n")
     } yield {
       val input = NegLong.unsafeFrom(n)
 
@@ -417,7 +418,7 @@ object numericSpec {
 
   def testDecoderNegLong: Property =
     for {
-      n <- Gen.long(Range.linear(-1L, Long.MinValue)).log("n")
+      n <- Gen.long(Range.linear(-1L, MinLongValue)).log("n")
     } yield {
       val input = n.asJson
 
@@ -428,7 +429,7 @@ object numericSpec {
 
   def testKeyEncoderNegLong: Property =
     for {
-      ns1   <- Gen.long(Range.linear(-1L, Long.MinValue)).list(Range.linear(1, 10)).log("ns1")
+      ns1   <- Gen.long(Range.linear(-1L, MinLongValue)).list(Range.linear(1, 10)).log("ns1")
       ns2   <- Gen.int(Range.linear(0, Int.MaxValue)).list(Range.singleton(ns1.length)).log("ns2")
       map   <- Gen.constant(ns1.zip(ns2).toMap).log("map")
       input <- Gen.constant(map.map { case (key, value) => NegLong.unsafeFrom(key) -> value }).log("input")
@@ -446,7 +447,7 @@ object numericSpec {
 
   def testKeyDecoderNegLong: Property =
     for {
-      ns1      <- Gen.long(Range.linear(-1L, Long.MinValue)).list(Range.linear(1, 10)).log("ns1")
+      ns1      <- Gen.long(Range.linear(-1L, MinLongValue)).list(Range.linear(1, 10)).log("ns1")
       ns2      <- Gen.int(Range.linear(0, Int.MaxValue)).list(Range.singleton(ns1.length)).log("ns2")
       map      <- Gen.constant(ns1.zip(ns2).toMap).log("map")
       expected <- Gen.constant(map.map { case (key, value) => NegLong.unsafeFrom(key) -> value }).log("expected")
@@ -461,7 +462,7 @@ object numericSpec {
 
   def testEncoderNonNegLong: Property =
     for {
-      n <- Gen.long(Range.linear(0L, Long.MaxValue)).log("n")
+      n <- Gen.long(Range.linear(0L, MaxLongValue)).log("n")
     } yield {
       val input = NonNegLong.unsafeFrom(n)
 
@@ -477,7 +478,7 @@ object numericSpec {
 
   def testDecoderNonNegLong: Property =
     for {
-      n <- Gen.long(Range.linear(0L, Long.MaxValue)).log("n")
+      n <- Gen.long(Range.linear(0L, MaxLongValue)).log("n")
     } yield {
       val input = n.asJson
 
@@ -488,7 +489,7 @@ object numericSpec {
 
   def testKeyEncoderNonNegLong: Property =
     for {
-      ns1   <- Gen.long(Range.linear(0L, Long.MaxValue)).list(Range.linear(1, 10)).log("ns1")
+      ns1   <- Gen.long(Range.linear(0L, MaxLongValue)).list(Range.linear(1, 10)).log("ns1")
       ns2   <- Gen.int(Range.linear(0, Int.MaxValue)).list(Range.singleton(ns1.length)).log("ns2")
       map   <- Gen.constant(ns1.zip(ns2).toMap).log("map")
       input <- Gen.constant(map.map { case (key, value) => NonNegLong.unsafeFrom(key) -> value }).log("input")
@@ -506,7 +507,7 @@ object numericSpec {
 
   def testKeyDecoderNonNegLong: Property =
     for {
-      ns1      <- Gen.long(Range.linear(0L, Long.MaxValue)).list(Range.linear(1, 10)).log("ns1")
+      ns1      <- Gen.long(Range.linear(0L, MaxLongValue)).list(Range.linear(1, 10)).log("ns1")
       ns2      <- Gen.int(Range.linear(0, Int.MaxValue)).list(Range.singleton(ns1.length)).log("ns2")
       map      <- Gen.constant(ns1.zip(ns2).toMap).log("map")
       expected <- Gen.constant(map.map { case (key, value) => NonNegLong.unsafeFrom(key) -> value }).log("expected")
@@ -521,7 +522,7 @@ object numericSpec {
 
   def testEncoderPosLong: Property =
     for {
-      n <- Gen.long(Range.linear(1L, Long.MaxValue)).log("n")
+      n <- Gen.long(Range.linear(1L, MaxLongValue)).log("n")
     } yield {
       val input = PosLong.unsafeFrom(n)
 
@@ -537,7 +538,7 @@ object numericSpec {
 
   def testDecoderPosLong: Property =
     for {
-      n <- Gen.long(Range.linear(1L, Long.MaxValue)).log("n")
+      n <- Gen.long(Range.linear(1L, MaxLongValue)).log("n")
     } yield {
       val input = n.asJson
 
@@ -548,7 +549,7 @@ object numericSpec {
 
   def testKeyEncoderPosLong: Property =
     for {
-      ns1   <- Gen.long(Range.linear(1L, Long.MaxValue)).list(Range.linear(1, 10)).log("ns1")
+      ns1   <- Gen.long(Range.linear(1L, MaxLongValue)).list(Range.linear(1, 10)).log("ns1")
       ns2   <- Gen.int(Range.linear(0, Int.MaxValue)).list(Range.singleton(ns1.length)).log("ns2")
       map   <- Gen.constant(ns1.zip(ns2).toMap).log("map")
       input <- Gen.constant(map.map { case (key, value) => PosLong.unsafeFrom(key) -> value }).log("input")
@@ -566,7 +567,7 @@ object numericSpec {
 
   def testKeyDecoderPosLong: Property =
     for {
-      ns1      <- Gen.long(Range.linear(1L, Long.MaxValue)).list(Range.linear(1, 10)).log("ns1")
+      ns1      <- Gen.long(Range.linear(1L, MaxLongValue)).list(Range.linear(1, 10)).log("ns1")
       ns2      <- Gen.int(Range.linear(0, Int.MaxValue)).list(Range.singleton(ns1.length)).log("ns2")
       map      <- Gen.constant(ns1.zip(ns2).toMap).log("map")
       expected <- Gen.constant(map.map { case (key, value) => PosLong.unsafeFrom(key) -> value }).log("expected")
@@ -581,7 +582,7 @@ object numericSpec {
 
   def testEncoderNonPosLong: Property =
     for {
-      n <- Gen.long(Range.linear(0L, Long.MinValue)).log("n")
+      n <- Gen.long(Range.linear(0L, MinLongValue)).log("n")
     } yield {
       val input = NonPosLong.unsafeFrom(n)
 
@@ -597,7 +598,7 @@ object numericSpec {
 
   def testDecoderNonPosLong: Property =
     for {
-      n <- Gen.long(Range.linear(0L, Long.MinValue)).log("n")
+      n <- Gen.long(Range.linear(0L, MinLongValue)).log("n")
     } yield {
       val input = n.asJson
 
@@ -608,7 +609,7 @@ object numericSpec {
 
   def testKeyEncoderNonPosLong: Property =
     for {
-      ns1   <- Gen.long(Range.linear(0L, Long.MinValue)).list(Range.linear(1, 10)).log("ns1")
+      ns1   <- Gen.long(Range.linear(0L, MinLongValue)).list(Range.linear(1, 10)).log("ns1")
       ns2   <- Gen.int(Range.linear(0, Int.MaxValue)).list(Range.singleton(ns1.length)).log("ns2")
       map   <- Gen.constant(ns1.zip(ns2).toMap).log("map")
       input <- Gen.constant(map.map { case (key, value) => NonPosLong.unsafeFrom(key) -> value }).log("input")
@@ -626,7 +627,7 @@ object numericSpec {
 
   def testKeyDecoderNonPosLong: Property =
     for {
-      ns1      <- Gen.long(Range.linear(0L, Long.MinValue)).list(Range.linear(1, 10)).log("ns1")
+      ns1      <- Gen.long(Range.linear(0L, MinLongValue)).list(Range.linear(1, 10)).log("ns1")
       ns2      <- Gen.int(Range.linear(0, Int.MaxValue)).list(Range.singleton(ns1.length)).log("ns2")
       map      <- Gen.constant(ns1.zip(ns2).toMap).log("map")
       expected <- Gen.constant(map.map { case (key, value) => NonPosLong.unsafeFrom(key) -> value }).log("expected")
@@ -1353,7 +1354,7 @@ object numericSpec {
 
   def testEncoderNegBigInt: Property =
     for {
-      n <- Gen.long(Range.linear(-1L, Long.MinValue)).map(BigInt(_)).log("n")
+      n <- Gen.long(Range.linear(-1L, MinLongValue)).map(BigInt(_)).log("n")
     } yield {
       val input = NegBigInt.unsafeFrom(n)
 
@@ -1369,7 +1370,7 @@ object numericSpec {
 
   def testDecoderNegBigInt: Property =
     for {
-      n <- Gen.long(Range.linear(-1L, Long.MinValue)).map(BigInt(_)).log("n")
+      n <- Gen.long(Range.linear(-1L, MinLongValue)).map(BigInt(_)).log("n")
     } yield {
       val input = n.asJson
 
@@ -1380,7 +1381,7 @@ object numericSpec {
 
   def testKeyEncoderNegBigInt: Property =
     for {
-      ns1   <- Gen.long(Range.linear(-1L, Long.MinValue)).list(Range.linear(1, 10)).log("ns1")
+      ns1   <- Gen.long(Range.linear(-1L, MinLongValue)).list(Range.linear(1, 10)).log("ns1")
       ns2   <- Gen.int(Range.linear(0, Int.MaxValue)).list(Range.singleton(ns1.length)).log("ns2")
       map   <- Gen.constant(ns1.zip(ns2).toMap).log("map")
       input <- Gen.constant(map.map { case (key, value) => NegBigInt.unsafeFrom(key) -> value }).log("input")
@@ -1399,7 +1400,7 @@ object numericSpec {
   @SuppressWarnings(Array("org.wartremover.warts.ToString"))
   def testKeyDecoderNegBigInt: Property =
     for {
-      ns1      <- Gen.long(Range.linear(-1L, Long.MinValue)).map(BigInt(_)).list(Range.linear(1, 10)).log("ns1")
+      ns1      <- Gen.long(Range.linear(-1L, MinLongValue)).map(BigInt(_)).list(Range.linear(1, 10)).log("ns1")
       ns2      <- Gen.int(Range.linear(0, Int.MaxValue)).list(Range.singleton(ns1.length)).log("ns2")
       map      <- Gen.constant(ns1.zip(ns2).toMap).log("map")
       expected <- Gen.constant(map.map { case (key, value) => NegBigInt.unsafeFrom(key) -> value }).log("expected")
@@ -1414,7 +1415,7 @@ object numericSpec {
 
   def testEncoderNonNegBigInt: Property =
     for {
-      n <- Gen.long(Range.linear(0L, Long.MaxValue)).map(BigInt(_)).log("n")
+      n <- Gen.long(Range.linear(0L, MaxLongValue)).map(BigInt(_)).log("n")
     } yield {
       val input = NonNegBigInt.unsafeFrom(n)
 
@@ -1430,7 +1431,7 @@ object numericSpec {
 
   def testDecoderNonNegBigInt: Property =
     for {
-      n <- Gen.long(Range.linear(0L, Long.MaxValue)).map(BigInt(_)).log("n")
+      n <- Gen.long(Range.linear(0L, MaxLongValue)).map(BigInt(_)).log("n")
     } yield {
       val input = n.asJson
 
@@ -1442,7 +1443,7 @@ object numericSpec {
   @SuppressWarnings(Array("org.wartremover.warts.ToString"))
   def testKeyEncoderNonNegBigInt: Property =
     for {
-      ns1   <- Gen.long(Range.linear(0L, Long.MaxValue)).map(BigInt(_)).list(Range.linear(1, 10)).log("ns1")
+      ns1   <- Gen.long(Range.linear(0L, MaxLongValue)).map(BigInt(_)).list(Range.linear(1, 10)).log("ns1")
       ns2   <- Gen.int(Range.linear(0, Int.MaxValue)).list(Range.singleton(ns1.length)).log("ns2")
       map   <- Gen.constant(ns1.zip(ns2).toMap).log("map")
       input <- Gen.constant(map.map { case (key, value) => NonNegBigInt.unsafeFrom(key) -> value }).log("input")
@@ -1461,7 +1462,7 @@ object numericSpec {
   @SuppressWarnings(Array("org.wartremover.warts.ToString"))
   def testKeyDecoderNonNegBigInt: Property =
     for {
-      ns1      <- Gen.long(Range.linear(0L, Long.MaxValue)).map(BigInt(_)).list(Range.linear(1, 10)).log("ns1")
+      ns1      <- Gen.long(Range.linear(0L, MaxLongValue)).map(BigInt(_)).list(Range.linear(1, 10)).log("ns1")
       ns2      <- Gen.int(Range.linear(0, Int.MaxValue)).list(Range.singleton(ns1.length)).log("ns2")
       map      <- Gen.constant(ns1.zip(ns2).toMap).log("map")
       expected <- Gen.constant(map.map { case (key, value) => NonNegBigInt.unsafeFrom(key) -> value }).log("expected")
@@ -1476,7 +1477,7 @@ object numericSpec {
 
   def testEncoderPosBigInt: Property =
     for {
-      n <- Gen.long(Range.linear(1L, Long.MaxValue)).map(BigInt(_)).log("n")
+      n <- Gen.long(Range.linear(1L, MaxLongValue)).map(BigInt(_)).log("n")
     } yield {
       val input = PosBigInt.unsafeFrom(n)
 
@@ -1492,7 +1493,7 @@ object numericSpec {
 
   def testDecoderPosBigInt: Property =
     for {
-      n <- Gen.long(Range.linear(1L, Long.MaxValue)).map(BigInt(_)).log("n")
+      n <- Gen.long(Range.linear(1L, MaxLongValue)).map(BigInt(_)).log("n")
     } yield {
       val input = n.asJson
 
@@ -1504,7 +1505,7 @@ object numericSpec {
   @SuppressWarnings(Array("org.wartremover.warts.ToString"))
   def testKeyEncoderPosBigInt: Property =
     for {
-      ns1   <- Gen.long(Range.linear(1L, Long.MaxValue)).map(BigInt(_)).list(Range.linear(1, 10)).log("ns1")
+      ns1   <- Gen.long(Range.linear(1L, MaxLongValue)).map(BigInt(_)).list(Range.linear(1, 10)).log("ns1")
       ns2   <- Gen.int(Range.linear(0, Int.MaxValue)).list(Range.singleton(ns1.length)).log("ns2")
       map   <- Gen.constant(ns1.zip(ns2).toMap).log("map")
       input <- Gen.constant(map.map { case (key, value) => PosBigInt.unsafeFrom(key) -> value }).log("input")
@@ -1523,7 +1524,7 @@ object numericSpec {
   @SuppressWarnings(Array("org.wartremover.warts.ToString"))
   def testKeyDecoderPosBigInt: Property =
     for {
-      ns1      <- Gen.long(Range.linear(1L, Long.MaxValue)).map(BigInt(_)).list(Range.linear(1, 10)).log("ns1")
+      ns1      <- Gen.long(Range.linear(1L, MaxLongValue)).map(BigInt(_)).list(Range.linear(1, 10)).log("ns1")
       ns2      <- Gen.int(Range.linear(0, Int.MaxValue)).list(Range.singleton(ns1.length)).log("ns2")
       map      <- Gen.constant(ns1.zip(ns2).toMap).log("map")
       expected <- Gen.constant(map.map { case (key, value) => PosBigInt.unsafeFrom(key) -> value }).log("expected")
@@ -1538,7 +1539,7 @@ object numericSpec {
 
   def testEncoderNonPosBigInt: Property =
     for {
-      n <- Gen.long(Range.linear(0L, Long.MinValue)).map(BigInt(_)).log("n")
+      n <- Gen.long(Range.linear(0L, MinLongValue)).map(BigInt(_)).log("n")
     } yield {
       val input = NonPosBigInt.unsafeFrom(n)
 
@@ -1554,7 +1555,7 @@ object numericSpec {
 
   def testDecoderNonPosBigInt: Property =
     for {
-      n <- Gen.long(Range.linear(0L, Long.MinValue)).map(BigInt(_)).log("n")
+      n <- Gen.long(Range.linear(0L, MinLongValue)).map(BigInt(_)).log("n")
     } yield {
       val input = n.asJson
 
@@ -1566,7 +1567,7 @@ object numericSpec {
   @SuppressWarnings(Array("org.wartremover.warts.ToString"))
   def testKeyEncoderNonPosBigInt: Property =
     for {
-      ns1   <- Gen.long(Range.linear(0L, Long.MinValue)).map(BigInt(_)).list(Range.linear(1, 10)).log("ns1")
+      ns1   <- Gen.long(Range.linear(0L, MinLongValue)).map(BigInt(_)).list(Range.linear(1, 10)).log("ns1")
       ns2   <- Gen.int(Range.linear(0, Int.MaxValue)).list(Range.singleton(ns1.length)).log("ns2")
       map   <- Gen.constant(ns1.zip(ns2).toMap).log("map")
       input <- Gen.constant(map.map { case (key, value) => NonPosBigInt.unsafeFrom(key) -> value }).log("input")
@@ -1585,7 +1586,7 @@ object numericSpec {
   @SuppressWarnings(Array("org.wartremover.warts.ToString"))
   def testKeyDecoderNonPosBigInt: Property =
     for {
-      ns1      <- Gen.long(Range.linear(0L, Long.MinValue)).map(BigInt(_)).list(Range.linear(1, 10)).log("ns1")
+      ns1      <- Gen.long(Range.linear(0L, MinLongValue)).map(BigInt(_)).list(Range.linear(1, 10)).log("ns1")
       ns2      <- Gen.int(Range.linear(0, Int.MaxValue)).list(Range.singleton(ns1.length)).log("ns2")
       map      <- Gen.constant(ns1.zip(ns2).toMap).log("map")
       expected <- Gen.constant(map.map { case (key, value) => NonPosBigInt.unsafeFrom(key) -> value }).log("expected")

--- a/modules/refined4s-circe/shared/src/test/scala/refined4s/modules/circe/derivation/types/CirceCodecWithTypeClassesForTypesSpec.scala
+++ b/modules/refined4s-circe/shared/src/test/scala/refined4s/modules/circe/derivation/types/CirceCodecWithTypeClassesForTypesSpec.scala
@@ -17,7 +17,7 @@ import java.time.Instant
 /** @author Kevin Lee
   * @since 2023-12-25
   */
-object CirceCodecWithTypeClassesForTypesSpec extends Properties {
+object CirceCodecWithTypeClassesForTypesSpec extends Properties, NumericTestValues {
 
   override def tests: List[Test] = List(
     property("round-trip test Newtype and Refined with derived and custom Codec", roundTripTest),
@@ -34,7 +34,7 @@ object CirceCodecWithTypeClassesForTypesSpec extends Properties {
                     .map(Name(_))
                     .log("name")
       created  <- Gen
-                    .long(Range.linear(0, Long.MaxValue))
+                    .long(Range.linear(0, MaxLongValue))
                     .map(Instant.ofEpochMilli)
                     .map(Created(_))
                     .log("created")
@@ -53,7 +53,7 @@ object CirceCodecWithTypeClassesForTypesSpec extends Properties {
                     .map(Name(_))
                     .log("name")
       created  <- Gen
-                    .long(Range.linear(0, Long.MaxValue))
+                    .long(Range.linear(0, MaxLongValue))
                     .map(Instant.ofEpochMilli)
                     .map(Created(_))
                     .log("created")

--- a/modules/refined4s-circe/shared/src/test/scala/refined4s/modules/circe/derivation/types/numericSpec.scala
+++ b/modules/refined4s-circe/shared/src/test/scala/refined4s/modules/circe/derivation/types/numericSpec.scala
@@ -11,7 +11,7 @@ import refined4s.types.all.*
 /** @author Kevin Lee
   * @since 2024-08-23
   */
-trait numericSpec {
+trait numericSpec extends NumericTestValues {
 
   protected val numericTypeClasses: refined4s.modules.circe.derivation.types.numeric
 
@@ -398,7 +398,7 @@ trait numericSpec {
 
   def testEncoderNegLong: Property =
     for {
-      n <- Gen.long(Range.linear(-1L, Long.MinValue)).log("n")
+      n <- Gen.long(Range.linear(-1L, MinLongValue)).log("n")
     } yield {
       val input = NegLong.unsafeFrom(n)
 
@@ -414,7 +414,7 @@ trait numericSpec {
 
   def testDecoderNegLong: Property =
     for {
-      n <- Gen.long(Range.linear(-1L, Long.MinValue)).log("n")
+      n <- Gen.long(Range.linear(-1L, MinLongValue)).log("n")
     } yield {
       val input = n.asJson
 
@@ -425,7 +425,7 @@ trait numericSpec {
 
   def testKeyEncoderNegLong: Property =
     for {
-      ns1   <- Gen.long(Range.linear(-1L, Long.MinValue)).list(Range.linear(1, 10)).log("ns1")
+      ns1   <- Gen.long(Range.linear(-1L, MinLongValue)).list(Range.linear(1, 10)).log("ns1")
       ns2   <- Gen.int(Range.linear(0, Int.MaxValue)).list(Range.singleton(ns1.length)).log("ns2")
       map   <- Gen.constant(ns1.zip(ns2).toMap).log("map")
       input <- Gen.constant(map.map { case (key, value) => NegLong.unsafeFrom(key) -> value }).log("input")
@@ -443,7 +443,7 @@ trait numericSpec {
 
   def testKeyDecoderNegLong: Property =
     for {
-      ns1      <- Gen.long(Range.linear(-1L, Long.MinValue)).list(Range.linear(1, 10)).log("ns1")
+      ns1      <- Gen.long(Range.linear(-1L, MinLongValue)).list(Range.linear(1, 10)).log("ns1")
       ns2      <- Gen.int(Range.linear(0, Int.MaxValue)).list(Range.singleton(ns1.length)).log("ns2")
       map      <- Gen.constant(ns1.zip(ns2).toMap).log("map")
       expected <- Gen.constant(map.map { case (key, value) => NegLong.unsafeFrom(key) -> value }).log("expected")
@@ -458,7 +458,7 @@ trait numericSpec {
 
   def testEncoderNonNegLong: Property =
     for {
-      n <- Gen.long(Range.linear(0L, Long.MaxValue)).log("n")
+      n <- Gen.long(Range.linear(0L, MaxLongValue)).log("n")
     } yield {
       val input = NonNegLong.unsafeFrom(n)
 
@@ -474,7 +474,7 @@ trait numericSpec {
 
   def testDecoderNonNegLong: Property =
     for {
-      n <- Gen.long(Range.linear(0L, Long.MaxValue)).log("n")
+      n <- Gen.long(Range.linear(0L, MaxLongValue)).log("n")
     } yield {
       val input = n.asJson
 
@@ -485,7 +485,7 @@ trait numericSpec {
 
   def testKeyEncoderNonNegLong: Property =
     for {
-      ns1   <- Gen.long(Range.linear(0L, Long.MaxValue)).list(Range.linear(1, 10)).log("ns1")
+      ns1   <- Gen.long(Range.linear(0L, MaxLongValue)).list(Range.linear(1, 10)).log("ns1")
       ns2   <- Gen.int(Range.linear(0, Int.MaxValue)).list(Range.singleton(ns1.length)).log("ns2")
       map   <- Gen.constant(ns1.zip(ns2).toMap).log("map")
       input <- Gen.constant(map.map { case (key, value) => NonNegLong.unsafeFrom(key) -> value }).log("input")
@@ -503,7 +503,7 @@ trait numericSpec {
 
   def testKeyDecoderNonNegLong: Property =
     for {
-      ns1      <- Gen.long(Range.linear(0L, Long.MaxValue)).list(Range.linear(1, 10)).log("ns1")
+      ns1      <- Gen.long(Range.linear(0L, MaxLongValue)).list(Range.linear(1, 10)).log("ns1")
       ns2      <- Gen.int(Range.linear(0, Int.MaxValue)).list(Range.singleton(ns1.length)).log("ns2")
       map      <- Gen.constant(ns1.zip(ns2).toMap).log("map")
       expected <- Gen.constant(map.map { case (key, value) => NonNegLong.unsafeFrom(key) -> value }).log("expected")
@@ -518,7 +518,7 @@ trait numericSpec {
 
   def testEncoderPosLong: Property =
     for {
-      n <- Gen.long(Range.linear(1L, Long.MaxValue)).log("n")
+      n <- Gen.long(Range.linear(1L, MaxLongValue)).log("n")
     } yield {
       val input = PosLong.unsafeFrom(n)
 
@@ -534,7 +534,7 @@ trait numericSpec {
 
   def testDecoderPosLong: Property =
     for {
-      n <- Gen.long(Range.linear(1L, Long.MaxValue)).log("n")
+      n <- Gen.long(Range.linear(1L, MaxLongValue)).log("n")
     } yield {
       val input = n.asJson
 
@@ -545,7 +545,7 @@ trait numericSpec {
 
   def testKeyEncoderPosLong: Property =
     for {
-      ns1   <- Gen.long(Range.linear(1L, Long.MaxValue)).list(Range.linear(1, 10)).log("ns1")
+      ns1   <- Gen.long(Range.linear(1L, MaxLongValue)).list(Range.linear(1, 10)).log("ns1")
       ns2   <- Gen.int(Range.linear(0, Int.MaxValue)).list(Range.singleton(ns1.length)).log("ns2")
       map   <- Gen.constant(ns1.zip(ns2).toMap).log("map")
       input <- Gen.constant(map.map { case (key, value) => PosLong.unsafeFrom(key) -> value }).log("input")
@@ -563,7 +563,7 @@ trait numericSpec {
 
   def testKeyDecoderPosLong: Property =
     for {
-      ns1      <- Gen.long(Range.linear(1L, Long.MaxValue)).list(Range.linear(1, 10)).log("ns1")
+      ns1      <- Gen.long(Range.linear(1L, MaxLongValue)).list(Range.linear(1, 10)).log("ns1")
       ns2      <- Gen.int(Range.linear(0, Int.MaxValue)).list(Range.singleton(ns1.length)).log("ns2")
       map      <- Gen.constant(ns1.zip(ns2).toMap).log("map")
       expected <- Gen.constant(map.map { case (key, value) => PosLong.unsafeFrom(key) -> value }).log("expected")
@@ -578,7 +578,7 @@ trait numericSpec {
 
   def testEncoderNonPosLong: Property =
     for {
-      n <- Gen.long(Range.linear(0L, Long.MinValue)).log("n")
+      n <- Gen.long(Range.linear(0L, MinLongValue)).log("n")
     } yield {
       val input = NonPosLong.unsafeFrom(n)
 
@@ -594,7 +594,7 @@ trait numericSpec {
 
   def testDecoderNonPosLong: Property =
     for {
-      n <- Gen.long(Range.linear(0L, Long.MinValue)).log("n")
+      n <- Gen.long(Range.linear(0L, MinLongValue)).log("n")
     } yield {
       val input = n.asJson
 
@@ -605,7 +605,7 @@ trait numericSpec {
 
   def testKeyEncoderNonPosLong: Property =
     for {
-      ns1   <- Gen.long(Range.linear(0L, Long.MinValue)).list(Range.linear(1, 10)).log("ns1")
+      ns1   <- Gen.long(Range.linear(0L, MinLongValue)).list(Range.linear(1, 10)).log("ns1")
       ns2   <- Gen.int(Range.linear(0, Int.MaxValue)).list(Range.singleton(ns1.length)).log("ns2")
       map   <- Gen.constant(ns1.zip(ns2).toMap).log("map")
       input <- Gen.constant(map.map { case (key, value) => NonPosLong.unsafeFrom(key) -> value }).log("input")
@@ -623,7 +623,7 @@ trait numericSpec {
 
   def testKeyDecoderNonPosLong: Property =
     for {
-      ns1      <- Gen.long(Range.linear(0L, Long.MinValue)).list(Range.linear(1, 10)).log("ns1")
+      ns1      <- Gen.long(Range.linear(0L, MinLongValue)).list(Range.linear(1, 10)).log("ns1")
       ns2      <- Gen.int(Range.linear(0, Int.MaxValue)).list(Range.singleton(ns1.length)).log("ns2")
       map      <- Gen.constant(ns1.zip(ns2).toMap).log("map")
       expected <- Gen.constant(map.map { case (key, value) => NonPosLong.unsafeFrom(key) -> value }).log("expected")
@@ -1350,7 +1350,7 @@ trait numericSpec {
 
   def testEncoderNegBigInt: Property =
     for {
-      n <- Gen.long(Range.linear(-1L, Long.MinValue)).map(BigInt(_)).log("n")
+      n <- Gen.long(Range.linear(-1L, MinLongValue)).map(BigInt(_)).log("n")
     } yield {
       val input = NegBigInt.unsafeFrom(n)
 
@@ -1366,7 +1366,7 @@ trait numericSpec {
 
   def testDecoderNegBigInt: Property =
     for {
-      n <- Gen.long(Range.linear(-1L, Long.MinValue)).map(BigInt(_)).log("n")
+      n <- Gen.long(Range.linear(-1L, MinLongValue)).map(BigInt(_)).log("n")
     } yield {
       val input = n.asJson
 
@@ -1377,7 +1377,7 @@ trait numericSpec {
 
   def testKeyEncoderNegBigInt: Property =
     for {
-      ns1   <- Gen.long(Range.linear(-1L, Long.MinValue)).list(Range.linear(1, 10)).log("ns1")
+      ns1   <- Gen.long(Range.linear(-1L, MinLongValue)).list(Range.linear(1, 10)).log("ns1")
       ns2   <- Gen.int(Range.linear(0, Int.MaxValue)).list(Range.singleton(ns1.length)).log("ns2")
       map   <- Gen.constant(ns1.zip(ns2).toMap).log("map")
       input <- Gen.constant(map.map { case (key, value) => NegBigInt.unsafeFrom(key) -> value }).log("input")
@@ -1396,7 +1396,7 @@ trait numericSpec {
   @SuppressWarnings(Array("org.wartremover.warts.ToString"))
   def testKeyDecoderNegBigInt: Property =
     for {
-      ns1      <- Gen.long(Range.linear(-1L, Long.MinValue)).map(BigInt(_)).list(Range.linear(1, 10)).log("ns1")
+      ns1      <- Gen.long(Range.linear(-1L, MinLongValue)).map(BigInt(_)).list(Range.linear(1, 10)).log("ns1")
       ns2      <- Gen.int(Range.linear(0, Int.MaxValue)).list(Range.singleton(ns1.length)).log("ns2")
       map      <- Gen.constant(ns1.zip(ns2).toMap).log("map")
       expected <- Gen.constant(map.map { case (key, value) => NegBigInt.unsafeFrom(key) -> value }).log("expected")
@@ -1411,7 +1411,7 @@ trait numericSpec {
 
   def testEncoderNonNegBigInt: Property =
     for {
-      n <- Gen.long(Range.linear(0L, Long.MaxValue)).map(BigInt(_)).log("n")
+      n <- Gen.long(Range.linear(0L, MaxLongValue)).map(BigInt(_)).log("n")
     } yield {
       val input = NonNegBigInt.unsafeFrom(n)
 
@@ -1427,7 +1427,7 @@ trait numericSpec {
 
   def testDecoderNonNegBigInt: Property =
     for {
-      n <- Gen.long(Range.linear(0L, Long.MaxValue)).map(BigInt(_)).log("n")
+      n <- Gen.long(Range.linear(0L, MaxLongValue)).map(BigInt(_)).log("n")
     } yield {
       val input = n.asJson
 
@@ -1439,7 +1439,7 @@ trait numericSpec {
   @SuppressWarnings(Array("org.wartremover.warts.ToString"))
   def testKeyEncoderNonNegBigInt: Property =
     for {
-      ns1   <- Gen.long(Range.linear(0L, Long.MaxValue)).map(BigInt(_)).list(Range.linear(1, 10)).log("ns1")
+      ns1   <- Gen.long(Range.linear(0L, MaxLongValue)).map(BigInt(_)).list(Range.linear(1, 10)).log("ns1")
       ns2   <- Gen.int(Range.linear(0, Int.MaxValue)).list(Range.singleton(ns1.length)).log("ns2")
       map   <- Gen.constant(ns1.zip(ns2).toMap).log("map")
       input <- Gen.constant(map.map { case (key, value) => NonNegBigInt.unsafeFrom(key) -> value }).log("input")
@@ -1458,7 +1458,7 @@ trait numericSpec {
   @SuppressWarnings(Array("org.wartremover.warts.ToString"))
   def testKeyDecoderNonNegBigInt: Property =
     for {
-      ns1      <- Gen.long(Range.linear(0L, Long.MaxValue)).map(BigInt(_)).list(Range.linear(1, 10)).log("ns1")
+      ns1      <- Gen.long(Range.linear(0L, MaxLongValue)).map(BigInt(_)).list(Range.linear(1, 10)).log("ns1")
       ns2      <- Gen.int(Range.linear(0, Int.MaxValue)).list(Range.singleton(ns1.length)).log("ns2")
       map      <- Gen.constant(ns1.zip(ns2).toMap).log("map")
       expected <- Gen.constant(map.map { case (key, value) => NonNegBigInt.unsafeFrom(key) -> value }).log("expected")
@@ -1473,7 +1473,7 @@ trait numericSpec {
 
   def testEncoderPosBigInt: Property =
     for {
-      n <- Gen.long(Range.linear(1L, Long.MaxValue)).map(BigInt(_)).log("n")
+      n <- Gen.long(Range.linear(1L, MaxLongValue)).map(BigInt(_)).log("n")
     } yield {
       val input = PosBigInt.unsafeFrom(n)
 
@@ -1489,7 +1489,7 @@ trait numericSpec {
 
   def testDecoderPosBigInt: Property =
     for {
-      n <- Gen.long(Range.linear(1L, Long.MaxValue)).map(BigInt(_)).log("n")
+      n <- Gen.long(Range.linear(1L, MaxLongValue)).map(BigInt(_)).log("n")
     } yield {
       val input = n.asJson
 
@@ -1501,7 +1501,7 @@ trait numericSpec {
   @SuppressWarnings(Array("org.wartremover.warts.ToString"))
   def testKeyEncoderPosBigInt: Property =
     for {
-      ns1   <- Gen.long(Range.linear(1L, Long.MaxValue)).map(BigInt(_)).list(Range.linear(1, 10)).log("ns1")
+      ns1   <- Gen.long(Range.linear(1L, MaxLongValue)).map(BigInt(_)).list(Range.linear(1, 10)).log("ns1")
       ns2   <- Gen.int(Range.linear(0, Int.MaxValue)).list(Range.singleton(ns1.length)).log("ns2")
       map   <- Gen.constant(ns1.zip(ns2).toMap).log("map")
       input <- Gen.constant(map.map { case (key, value) => PosBigInt.unsafeFrom(key) -> value }).log("input")
@@ -1520,7 +1520,7 @@ trait numericSpec {
   @SuppressWarnings(Array("org.wartremover.warts.ToString"))
   def testKeyDecoderPosBigInt: Property =
     for {
-      ns1      <- Gen.long(Range.linear(1L, Long.MaxValue)).map(BigInt(_)).list(Range.linear(1, 10)).log("ns1")
+      ns1      <- Gen.long(Range.linear(1L, MaxLongValue)).map(BigInt(_)).list(Range.linear(1, 10)).log("ns1")
       ns2      <- Gen.int(Range.linear(0, Int.MaxValue)).list(Range.singleton(ns1.length)).log("ns2")
       map      <- Gen.constant(ns1.zip(ns2).toMap).log("map")
       expected <- Gen.constant(map.map { case (key, value) => PosBigInt.unsafeFrom(key) -> value }).log("expected")
@@ -1535,7 +1535,7 @@ trait numericSpec {
 
   def testEncoderNonPosBigInt: Property =
     for {
-      n <- Gen.long(Range.linear(0L, Long.MinValue)).map(BigInt(_)).log("n")
+      n <- Gen.long(Range.linear(0L, MinLongValue)).map(BigInt(_)).log("n")
     } yield {
       val input = NonPosBigInt.unsafeFrom(n)
 
@@ -1551,7 +1551,7 @@ trait numericSpec {
 
   def testDecoderNonPosBigInt: Property =
     for {
-      n <- Gen.long(Range.linear(0L, Long.MinValue)).map(BigInt(_)).log("n")
+      n <- Gen.long(Range.linear(0L, MinLongValue)).map(BigInt(_)).log("n")
     } yield {
       val input = n.asJson
 
@@ -1563,7 +1563,7 @@ trait numericSpec {
   @SuppressWarnings(Array("org.wartremover.warts.ToString"))
   def testKeyEncoderNonPosBigInt: Property =
     for {
-      ns1   <- Gen.long(Range.linear(0L, Long.MinValue)).map(BigInt(_)).list(Range.linear(1, 10)).log("ns1")
+      ns1   <- Gen.long(Range.linear(0L, MinLongValue)).map(BigInt(_)).list(Range.linear(1, 10)).log("ns1")
       ns2   <- Gen.int(Range.linear(0, Int.MaxValue)).list(Range.singleton(ns1.length)).log("ns2")
       map   <- Gen.constant(ns1.zip(ns2).toMap).log("map")
       input <- Gen.constant(map.map { case (key, value) => NonPosBigInt.unsafeFrom(key) -> value }).log("input")
@@ -1582,7 +1582,7 @@ trait numericSpec {
   @SuppressWarnings(Array("org.wartremover.warts.ToString"))
   def testKeyDecoderNonPosBigInt: Property =
     for {
-      ns1      <- Gen.long(Range.linear(0L, Long.MinValue)).map(BigInt(_)).list(Range.linear(1, 10)).log("ns1")
+      ns1      <- Gen.long(Range.linear(0L, MinLongValue)).map(BigInt(_)).list(Range.linear(1, 10)).log("ns1")
       ns2      <- Gen.int(Range.linear(0, Int.MaxValue)).list(Range.singleton(ns1.length)).log("ns2")
       map      <- Gen.constant(ns1.zip(ns2).toMap).log("map")
       expected <- Gen.constant(map.map { case (key, value) => NonPosBigInt.unsafeFrom(key) -> value }).log("expected")

--- a/modules/refined4s-core/js/src/main/scala/refined4s/types/networkCompat.scala
+++ b/modules/refined4s-core/js/src/main/scala/refined4s/types/networkCompat.scala
@@ -1,0 +1,129 @@
+package refined4s.types
+
+import refined4s.InlinedRefined
+import refined4s.types.network.Uri
+import refined4s.types.network.UnexpectedLiteralErrorMessage
+
+import scala.quoted.*
+
+import java.net.URI
+import scala.quoted.{Expr, Quotes}
+import scala.util.control.NonFatal
+
+/** @author Kevin Lee
+  * @since 2024-09-04
+  */
+object networkCompat {
+  val validUrlSchemes = Set("http", "https", "ftp", "file")
+
+  type Url = Url.Type
+  object Url extends InlinedRefined[String] {
+
+    override def invalidReason(a: String): String =
+      expectedMessage(inlinedExpectedValue)
+
+    @SuppressWarnings(Array("org.wartremover.warts.JavaNetURLConstructors"))
+    override def predicate(a: String): Boolean =
+      validate(a) match {
+        case Left(err) =>
+//          println(err)
+          false
+        case Right(_) =>
+          true
+      }
+
+    def validate(url: String): Either[String, String] =
+      try {
+        val uri = new URI(url)
+
+        val isValidSchemas   = validUrlSchemes.contains(uri.getScheme)
+        /* URI.getHost works different from Java.'s URI.getHost */
+//        val isValidHost      = Option(uri.getHost).isDefined
+        val isValidAuthority = Option(uri.getAuthority).isDefined
+        val isAbsolute       = uri.isAbsolute
+        val isValidPath      = {
+          val path = uri.getPath
+          path.isEmpty || path.startsWith("/")
+        }
+
+        val errors = List(
+          if isValidSchemas then None else Some("Schema"),
+//          if isValidHost then None else Some("Host"),
+          if isValidAuthority then None else Some("Authority"),
+          if isAbsolute then None else Some("Absolute URL"),
+          if isValidPath then None else Some("Path"),
+        ).flatten
+
+        if errors.isEmpty
+        then Right(url)
+        else
+          Left(
+            s"Invalid URL. URL: $url, The following propert${if errors.length > 1 then "ies are" else "y is"} invalid: ${errors.mkString("[", ", ", "]")}"
+          )
+      } catch {
+        case NonFatal(err) =>
+          Left(s"Invalid URL. URL: $url, Error: ${err.getMessage}")
+      }
+
+    override inline val inlinedExpectedValue = "a URL String"
+
+    override inline def inlinedPredicate(inline url: String): Boolean = ${ isValidateUrl('url) }
+
+//    @SuppressWarnings(Array("org.wartremover.warts.ToString"))
+//    def apply(a: URL): Type = unsafeFrom(a.toString)
+
+    extension (url: Type) {
+//      @SuppressWarnings(Array("org.wartremover.warts.JavaNetURLConstructors"))
+//      def toURL: URL = new URL(url.value)
+
+      def toUri: Uri = Uri(toURI)
+
+      def toURI: URI = new URI(url.value)
+    }
+
+  }
+
+  @SuppressWarnings(Array("org.wartremover.warts.JavaNetURLConstructors"))
+  def isValidateUrl(urlExpr: Expr[String])(using Quotes): Expr[Boolean] = {
+    import quotes.reflect.*
+
+    def debug(isValid: Boolean, message: String): Unit = if !isValid then report.info(message + " is invalid", urlExpr) else ()
+
+    urlExpr.asTerm match {
+      case Inlined(_, _, Literal(StringConstant(urlStr))) =>
+        try {
+          val uri = new URI(urlStr)
+
+          val isValidSchemas   = validUrlSchemes.contains(uri.getScheme)
+//          val isValidHost      = Option(uri.getHost).isDefined
+          val isValidAuthority = Option(uri.getAuthority).isDefined
+          val isAbsolute       = uri.isAbsolute
+          val isValidPath      = {
+            val path = uri.getPath
+            path.isEmpty || path.startsWith("/")
+          }
+
+          debug(isValidSchemas, "Schema")
+//          debug(isValidHost, "Host")
+          debug(isValidAuthority, "Authority")
+          debug(isAbsolute, "It should be absolute but ")
+          debug(isValidPath, "Path")
+
+          val validity = isValidSchemas &&
+//            isValidHost &&
+            isValidAuthority &&
+            isAbsolute && isValidPath
+          Expr(validity)
+        } catch {
+          case _: Throwable => Expr(false)
+        }
+      case _ =>
+        report.error(
+          UnexpectedLiteralErrorMessage,
+          urlExpr,
+        )
+        Expr(false)
+    }
+  }
+
+}

--- a/modules/refined4s-core/js/src/test/scala/refined4s/types/networkCompatSpec.scala
+++ b/modules/refined4s-core/js/src/test/scala/refined4s/types/networkCompatSpec.scala
@@ -1,0 +1,277 @@
+package refined4s.types
+
+import cats.syntax.all.*
+import hedgehog.*
+import hedgehog.runner.*
+
+import java.net.URI
+
+/** @author Kevin Lee
+  * @since 2024-09-05
+  */
+trait networkCompatSpec {
+
+  import refined4s.types.network.*
+
+  def compatTests: List[Test] = List(
+    property("test Uri.toUrl", testUriToUrl),
+    //
+    example("test Url(valid URL String)", testUrlApply),
+//    example("test Url(URL)", testUrlApplyURL),
+    example("test Url(invalid URL String)", testUrlApplyInvalid),
+    property("test Url.from(valid)", testUrlFromValid),
+    property("test Url.from(invalid)", testUrlFromInvalid),
+    property("test Url.unsafeFrom(valid)", testUrlUnsafeFromValid),
+    property("test Url.unsafeFrom(invalid)", testUrlUnsafeFromInvalid),
+    property("test Url.value", testUrlValue),
+    property("test Url.unapply", testUrlUnapply),
+//    property("test Url.toURL", testUrlToURL),
+    property("test Url.toUri", testUrlToUri),
+    property("test Url.toURI", testUrlToURI),
+    example("test network.isValidateUrl(valid URL String)", testNetworkIsValidateUrlValid),
+    example("test network.isValidateUrl(invalid URL String)", testNetworkIsValidateUrlInvalid),
+    example("test network.isValidateUrl(non-String literal)", testNetworkIsValidateUrlWithInvalidLiteral),
+  )
+  //
+
+  def testUriToUrl: Property =
+    for {
+      uri <- networkGens.genUrlString.log("uri")
+    } yield {
+      val expected = Url.unsafeFrom(uri)
+      val actual   = Uri.unsafeFrom(uri).toUrl
+
+      actual ==== expected
+    }
+
+  //
+
+  def testUrlApply: Result = {
+    @SuppressWarnings(Array("org.wartremover.warts.JavaNetURLConstructors"))
+    val expected = URI("https://github.com/kevin-lee/refined4s")
+    val actual   = Url("https://github.com/kevin-lee/refined4s")
+    Result.all(
+      List(
+        actual.value ==== expected.toString,
+        actual.toURI ==== expected,
+      )
+    )
+  }
+
+//  def testUrlApplyURL: Result = {
+//    @SuppressWarnings(Array("org.wartremover.warts.JavaNetURLConstructors"))
+//    val url      = new URL("https://github.com/kevin-lee/refined4s")
+//    val expected = url
+//    val actual   = Url(url)
+//    Result.all(
+//      List(
+//        actual.value ==== expected.toString,
+//        actual.toURL ==== expected,
+//      )
+//    )
+//  }
+
+  def testUrlApplyInvalid: Result = {
+    import scala.compiletime.testing.typeChecks
+
+    val shouldNotCompile1 = !typeChecks(
+      """
+        import network.*
+        Url("%^<>[]`{}")
+      """
+    )
+
+    val shouldNotCompile2 = !typeChecks(
+      """
+        import network.*
+        Url("blah://www.google.com")
+      """
+    )
+
+    Result.all(
+      List(
+        Result.assert(shouldNotCompile1).log("""Url("%^<>[]`{}") should have failed compilation but it succeeded."""),
+        Result.assert(shouldNotCompile2).log("""Url("blah://www.google.com") should have failed compilation but it succeeded."""),
+      )
+    )
+  }
+
+  def testUrlFromValid: Property =
+    for {
+      url <- networkGens.genUrlString.log("url")
+    } yield {
+      val expected = Url.unsafeFrom(url).asRight
+      val actual   = Url.from(url)
+
+      Result.all(
+        List(
+          actual ==== expected
+        )
+      )
+    }
+
+  def testUrlFromInvalid: Property =
+    for {
+      input <- Gen
+                 .frequency1(
+                   30 ->
+                     Gen.string(Gen.element1('%', '^', '<', '>', '[', ']', '`', '{', '}'), Range.linear(1, 5)),
+                   70 -> (for {
+                     scheme    <- Gen.string(Gen.alpha, Range.linear(3, 10)).map {
+                                    case "http" | "https" | "ftp" | "file" => "blah"
+                                    case anythingElse => anythingElse
+                                  }
+                     authority <- Gen
+                                    .string(Gen.alphaNum, Range.linear(3, 10))
+                                    .list(Range.linear(1, 4))
+                                    .map(_.mkString("."))
+                   } yield s"$scheme/$authority"),
+                 )
+                 .log("input")
+    } yield {
+      val expected = s"Invalid value: [$input]. It must be a URL String".asLeft
+      val actual   = Url.from(input)
+
+      actual ==== expected
+    }
+
+  def testUrlUnsafeFromValid: Property =
+    for {
+      url <- networkGens.genUrlString.log("url")
+    } yield {
+      val expected = Url.from(url)
+      val actual   = Url.unsafeFrom(url)
+
+      Result.all(
+        List(
+          actual.asRight ==== expected,
+          expected.fold(err => Result.failure.log(s"expected Url.from(url) results in error: $err"), actual ==== _),
+        )
+      )
+    }
+
+  def testUrlUnsafeFromInvalid: Property =
+    for {
+      input <- Gen
+                 .frequency1(
+                   30 ->
+                     Gen.string(Gen.element1('%', '^', '<', '>', '[', ']', '`', '{', '}'), Range.linear(1, 5)),
+                   70 -> (for {
+                     scheme    <- Gen.string(Gen.alpha, Range.linear(3, 10)).map {
+                                    case "http" | "https" | "ftp" | "file" => "blah"
+                                    case anythingElse => anythingElse
+                                  }
+                     authority <- Gen
+                                    .string(Gen.alphaNum, Range.linear(3, 10))
+                                    .list(Range.linear(1, 4))
+                                    .map(_.mkString("."))
+                   } yield s"$scheme/$authority"),
+                 )
+                 .log("input")
+    } yield {
+      val expected = s"Invalid value: [$input]. It must be a URL String"
+
+      try {
+        val _ = Url.unsafeFrom(input)
+        Result
+          .failure
+          .log(
+            s"""IllegalArgumentException was expected from Url.unsafeFrom($input), but it was not thrown."""
+          )
+      } catch {
+        case ex: IllegalArgumentException =>
+          ex.getMessage ==== expected
+      }
+    }
+
+  def testUrlValue: Property =
+    for {
+      uri <- networkGens.genUrlString.log("uri")
+    } yield {
+      val expected = uri
+      val actual   = Url.unsafeFrom(uri).value
+
+      actual ==== expected
+    }
+
+  def testUrlUnapply: Property =
+    for {
+      uri <- networkGens.genUrlString.log("uri")
+    } yield {
+      val expected = uri
+      Url.unsafeFrom(uri) match {
+        case Url(actual) =>
+          actual ==== expected
+      }
+    }
+
+//  def testUrlToURL: Property =
+//    for {
+//      uri <- networkGens.genUrlString.log("uri")
+//    } yield {
+//      @SuppressWarnings(Array("org.wartremover.warts.JavaNetURLConstructors"))
+//      val expected = new URL(uri)
+//      val actual   = Url.unsafeFrom(uri).toURL
+//
+//      actual ==== expected
+//    }
+
+  def testUrlToUri: Property =
+    for {
+      uri <- networkGens.genUrlString.log("uri")
+    } yield {
+      val expected = Uri.unsafeFrom(uri)
+      val actual   = Url.unsafeFrom(uri).toUri
+
+      actual ==== expected
+    }
+
+  def testUrlToURI: Property =
+    for {
+      uri <- networkGens.genUrlString.log("uri")
+    } yield {
+      val expected = new URI(uri)
+      val actual   = Url.unsafeFrom(uri).toURI
+
+      actual ==== expected
+    }
+
+  inline def runNetworkIsValidateUrl(inline a: String): Boolean = ${ networkCompat.isValidateUrl('a) }
+
+  def testNetworkIsValidateUrlValid: Result = {
+    val expected = true
+    val actual   = runNetworkIsValidateUrl("https://github.com/kevin-lee/refined4s")
+    (actual ==== expected)
+      .log("""network.isValidateUrl("https://github.com/kevin-lee/refined4s") should return true but it returned false.""")
+  }
+
+  def testNetworkIsValidateUrlInvalid: Result = {
+    val expected = false
+    val actual1  = runNetworkIsValidateUrl("%^<>[]`{}")
+    val actual2  = runNetworkIsValidateUrl("blah://www.google.com")
+    Result.all(
+      List(
+        (actual1 ==== expected)
+          .log("""network.isValidateUrl("%^<>[]`{}") should return false but it returned true"""),
+        (actual2 ==== expected)
+          .log("""network.isValidateUrl("blah://www.google.com") should return false but it returned true"""),
+      )
+    )
+  }
+
+  def testNetworkIsValidateUrlWithInvalidLiteral: Result = {
+    import scala.compiletime.testing.typeCheckErrors
+    val expectedMessage = network.UnexpectedLiteralErrorMessage
+
+    val actual = typeCheckErrors(
+      """
+        val a = "blah"
+        runNetworkIsValidateUrl(a)
+      """
+    )
+
+    val actualErrorMessage = actual.map(_.message).mkString
+    (actualErrorMessage ==== expectedMessage)
+  }
+
+}

--- a/modules/refined4s-core/jvm/src/main/scala/refined4s/types/networkCompat.scala
+++ b/modules/refined4s-core/jvm/src/main/scala/refined4s/types/networkCompat.scala
@@ -1,0 +1,71 @@
+package refined4s.types
+
+import refined4s.InlinedRefined
+import refined4s.types.network.{UnexpectedLiteralErrorMessage, Uri}
+
+import scala.quoted.*
+
+import java.net.{URI, URL}
+import scala.quoted.{Expr, Quotes}
+import scala.util.control.NonFatal
+
+/** @author Kevin Lee
+  * @since 2024-09-04
+  */
+object networkCompat {
+
+  type Url = Url.Type
+  object Url extends InlinedRefined[String] {
+
+    override def invalidReason(a: String): String =
+      expectedMessage(inlinedExpectedValue)
+
+    @SuppressWarnings(Array("org.wartremover.warts.JavaNetURLConstructors"))
+    override def predicate(a: String): Boolean =
+      try {
+        new URL(a)
+        true
+      } catch {
+        case NonFatal(_) =>
+          false
+      }
+
+    override inline val inlinedExpectedValue = "a URL String"
+
+    override inline def inlinedPredicate(inline url: String): Boolean = ${ isValidateUrl('url) }
+
+    @SuppressWarnings(Array("org.wartremover.warts.ToString"))
+    def apply(a: URL): Type = unsafeFrom(a.toString)
+
+    extension (url: Type) {
+      @SuppressWarnings(Array("org.wartremover.warts.JavaNetURLConstructors"))
+      def toURL: URL = new URL(url.value)
+
+      def toUri: Uri = Uri(toURL.toURI)
+
+      def toURI: URI = toURL.toURI
+    }
+
+  }
+
+  @SuppressWarnings(Array("org.wartremover.warts.JavaNetURLConstructors"))
+  def isValidateUrl(urlExpr: Expr[String])(using Quotes): Expr[Boolean] = {
+    import quotes.reflect.*
+    urlExpr.asTerm match {
+      case Inlined(_, _, Literal(StringConstant(urlStr))) =>
+        try {
+          new java.net.URL(urlStr)
+          Expr(true)
+        } catch {
+          case _: Throwable => Expr(false)
+        }
+      case _ =>
+        report.error(
+          UnexpectedLiteralErrorMessage,
+          urlExpr,
+        )
+        Expr(false)
+    }
+  }
+
+}

--- a/modules/refined4s-core/jvm/src/test/scala/refined4s/types/networkCompatSpec.scala
+++ b/modules/refined4s-core/jvm/src/test/scala/refined4s/types/networkCompatSpec.scala
@@ -1,0 +1,286 @@
+package refined4s.types
+
+import cats.syntax.all.*
+import hedgehog.*
+import hedgehog.runner.*
+
+import java.net.{URI, URL}
+
+/** @author Kevin Lee
+  * @since 2024-09-05
+  */
+trait networkCompatSpec {
+
+  import refined4s.types.network.*
+
+  def compatTests: List[Test] = List(
+    property("test Uri.toUrl", testUriToUrl),
+    //
+    example("test Url(valid URL String)", testUrlApply),
+    example("test Url(URL)", testUrlApplyURL),
+    example("test Url(invalid URL String)", testUrlApplyInvalid),
+    property("test Url.from(valid)", testUrlFromValid),
+    property("test Url.from(invalid)", testUrlFromInvalid),
+    property("test Url.unsafeFrom(valid)", testUrlUnsafeFromValid),
+    property("test Url.unsafeFrom(invalid)", testUrlUnsafeFromInvalid),
+    property("test Url.value", testUrlValue),
+    property("test Url.unapply", testUrlUnapply),
+    property("test Url.toURL", testUrlToURL),
+    property("test Url.toUri", testUrlToUri),
+    property("test Url.toURI", testUrlToURI),
+    example("test network.isValidateUrl(valid URL String)", testNetworkIsValidateUrlValid),
+    example("test network.isValidateUrl(invalid URL String)", testNetworkIsValidateUrlInvalid),
+    example("test network.isValidateUrl(non-String literal)", testNetworkIsValidateUrlWithInvalidLiteral),
+  )
+  //
+
+  def testUriToUrl: Property =
+    for {
+      uri <- networkGens.genUrlString.log("uri")
+    } yield {
+      val expected = Url.unsafeFrom(uri)
+      val actual   = Uri.unsafeFrom(uri).toUrl
+
+      actual ==== expected
+    }
+
+  //
+
+  def testUrlApply: Result = {
+    @SuppressWarnings(Array("org.wartremover.warts.JavaNetURLConstructors"))
+    val expected = new URL("https://github.com/kevin-lee/refined4s")
+    val actual   = Url("https://github.com/kevin-lee/refined4s")
+    Result.all(
+      List(
+        actual.value ==== expected.toString,
+        actual.toURL ==== expected,
+      )
+    )
+  }
+
+  def testUrlApplyURL: Result = {
+    @SuppressWarnings(Array("org.wartremover.warts.JavaNetURLConstructors"))
+    val url      = new URL("https://github.com/kevin-lee/refined4s")
+    val expected = url
+    val actual   = Url(url)
+    Result.all(
+      List(
+        actual.value ==== expected.toString,
+        actual.toURL ==== expected,
+      )
+    )
+  }
+
+  def testUrlApplyInvalid: Result = {
+    import scala.compiletime.testing.typeChecks
+
+    val shouldNotCompile1 = !typeChecks(
+      """
+        import network.*
+        Url("%^<>[]`{}")
+      """
+    )
+
+    val shouldNotCompile2 = !typeChecks(
+      """
+        import network.*
+        Url("blah://www.google.com")
+      """
+    )
+
+    Result.all(
+      List(
+        Result.assert(shouldNotCompile1).log("""Url("%^<>[]`{}") should have failed compilation but it succeeded."""),
+        Result.assert(shouldNotCompile2).log("""Url("blah://www.google.com") should have failed compilation but it succeeded."""),
+      )
+    )
+  }
+
+  def testUrlFromValid: Property =
+    for {
+      uri <- networkGens.genUrlString.log("uri")
+    } yield {
+      val expected = Url.unsafeFrom(uri).asRight
+      val actual   = Url.from(uri)
+
+      @SuppressWarnings(Array("org.wartremover.warts.JavaNetURLConstructors"))
+      val expectedUrl = new URL(uri).asRight
+      val actualUrl   = actual.map(_.toURL)
+
+      Result.all(
+        List(
+          actual ==== expected,
+          actualUrl ==== expectedUrl,
+        )
+      )
+    }
+
+  def testUrlFromInvalid: Property =
+    for {
+      input <- Gen
+                 .frequency1(
+                   30 ->
+                     Gen.string(Gen.element1('%', '^', '<', '>', '[', ']', '`', '{', '}'), Range.linear(1, 5)),
+                   70 -> (for {
+                     scheme    <- Gen.string(Gen.alpha, Range.linear(3, 10)).map {
+                                    case "http" | "https" | "ftp" | "file" => "blah"
+                                    case anythingElse => anythingElse
+                                  }
+                     authority <- Gen
+                                    .string(Gen.alphaNum, Range.linear(3, 10))
+                                    .list(Range.linear(1, 4))
+                                    .map(_.mkString("."))
+                   } yield s"$scheme/$authority"),
+                 )
+                 .log("input")
+    } yield {
+      val expected = s"Invalid value: [$input]. It must be a URL String".asLeft
+      val actual   = Url.from(input)
+
+      actual ==== expected
+    }
+
+  def testUrlUnsafeFromValid: Property =
+    for {
+      uri <- networkGens.genUrlString.log("uri")
+    } yield {
+      val expected = Url.from(uri)
+      val actual   = Url.unsafeFrom(uri)
+
+      @SuppressWarnings(Array("org.wartremover.warts.JavaNetURLConstructors"))
+      val expectedUrl = new URL(uri)
+      val actualUrl   = actual.toURL
+
+      Result.all(
+        List(
+          actual.asRight ==== expected,
+          actualUrl ==== expectedUrl,
+        )
+      )
+    }
+
+  def testUrlUnsafeFromInvalid: Property =
+    for {
+      input <- Gen
+                 .frequency1(
+                   30 ->
+                     Gen.string(Gen.element1('%', '^', '<', '>', '[', ']', '`', '{', '}'), Range.linear(1, 5)),
+                   70 -> (for {
+                     scheme    <- Gen.string(Gen.alpha, Range.linear(3, 10)).map {
+                                    case "http" | "https" | "ftp" | "file" => "blah"
+                                    case anythingElse => anythingElse
+                                  }
+                     authority <- Gen
+                                    .string(Gen.alphaNum, Range.linear(3, 10))
+                                    .list(Range.linear(1, 4))
+                                    .map(_.mkString("."))
+                   } yield s"$scheme/$authority"),
+                 )
+                 .log("input")
+    } yield {
+      val expected = s"Invalid value: [$input]. It must be a URL String"
+
+      try {
+        val _ = Url.unsafeFrom(input)
+        Result
+          .failure
+          .log(
+            s"""IllegalArgumentException was expected from Url.unsafeFrom($input), but it was not thrown."""
+          )
+      } catch {
+        case ex: IllegalArgumentException =>
+          ex.getMessage ==== expected
+      }
+    }
+
+  def testUrlValue: Property =
+    for {
+      uri <- networkGens.genUrlString.log("uri")
+    } yield {
+      val expected = uri
+      val actual   = Url.unsafeFrom(uri).value
+
+      actual ==== expected
+    }
+
+  def testUrlUnapply: Property =
+    for {
+      uri <- networkGens.genUrlString.log("uri")
+    } yield {
+      val expected = uri
+      Url.unsafeFrom(uri) match {
+        case Url(actual) =>
+          actual ==== expected
+      }
+    }
+
+  def testUrlToURL: Property =
+    for {
+      uri <- networkGens.genUrlString.log("uri")
+    } yield {
+      @SuppressWarnings(Array("org.wartremover.warts.JavaNetURLConstructors"))
+      val expected = new URL(uri)
+      val actual   = Url.unsafeFrom(uri).toURL
+
+      actual ==== expected
+    }
+
+  def testUrlToUri: Property =
+    for {
+      uri <- networkGens.genUrlString.log("uri")
+    } yield {
+      val expected = Uri.unsafeFrom(uri)
+      val actual   = Url.unsafeFrom(uri).toUri
+
+      actual ==== expected
+    }
+
+  def testUrlToURI: Property =
+    for {
+      uri <- networkGens.genUrlString.log("uri")
+    } yield {
+      val expected = new URI(uri)
+      val actual   = Url.unsafeFrom(uri).toURI
+
+      actual ==== expected
+    }
+
+  inline def runNetworkIsValidateUrl(inline a: String): Boolean = ${ networkCompat.isValidateUrl('a) }
+
+  def testNetworkIsValidateUrlValid: Result = {
+    val expected = true
+    val actual   = runNetworkIsValidateUrl("https://github.com/kevin-lee/refined4s")
+    (actual ==== expected)
+      .log("""network.isValidateUrl("https://github.com/kevin-lee/refined4s") should return true but it returned false.""")
+  }
+
+  def testNetworkIsValidateUrlInvalid: Result = {
+    val expected = false
+    val actual1  = runNetworkIsValidateUrl("%^<>[]`{}")
+    val actual2  = runNetworkIsValidateUrl("blah://www.google.com")
+    Result.all(
+      List(
+        (actual1 ==== expected)
+          .log("""network.isValidateUrl("%^<>[]`{}") should return false but it returned true"""),
+        (actual2 ==== expected)
+          .log("""network.isValidateUrl("blah://www.google.com") should return false but it returned true"""),
+      )
+    )
+  }
+
+  def testNetworkIsValidateUrlWithInvalidLiteral: Result = {
+    import scala.compiletime.testing.typeCheckErrors
+    val expectedMessage = network.UnexpectedLiteralErrorMessage
+
+    val actual = typeCheckErrors(
+      """
+        val a = "blah"
+        runNetworkIsValidateUrl(a)
+      """
+    )
+
+    val actualErrorMessage = actual.map(_.message).mkString
+    (actualErrorMessage ==== expectedMessage)
+  }
+
+}

--- a/modules/refined4s-core/shared/src/test/scala/refined4s/types/networkSpec.scala
+++ b/modules/refined4s-core/shared/src/test/scala/refined4s/types/networkSpec.scala
@@ -5,16 +5,17 @@ import cats.syntax.all.*
 import hedgehog.*
 import hedgehog.runner.*
 
-import java.net.{URI, URL}
+//import java.net.{URI, URL}
+import java.net.URI
 
 /** @author Kevin Lee
   * @since 2023-12-09
   */
 @SuppressWarnings(Array("org.wartremover.warts.JavaNetURLConstructors"))
-object networkSpec extends Properties {
-  import all.*
+trait networkSpec extends Properties, networkCompatSpec {
+  import network.*
 
-  override def tests: List[Test] = List(
+  override def tests: List[Test] = compatTests ++ List(
     example("test Uri(valid URI String)", testUriApply),
     example("test Uri(URI)", testUriApplyURI),
     example("test Uri(invalid URI String)", testUriApplyInvalid),
@@ -25,27 +26,11 @@ object networkSpec extends Properties {
     property("test Uri.value", testUriValue),
     property("test Uri.unapply", testUriUnapply),
     property("test Uri.toURI", testUriToURI),
-    property("test Uri.toUrl", testUriToUrl),
-    property("test Uri.toURL", testUriToURL),
+//    property("test Uri.toURL", testUriToURL),
     example("test network.isValidateUri(valid URI String)", testNetworkIsValidateUriValid),
     example("test network.isValidateUri(invalid URI String)", testNetworkIsValidateUriInvalid),
     example("test network.isValidateUri(non-String literal)", testNetworkIsValidateUriWithInvalidLiteral),
-    //
-    example("test Url(valid URL String)", testUrlApply),
-    example("test Url(URL)", testUrlApplyURL),
-    example("test Url(invalid URL String)", testUrlApplyInvalid),
-    property("test Url.from(valid)", testUrlFromValid),
-    property("test Url.from(invalid)", testUrlFromInvalid),
-    property("test Url.unsafeFrom(valid)", testUrlUnsafeFromValid),
-    property("test Url.unsafeFrom(invalid)", testUrlUnsafeFromInvalid),
-    property("test Url.value", testUrlValue),
-    property("test Url.unapply", testUrlUnapply),
-    property("test Url.toURL", testUrlToURL),
-    property("test Url.toUri", testUrlToUri),
-    property("test Url.toURI", testUrlToURI),
-    example("test network.isValidateUrl(valid URL String)", testNetworkIsValidateUrlValid),
-    example("test network.isValidateUrl(invalid URL String)", testNetworkIsValidateUrlInvalid),
-    example("test network.isValidateUrl(non-String literal)", testNetworkIsValidateUrlWithInvalidLiteral),
+
     //
     example("test PortNumber(valid)", testPortNumberApply),
     example("test PortNumber(invalid)", testPortNumberApplyInvalid),
@@ -224,25 +209,15 @@ object networkSpec extends Properties {
       actual ==== expected
     }
 
-  def testUriToUrl: Property =
-    for {
-      uri <- networkGens.genUrlString.log("uri")
-    } yield {
-      val expected = Url.unsafeFrom(uri)
-      val actual   = Uri.unsafeFrom(uri).toUrl
-
-      actual ==== expected
-    }
-
-  def testUriToURL: Property =
-    for {
-      uri <- networkGens.genUrlString.log("uri")
-    } yield {
-      val expected = new URL(uri)
-      val actual   = Uri.unsafeFrom(uri).toURL
-
-      actual ==== expected
-    }
+//  def testUriToURL: Property =
+//    for {
+//      uri <- networkGens.genUrlString.log("uri")
+//    } yield {
+//      val expected = new URL(uri)
+//      val actual   = Uri.unsafeFrom(uri).toURL
+//
+//      actual ==== expected
+//    }
 
   inline def runNetworkIsValidateUri(inline a: String): Boolean = ${ network.isValidateUri('a) }
 
@@ -268,240 +243,6 @@ object networkSpec extends Properties {
       """
         val a = "blah"
         runNetworkIsValidateUri(a)
-      """
-    )
-
-    val actualErrorMessage = actual.map(_.message).mkString
-    (actualErrorMessage ==== expectedMessage)
-  }
-
-  //
-
-  def testUrlApply: Result = {
-    val expected = new URL("https://github.com/kevin-lee/refined4s")
-    val actual   = Url("https://github.com/kevin-lee/refined4s")
-    Result.all(
-      List(
-        actual.value ==== expected.toString,
-        actual.toURL ==== expected,
-      )
-    )
-  }
-
-  def testUrlApplyURL: Result = {
-    val url      = new URL("https://github.com/kevin-lee/refined4s")
-    val expected = url
-    val actual   = Url(url)
-    Result.all(
-      List(
-        actual.value ==== expected.toString,
-        actual.toURL ==== expected,
-      )
-    )
-  }
-
-  def testUrlApplyInvalid: Result = {
-    import scala.compiletime.testing.typeChecks
-
-    val shouldNotCompile1 = !typeChecks(
-      """
-        import network.*
-        Url("%^<>[]`{}")
-      """
-    )
-
-    val shouldNotCompile2 = !typeChecks(
-      """
-        import network.*
-        Url("blah://www.google.com")
-      """
-    )
-
-    Result.all(
-      List(
-        Result.assert(shouldNotCompile1).log("""Url("%^<>[]`{}") should have failed compilation but it succeeded."""),
-        Result.assert(shouldNotCompile2).log("""Url("blah://www.google.com") should have failed compilation but it succeeded."""),
-      )
-    )
-  }
-
-  def testUrlFromValid: Property =
-    for {
-      uri <- networkGens.genUrlString.log("uri")
-    } yield {
-      val expected = Url.unsafeFrom(uri).asRight
-      val actual   = Url.from(uri)
-
-      val expectedUrl = new URL(uri).asRight
-      val actualUrl   = actual.map(_.toURL)
-
-      Result.all(
-        List(
-          actual ==== expected,
-          actualUrl ==== expectedUrl,
-        )
-      )
-    }
-
-  def testUrlFromInvalid: Property =
-    for {
-      input <- Gen
-                 .frequency1(
-                   30 ->
-                     Gen.string(Gen.element1('%', '^', '<', '>', '[', ']', '`', '{', '}'), Range.linear(1, 5)),
-                   70 -> (for {
-                     scheme    <- Gen.string(Gen.alpha, Range.linear(3, 10)).map {
-                                    case "http" | "https" | "ftp" | "file" => "blah"
-                                    case anythingElse => anythingElse
-                                  }
-                     authority <- Gen
-                                    .string(Gen.alphaNum, Range.linear(3, 10))
-                                    .list(Range.linear(1, 4))
-                                    .map(_.mkString("."))
-                   } yield s"$scheme/$authority"),
-                 )
-                 .log("input")
-    } yield {
-      val expected = s"Invalid value: [$input]. It must be a URL String".asLeft
-      val actual   = Url.from(input)
-
-      actual ==== expected
-    }
-
-  def testUrlUnsafeFromValid: Property =
-    for {
-      uri <- networkGens.genUrlString.log("uri")
-    } yield {
-      val expected = Url.from(uri)
-      val actual   = Url.unsafeFrom(uri)
-
-      val expectedUrl = new URL(uri)
-      val actualUrl   = actual.toURL
-
-      Result.all(
-        List(
-          actual.asRight ==== expected,
-          actualUrl ==== expectedUrl,
-        )
-      )
-    }
-
-  def testUrlUnsafeFromInvalid: Property =
-    for {
-      input <- Gen
-                 .frequency1(
-                   30 ->
-                     Gen.string(Gen.element1('%', '^', '<', '>', '[', ']', '`', '{', '}'), Range.linear(1, 5)),
-                   70 -> (for {
-                     scheme    <- Gen.string(Gen.alpha, Range.linear(3, 10)).map {
-                                    case "http" | "https" | "ftp" | "file" => "blah"
-                                    case anythingElse => anythingElse
-                                  }
-                     authority <- Gen
-                                    .string(Gen.alphaNum, Range.linear(3, 10))
-                                    .list(Range.linear(1, 4))
-                                    .map(_.mkString("."))
-                   } yield s"$scheme/$authority"),
-                 )
-                 .log("input")
-    } yield {
-      val expected = s"Invalid value: [$input]. It must be a URL String"
-
-      try {
-        val _ = Url.unsafeFrom(input)
-        Result
-          .failure
-          .log(
-            s"""IllegalArgumentException was expected from Url.unsafeFrom($input), but it was not thrown."""
-          )
-      } catch {
-        case ex: IllegalArgumentException =>
-          ex.getMessage ==== expected
-      }
-    }
-
-  def testUrlValue: Property =
-    for {
-      uri <- networkGens.genUrlString.log("uri")
-    } yield {
-      val expected = uri
-      val actual   = Url.unsafeFrom(uri).value
-
-      actual ==== expected
-    }
-
-  def testUrlUnapply: Property =
-    for {
-      uri <- networkGens.genUrlString.log("uri")
-    } yield {
-      val expected = uri
-      Url.unsafeFrom(uri) match {
-        case Url(actual) =>
-          actual ==== expected
-      }
-    }
-
-  def testUrlToURL: Property =
-    for {
-      uri <- networkGens.genUrlString.log("uri")
-    } yield {
-      val expected = new URL(uri)
-      val actual   = Url.unsafeFrom(uri).toURL
-
-      actual ==== expected
-    }
-
-  def testUrlToUri: Property =
-    for {
-      uri <- networkGens.genUrlString.log("uri")
-    } yield {
-      val expected = Uri.unsafeFrom(uri)
-      val actual   = Url.unsafeFrom(uri).toUri
-
-      actual ==== expected
-    }
-
-  def testUrlToURI: Property =
-    for {
-      uri <- networkGens.genUrlString.log("uri")
-    } yield {
-      val expected = new URI(uri)
-      val actual   = Url.unsafeFrom(uri).toURI
-
-      actual ==== expected
-    }
-
-  inline def runNetworkIsValidateUrl(inline a: String): Boolean = ${ network.isValidateUrl('a) }
-
-  def testNetworkIsValidateUrlValid: Result = {
-    val expected = true
-    val actual   = runNetworkIsValidateUrl("https://github.com/kevin-lee/refined4s")
-    (actual ==== expected)
-      .log("""network.isValidateUrl("https://github.com/kevin-lee/refined4s") should return true but it returned false.""")
-  }
-
-  def testNetworkIsValidateUrlInvalid: Result = {
-    val expected = false
-    val actual1  = runNetworkIsValidateUrl("%^<>[]`{}")
-    val actual2  = runNetworkIsValidateUrl("blah://www.google.com")
-    Result.all(
-      List(
-        (actual1 ==== expected)
-          .log("""network.isValidateUrl("%^<>[]`{}") should return false but it returned true"""),
-        (actual2 ==== expected)
-          .log("""network.isValidateUrl("blah://www.google.com") should return false but it returned true"""),
-      )
-    )
-  }
-
-  def testNetworkIsValidateUrlWithInvalidLiteral: Result = {
-    import scala.compiletime.testing.typeCheckErrors
-    val expectedMessage = network.UnexpectedLiteralErrorMessage
-
-    val actual = typeCheckErrors(
-      """
-        val a = "blah"
-        runNetworkIsValidateUrl(a)
       """
     )
 
@@ -1061,3 +802,4 @@ object networkSpec extends Properties {
     }
 
 }
+object networkSpec extends networkSpec

--- a/modules/refined4s-pureconfig/shared/src/test/scala/refined4s/modules/pureconfig/derivation/generic/autoSpec.scala
+++ b/modules/refined4s-pureconfig/shared/src/test/scala/refined4s/modules/pureconfig/derivation/generic/autoSpec.scala
@@ -2782,7 +2782,7 @@ object autoSpec extends Properties {
         val confString = raw"""url = "$url""""
 
         val expected = Url.from(url).leftMap { err =>
-          s"The value $url cannot be created as the expected type, ${typeTools.getTypeName[refined4s.types.network.Url]}.Type, due to the following error: $err"
+          s"The value $url cannot be created as the expected type, ${typeTools.getTypeName[refined4s.types.networkCompat.Url]}.Type, due to the following error: $err"
         }
 
         ConfigSource

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -4,7 +4,7 @@ addSbtPlugin("org.wartremover" % "sbt-wartremover" % "3.2.0")
 
 addSbtPlugin("ch.epfl.scala" % "sbt-scalafix"  % "0.12.1")
 addSbtPlugin("org.scalameta" % "sbt-scalafmt"  % "2.5.2")
-addSbtPlugin("org.scoverage" % "sbt-scoverage" % "2.1.1")
+addSbtPlugin("org.scoverage" % "sbt-scoverage" % "2.2.2")
 addSbtPlugin("org.scalameta" % "sbt-mdoc"      % "2.5.4")
 addSbtPlugin("io.kevinlee"   % "sbt-docusaur"  % "0.16.0")
 


### PR DESCRIPTION
Fix #370 - Scala.js support is broken

Add
- `scalajs-java-securerandom` to use `java.security.SecureRandom` for `java.util.UUID`
- `scala-java-time` for `java.time` for Scala.js
- a custom URL for Scala.js because there's no alternative to `java.net.URL`

Also make some necessary changes including removing the code that won't be available in JavaScript.

Fix the tests for JavaScript. There are some issues with `Long` and `BigInt` less than -9007199254740991L and greater than 9007199254740991L.