### PR TITLE
Update GitHub Actions workflows for the doc site build: Bump Node to 22.17.0

### DIFF
--- a/.github/workflows/doc-site-build-only.yml
+++ b/.github/workflows/doc-site-build-only.yml
@@ -18,7 +18,7 @@ jobs:
         scala:
           - { version: "3.3.3", binary-version: "3", java-version: "17", java-distribution: "temurin" }
         node:
-          - { version: "18.13.0" }
+          - { version: "22.17.0" }
 
     steps:
       - uses: actions/checkout@v4.1.2

--- a/.github/workflows/doc-site-publish.yml
+++ b/.github/workflows/doc-site-publish.yml
@@ -18,7 +18,7 @@ jobs:
         scala:
           - { version: "3.3.3", binary-version: "3", java-version: "17", java-distribution: "temurin" }
         node:
-          - { version: "18.13.0" }
+          - { version: "22.17.0" }
 
     steps:
       - uses: actions/checkout@v4.1.2


### PR DESCRIPTION
Update GitHub Actions workflows for the doc site build: Bump Node to 22.17.0