### PR TITLE
Upgrade sbt to 1.11.0 and the sbt-ci-release plugin to 1.11.1 / clean up unused build settings related to the old Maven Central (OSSRH).

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -26,8 +26,6 @@ ThisBuild / scmInfo :=
   )
 ThisBuild / licenses := props.licenses
 
-ThisBuild / resolvers += props.SonatypeSnapshots
-
 ThisBuild / scalafixDependencies += "com.github.xuwei-k" %% "scalafix-rules" % "0.4.5"
 
 ThisBuild / scalafixConfig := (
@@ -39,7 +37,6 @@ ThisBuild / scalafixConfig := (
 
 lazy val refined4s = (project in file("."))
   .enablePlugins(DevOopsGitHubReleasePlugin)
-  .settings(mavenCentralPublishSettings)
   .settings(noPublish)
   .aggregate(
     coreJvm,
@@ -310,11 +307,6 @@ lazy val props =
 
     lazy val licenses = List("MIT" -> url("http://opensource.org/licenses/MIT"))
 
-    val SonatypeCredentialHost = "s01.oss.sonatype.org"
-    val SonatypeRepository     = s"https://$SonatypeCredentialHost/service/local"
-
-    val SonatypeSnapshots = "sonatype-snapshots".at(s"https://$SonatypeCredentialHost/content/repositories/snapshots")
-
     val removeDottyIncompatible: ModuleID => Boolean =
       m =>
         m.name == "ammonite" ||
@@ -415,13 +407,6 @@ lazy val libs = new {
 def prefixedProjectName(name: String) = s"${props.RepoName}${if (name.isEmpty) "" else s"-$name"}"
 // scalafmt: on
 
-lazy val mavenCentralPublishSettings: SettingsDefinition = List(
-  /* Publish to Maven Central { */
-  sonatypeCredentialHost := props.SonatypeCredentialHost,
-  sonatypeRepository := props.SonatypeRepository,
-  /* } Publish to Maven Central */
-)
-
 def isScala3(scalaVersion: String): Boolean = scalaVersion.startsWith("3")
 
 def module(projectName: String, crossProject: CrossProject.Builder): CrossProject = {
@@ -472,7 +457,6 @@ def module(projectName: String, crossProject: CrossProject.Builder): CrossProjec
 //        "-language:implicitConversions",
 //      ),
     )
-    .settings(mavenCentralPublishSettings)
 }
 
 lazy val jsSettingsForFuture: SettingsDefinition = List(

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.10.11
+sbt.version=1.11.0

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,4 +1,4 @@
-addSbtPlugin("com.github.sbt" % "sbt-ci-release" % "1.6.1")
+addSbtPlugin("com.github.sbt" % "sbt-ci-release" % "1.11.1")
 
 addSbtPlugin("org.wartremover" % "sbt-wartremover" % "3.2.0")
 


### PR DESCRIPTION
Upgrade sbt to 1.11.0 and the sbt-ci-release plugin to 1.11.1 / clean up unused build settings related to the old Maven Central (OSSRH).

Due to the end-of-life (sunset) of OSSRH, upgrading sbt to 1.11.0 and sbt-ci-release to 1.11.1 was required in order to publish artifacts to the Central Publisher Portal (Maven Central).