### PR TITLE
refined4s v1.0.0

### DIFF
--- a/changelogs/1.0.0.md
+++ b/changelogs/1.0.0.md
@@ -1,0 +1,15 @@
+## [1.0.0](https://github.com/kevin-lee/refined4s/issues?q=is%3Aissue+is%3Aclosed+-label%3Ainvalid+-label%3Awontfix+milestone%3Am20) - 2024-11-02
+
+
+### Breaking Change
+* Fix: Scala.js support is broken (#370)
+
+  To fix it, the following changes were made:
+  * Added
+    * `scalajs-java-securerandom` to use `java.security.SecureRandom` for `java.util.UUID`
+    * `scala-java-time` for `java.time` in Scala.js
+    * a custom URL implementation for Scala.js because there's no alternative to `java.net.URL`
+
+  * Made other necessary changes, including removing code unavailable in JavaScript.
+
+  * Fixed the tests for JavaScript. There were issues with `Long` and `BigInt` values less than `-9007199254740991L` and greater than `9007199254740991L`.


### PR DESCRIPTION
# refined4s v1.0.0
## [1.0.0](https://github.com/kevin-lee/refined4s/issues?q=is%3Aissue+is%3Aclosed+-label%3Ainvalid+-label%3Awontfix+milestone%3Am20) - 2024-11-02


### Breaking Change
* Fix: Scala.js support is broken (#370)

  To fix it, the following changes were made:
  * Added
    * `scalajs-java-securerandom` to use `java.security.SecureRandom` for `java.util.UUID`
    * `scala-java-time` for `java.time` in Scala.js
    * a custom URL implementation for Scala.js because there's no alternative to `java.net.URL`

  * Made other necessary changes, including removing code unavailable in JavaScript.

  * Fixed the tests for JavaScript. There were issues with `Long` and `BigInt` values less than `-9007199254740991L` and greater than `9007199254740991L`.
