### PR TITLE
Close #426: Disable Scala.js because extras-type-info used by refined4s doesn't support Scala.js anymore (since 0.45.0)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       matrix:
         scala:
-          - { name: "Scala 3.3", version: "3.3.3", binary-version: "3", java-version: "11", java-distribution: "temurin", report: "report" }
+          - { name: "Scala 3.3", version: "3.3.5", binary-version: "3", java-version: "11", java-distribution: "temurin", report: "report" }
 
     steps:
       - uses: actions/checkout@v4.1.2

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       matrix:
         scala:
-          - { name: "Scala 3", version: "3.3.3",   binary-version: "3",    java-version: "11", java-distribution: "temurin", report: "" }
+          - { name: "Scala 3", version: "3.3.5",   binary-version: "3",    java-version: "11", java-distribution: "temurin", report: "" }
 
     steps:
       - uses: actions/checkout@v4.1.2

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       matrix:
         scala:
-          - { name: "Scala 3.3", version: "3.3.3", binary-version: "3", java-version: "11", java-distribution: "temurin", report: "report" }
+          - { name: "Scala 3.3", version: "3.3.5", binary-version: "3", java-version: "11", java-distribution: "temurin", report: "report" }
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/doc-site-build-only.yml
+++ b/.github/workflows/doc-site-build-only.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       matrix:
         scala:
-          - { version: "3.3.3", binary-version: "3", java-version: "17", java-distribution: "temurin" }
+          - { version: "3.3.5", binary-version: "3", java-version: "17", java-distribution: "temurin" }
         node:
           - { version: "22.17.0" }
 

--- a/.github/workflows/doc-site-publish.yml
+++ b/.github/workflows/doc-site-publish.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       matrix:
         scala:
-          - { version: "3.3.3", binary-version: "3", java-version: "17", java-distribution: "temurin" }
+          - { version: "3.3.5", binary-version: "3", java-version: "17", java-distribution: "temurin" }
         node:
           - { version: "22.17.0" }
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       matrix:
         scala:
-          - { name: "Scala 3", version: "3.3.3", binary-version: "3", java-version: "11", java-distribution: "temurin", report: "" }
+          - { name: "Scala 3", version: "3.3.5", binary-version: "3", java-version: "11", java-distribution: "temurin", report: "" }
 
     steps:
       - uses: actions/checkout@v4.1.2
@@ -65,7 +65,7 @@ jobs:
     strategy:
       matrix:
         scala:
-          - { name: "Scala 3", version: "3.3.3", binary-version: "3", java-version: "11", java-distribution: "temurin", report: "report" }
+          - { name: "Scala 3", version: "3.3.5", binary-version: "3", java-version: "11", java-distribution: "temurin", report: "report" }
 
     steps:
       - uses: actions/checkout@v4.1.2

--- a/build.sbt
+++ b/build.sbt
@@ -40,24 +40,24 @@ lazy val refined4s = (project in file("."))
   .settings(noPublish)
   .aggregate(
     coreJvm,
-    coreJs,
+//    coreJs,
     catsJvm,
-    catsJs,
+//    catsJs,
     circeJvm,
-    circeJs,
+//    circeJs,
     pureconfigJvm,
     doobieCe2Jvm,
     doobieCe3Jvm,
     extrasRenderJvm,
-    extrasRenderJs,
+//    extrasRenderJs,
     refinedCompatScala2Jvm,
-    refinedCompatScala2Js,
+//    refinedCompatScala2Js,
     refinedCompatScala3Jvm,
-    refinedCompatScala3Js,
+//    refinedCompatScala3Js,
     tapirJvm,
-    tapirJs,
+//    tapirJs,
     chimneyJvm,
-    chimneyJs,
+//    chimneyJs,
   )
 
 lazy val core    = module("core", crossProject(JVMPlatform, JSPlatform))


### PR DESCRIPTION
Close #426: Disable Scala.js because extras-type-info used by refined4s doesn't support Scala.js anymore (since 0.45.0)

Also update: GitHub Actions - Update Scala `3.3.3` to `3.3.5`