### PR TITLE
refined4s v1.2.0

### DIFF
--- a/changelogs/1.2.0.md
+++ b/changelogs/1.2.0.md
@@ -1,0 +1,18 @@
+## [1.2.0](https://github.com/kevin-lee/refined4s/issues?q=is%3Aissue+is%3Aclosed+-label%3Ainvalid+-label%3Awontfix+milestone%3Am22) - 2025-07-30
+
+### Internal Housekeeping
+
+* Bump Scala to `3.3.5` (#419)
+
+* [`refined4s-refined-compat-scala2`] Bump Scala 2 versions (#421)
+
+  - Upgrade Scala versions in `refinedCompatScala2` (`refined4s-refined-compat-scala2`) module:
+    - `2.12.16` -> `2.12.18`
+    - `2.13.13` -> `2.13.15`
+  - Exclude `scala-xml` dependency from `refined` library to avoid conflicts
+
+* Bump extras to `0.45.0` (#423)
+
+* Disable Scala.js because `extras-type-info` used by `refined4s` doesn't support Scala.js anymore (since `0.45.0`) (#426)
+
+* Bump sbt to `1.11.3` (#428)


### PR DESCRIPTION
# refined4s v1.2.0
## [1.2.0](https://github.com/kevin-lee/refined4s/issues?q=is%3Aissue+is%3Aclosed+-label%3Ainvalid+-label%3Awontfix+milestone%3Am22) - 2025-07-30

### Internal Housekeeping

* Bump Scala to `3.3.5` (#419)

* [`refined4s-refined-compat-scala2`] Bump Scala 2 versions (#421)

  - Upgrade Scala versions in `refinedCompatScala2` (`refined4s-refined-compat-scala2`) module:
    - `2.12.16` -> `2.12.18`
    - `2.13.13` -> `2.13.15`
  - Exclude `scala-xml` dependency from `refined` library to avoid conflicts

* Bump extras to `0.45.0` (#423)

* Disable Scala.js because `extras-type-info` used by `refined4s` doesn't support Scala.js anymore (since `0.45.0`) (#426)

* Bump sbt to `1.11.3` (#428)
