### PR TITLE
Close #444: Make the type parameters of `Newtype` and `Refined` `specialized`

### DIFF
--- a/modules/refined4s-core/shared/src/main/scala/refined4s/CanBeOrdered.scala
+++ b/modules/refined4s-core/shared/src/main/scala/refined4s/CanBeOrdered.scala
@@ -3,7 +3,7 @@ package refined4s
 /** @author Kevin Lee
   * @since 2023-12-29
   */
-trait CanBeOrdered[A: Ordering] {
+trait CanBeOrdered[@specialized(Int, Long, Short, Byte, Float, Double) A: Ordering] {
   self: NewtypeBase[A] =>
 
   given derivedOrdering: Ordering[Type] = deriving[Ordering]

--- a/modules/refined4s-core/shared/src/main/scala/refined4s/InlinedRefined.scala
+++ b/modules/refined4s-core/shared/src/main/scala/refined4s/InlinedRefined.scala
@@ -5,7 +5,7 @@ import scala.compiletime.*
 /** @author Kevin Lee
   * @since 2023-08-12
   */
-trait InlinedRefined[A] extends RefinedBase[A] {
+trait InlinedRefined[@specialized A] extends RefinedBase[A] {
 
   inline val inlinedExpectedValue: String
 

--- a/modules/refined4s-core/shared/src/main/scala/refined4s/Newtype.scala
+++ b/modules/refined4s-core/shared/src/main/scala/refined4s/Newtype.scala
@@ -3,7 +3,7 @@ package refined4s
 /** @author Kevin Lee
   * @since 2023-12-03
   */
-trait Newtype[A] extends NewtypeBase[A] {
+trait Newtype[@specialized A] extends NewtypeBase[A] {
   override opaque type Type = A
 
   def apply(a: A): Type = a

--- a/modules/refined4s-core/shared/src/main/scala/refined4s/NewtypeBase.scala
+++ b/modules/refined4s-core/shared/src/main/scala/refined4s/NewtypeBase.scala
@@ -3,7 +3,7 @@ package refined4s
 /** @author Kevin Lee
   * @since 2023-12-03
   */
-trait NewtypeBase[A] {
+trait NewtypeBase[@specialized A] {
   type Type
 
   given newRefinedCanEqual: CanEqual[Type, Type] = CanEqual.derived

--- a/modules/refined4s-core/shared/src/main/scala/refined4s/Refined.scala
+++ b/modules/refined4s-core/shared/src/main/scala/refined4s/Refined.scala
@@ -6,7 +6,7 @@ import compiletime.*
   * @author Kevin Lee
   * @since 2022-03-23
   */
-trait Refined[A] extends RefinedBase[A] {
+trait Refined[@specialized A] extends RefinedBase[A] {
 
   @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
   inline def apply(a: A): Type =

--- a/modules/refined4s-core/shared/src/main/scala/refined4s/RefinedBase.scala
+++ b/modules/refined4s-core/shared/src/main/scala/refined4s/RefinedBase.scala
@@ -4,7 +4,7 @@ package refined4s
   * @author Kevin Lee
   * @since 2022-03-23
   */
-trait RefinedBase[A] extends NewtypeBase[A] {
+trait RefinedBase[@specialized A] extends NewtypeBase[A] {
 
   override opaque type Type = A
 

--- a/modules/refined4s-core/shared/src/main/scala/refined4s/types/numeric.scala
+++ b/modules/refined4s-core/shared/src/main/scala/refined4s/types/numeric.scala
@@ -110,25 +110,25 @@ trait numeric {
 }
 object numeric {
 
-  trait Numeric[A: math.Ordering] extends Refined[A], CanBeOrdered[A]
+  trait Numeric[@specialized(Int, Long, Short, Byte, Float, Double) A: math.Ordering] extends Refined[A], CanBeOrdered[A]
 
-  trait InlinedNumeric[A: math.Ordering] extends InlinedRefined[A], CanBeOrdered[A]
+  trait InlinedNumeric[@specialized(Int, Long, Short, Byte, Float, Double) A: math.Ordering] extends InlinedRefined[A], CanBeOrdered[A]
 
-  trait Min[A] {
+  trait Min[@specialized(Int, Long, Short, Byte, Float, Double) A] {
     self: NewtypeBase[A] =>
     def min: Type
 
     val MinValue: Type = min
   }
 
-  trait Max[A] {
+  trait Max[@specialized(Int, Long, Short, Byte, Float, Double) A] {
     self: NewtypeBase[A] =>
     def max: Type
 
     val MaxValue: Type = max
   }
 
-  trait MinMax[A] extends Min[A], Max[A] {
+  trait MinMax[@specialized(Int, Long, Short, Byte, Float, Double) A] extends Min[A], Max[A] {
     self: NewtypeBase[A] =>
   }
 


### PR DESCRIPTION
Close #444: Make the type parameters of `Newtype` and `Refined` `specialized`

Specialize generic type parameters across core and numeric traits to reduce boxing when instantiated with primitive types.

Using Scala's `@specialized` to avoid boxing/unboxing and reduce allocations for `Int`, `Long`, `Short`, `Byte`, `Float`, and `Double` improves hot-path performance, especially for operations on refined/newtype values.

This change is annotation-only with no source-level API changes. Runtime semantics remain the same; only performance characteristics may improve.

Changes:
- `trait CanBeOrdered[@specialized(Int, Long, Short, Byte, Float, Double) A: Ordering]`
- `trait InlinedRefined[@specialized A]`
- `trait Newtype[@specialized A]`
- `trait NewtypeBase[@specialized A]`
- `trait Refined[@specialized A]`
- `trait RefinedBase[@specialized A]`
- `types/numeric`
  - `trait Numeric[@specialized(Int, Long, Short, Byte, Float, Double) A: math.Ordering]`
  - `trait InlinedNumeric[@specialized(Int, Long, Short, Byte, Float, Double) A: math.Ordering]`
  - `trait Min[@specialized(Int, Long, Short, Byte, Float, Double) A]`
  - `trait Max[@specialized(Int, Long, Short, Byte, Float, Double) A]`
  - `trait MinMax[@specialized(Int, Long, Short, Byte, Float, Double) A]`

Trade-offs:
- Specialization can increase bytecode size; no logic changes introduced.