### PR TITLE
Close #464: Move `Eq` and `Show` type class instances for `refined4s.types.network` types from `refined4s-cats` to `refined4s-core` with `orphan-cats`

### DIFF
--- a/modules/refined4s-cats/shared/src/main/scala/refined4s/modules/cats/derivation/types/all.scala
+++ b/modules/refined4s-cats/shared/src/main/scala/refined4s/modules/cats/derivation/types/all.scala
@@ -109,26 +109,5 @@ trait all {
 
   // network
 
-  inline given derivedUriEq(using eqActual: Eq[String]): Eq[Uri]         = contraCoercible(eqActual)
-  inline given derivedUriShow(using showActual: Show[String]): Show[Uri] = contraCoercible(showActual)
-
-  inline given derivedUrlEq(using eqActual: Eq[String]): Eq[Url]         = contraCoercible(eqActual)
-  inline given derivedUrlShow(using showActual: Show[String]): Show[Url] = contraCoercible(showActual)
-
-  inline given derivedPortNumberEq(using eqActual: Eq[Int]): Eq[PortNumber]         = contraCoercible(eqActual)
-  inline given derivedPortNumberShow(using showActual: Show[Int]): Show[PortNumber] = contraCoercible(showActual)
-
-  inline given derivedSystemPortNumberEq(using eqActual: Eq[Int]): Eq[SystemPortNumber]         = contraCoercible(eqActual)
-  inline given derivedSystemPortNumberShow(using showActual: Show[Int]): Show[SystemPortNumber] = contraCoercible(showActual)
-
-  inline given derivedNonSystemPortNumberEq(using eqActual: Eq[Int]): Eq[NonSystemPortNumber]         = contraCoercible(eqActual)
-  inline given derivedNonSystemPortNumberShow(using showActual: Show[Int]): Show[NonSystemPortNumber] = contraCoercible(showActual)
-
-  inline given derivedUserPortNumberEq(using eqActual: Eq[Int]): Eq[UserPortNumber]         = contraCoercible(eqActual)
-  inline given derivedUserPortNumberShow(using showActual: Show[Int]): Show[UserPortNumber] = contraCoercible(showActual)
-
-  inline given derivedDynamicPortNumberEq(using eqActual: Eq[Int]): Eq[DynamicPortNumber]         = contraCoercible(eqActual)
-  inline given derivedDynamicPortNumberShow(using showActual: Show[Int]): Show[DynamicPortNumber] = contraCoercible(showActual)
-
 }
 object all extends all

--- a/modules/refined4s-core/js/src/main/scala/refined4s/types/networkCompat.scala
+++ b/modules/refined4s-core/js/src/main/scala/refined4s/types/networkCompat.scala
@@ -1,10 +1,10 @@
 package refined4s.types
 
+import orphan.{OrphanCats, OrphanCatsKernel}
 import refined4s.InlinedRefined
 import refined4s.types.network.Uri
 
 import scala.quoted.*
-
 import java.net.URI
 import scala.quoted.{Expr, Quotes}
 import scala.util.control.NonFatal
@@ -12,7 +12,7 @@ import scala.util.control.NonFatal
 /** @author Kevin Lee
   * @since 2024-09-04
   */
-object networkCompat {
+object networkCompat extends OrphanCats, OrphanCatsKernel {
   val validUrlSchemes = Set("http", "https", "ftp", "file")
 
   type Url = Url.Type
@@ -79,6 +79,16 @@ object networkCompat {
 
       def toURI: URI = new URI(url.value)
     }
+
+    @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
+    inline given derivedUrlEq[F[*]: CatsEq, G[*]: CatsEq](using eqActual: G[String]): F[Url] = {
+      internalDef.contraCoercible(eqActual.asInstanceOf[cats.Eq[String]])
+    }.asInstanceOf[F[Url]] // scalafix:ok DisableSyntax.asInstanceOf
+
+    @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
+    inline given derivedUrlShow[F[*]: CatsShow, G[*]: CatsShow](using showActual: G[String]): F[Url] = {
+      internalDef.contraCoercible(showActual.asInstanceOf[cats.Show[String]])
+    }.asInstanceOf[F[Url]] // scalafix:ok DisableSyntax.asInstanceOf
 
   }
 

--- a/modules/refined4s-core/jvm/src/main/scala/refined4s/types/networkCompat.scala
+++ b/modules/refined4s-core/jvm/src/main/scala/refined4s/types/networkCompat.scala
@@ -1,10 +1,10 @@
 package refined4s.types
 
+import orphan.{OrphanCats, OrphanCatsKernel}
 import refined4s.InlinedRefined
 import refined4s.types.network.Uri
 
 import scala.quoted.*
-
 import java.net.{URI, URL}
 import scala.quoted.{Expr, Quotes}
 import scala.util.control.NonFatal
@@ -12,7 +12,7 @@ import scala.util.control.NonFatal
 /** @author Kevin Lee
   * @since 2024-09-04
   */
-object networkCompat {
+object networkCompat extends OrphanCats, OrphanCatsKernel {
 
   type Url = Url.Type
   object Url extends InlinedRefined[String] {
@@ -45,6 +45,16 @@ object networkCompat {
 
       def toURI: URI = toURL.toURI
     }
+
+    @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
+    inline given derivedUrlEq[F[*]: CatsEq, G[*]: CatsEq](using eqActual: G[String]): F[Url] = {
+      internalDef.contraCoercible(eqActual.asInstanceOf[cats.Eq[String]])
+    }.asInstanceOf[F[Url]] // scalafix:ok DisableSyntax.asInstanceOf
+
+    @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
+    inline given derivedUrlShow[F[*]: CatsShow, G[*]: CatsShow](using showActual: G[String]): F[Url] = {
+      internalDef.contraCoercible(showActual.asInstanceOf[cats.Show[String]])
+    }.asInstanceOf[F[Url]] // scalafix:ok DisableSyntax.asInstanceOf
 
   }
 

--- a/modules/refined4s-core/native/src/main/scala/refined4s/types/networkCompat.scala
+++ b/modules/refined4s-core/native/src/main/scala/refined4s/types/networkCompat.scala
@@ -1,10 +1,10 @@
 package refined4s.types
 
+import orphan.{OrphanCats, OrphanCatsKernel}
 import refined4s.InlinedRefined
 import refined4s.types.network.Uri
 
 import scala.quoted.*
-
 import java.net.URI
 import scala.quoted.{Expr, Quotes}
 import scala.util.control.NonFatal
@@ -12,7 +12,7 @@ import scala.util.control.NonFatal
 /** @author Kevin Lee
   * @since 2024-09-04
   */
-object networkCompat {
+object networkCompat extends OrphanCats, OrphanCatsKernel {
   val validUrlSchemes = Set("http", "https", "ftp", "file")
 
   type Url = Url.Type
@@ -79,6 +79,16 @@ object networkCompat {
 
       def toURI: URI = new URI(url.value)
     }
+
+    @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
+    inline given derivedUrlEq[F[*]: CatsEq, G[*]: CatsEq](using eqActual: G[String]): F[Url] = {
+      internalDef.contraCoercible(eqActual.asInstanceOf[cats.Eq[String]])
+    }.asInstanceOf[F[Url]] // scalafix:ok DisableSyntax.asInstanceOf
+
+    @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
+    inline given derivedUrlShow[F[*]: CatsShow, G[*]: CatsShow](using showActual: G[String]): F[Url] = {
+      internalDef.contraCoercible(showActual.asInstanceOf[cats.Show[String]])
+    }.asInstanceOf[F[Url]] // scalafix:ok DisableSyntax.asInstanceOf
 
   }
 

--- a/modules/refined4s-core/shared/src/main/scala/refined4s/types/network.scala
+++ b/modules/refined4s-core/shared/src/main/scala/refined4s/types/network.scala
@@ -1,10 +1,10 @@
 package refined4s.types
 
+import orphan.{OrphanCats, OrphanCatsKernel}
 import refined4s.*
 
 import scala.quoted.*
 import scala.util.control.NonFatal
-
 import java.net.{URI, URL}
 
 /** @author Kevin Lee
@@ -42,7 +42,7 @@ trait network {
 
 }
 
-object network {
+object network extends OrphanCats, OrphanCatsKernel {
 
   final type Url = networkCompat.Url
   // scalafix:off DisableSyntax.noFinalVal
@@ -79,6 +79,16 @@ object network {
       def toURL: URL = toURI.toURL
     }
 
+    @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
+    inline given derivedUriEq[F[*]: CatsEq, G[*]: CatsEq](using eqActual: G[String]): F[Uri] = {
+      internalDef.contraCoercible(eqActual.asInstanceOf[cats.Eq[String]])
+    }.asInstanceOf[F[Uri]] // scalafix:ok DisableSyntax.asInstanceOf
+
+    @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
+    inline given derivedUriShow[F[*]: CatsShow, G[*]: CatsShow](using showActual: G[String]): F[Uri] = {
+      internalDef.contraCoercible(showActual.asInstanceOf[cats.Show[String]])
+    }.asInstanceOf[F[Uri]] // scalafix:ok DisableSyntax.asInstanceOf
+
   }
 
   type PortNumber = PortNumber.Type
@@ -89,6 +99,17 @@ object network {
 
     override inline def predicate(a: Int): Boolean =
       0 <= a && a <= 65535
+
+    @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
+    inline given derivedPortNumberEq[F[*]: CatsEq, G[*]: CatsEq](using eqActual: G[Int]): F[PortNumber] = {
+      internalDef.contraCoercible(eqActual.asInstanceOf[cats.Eq[Int]])
+    }.asInstanceOf[F[PortNumber]] // scalafix:ok DisableSyntax.asInstanceOf
+
+    @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
+    inline given derivedPortNumberShow[F[*]: CatsShow, G[*]: CatsShow](using showActual: G[Int]): F[PortNumber] = {
+      internalDef.contraCoercible(showActual.asInstanceOf[cats.Show[Int]])
+    }.asInstanceOf[F[PortNumber]] // scalafix:ok DisableSyntax.asInstanceOf
+
   }
 
   type SystemPortNumber = SystemPortNumber.Type
@@ -99,6 +120,17 @@ object network {
 
     override inline def predicate(a: Int): Boolean =
       0 <= a && a <= 1023
+
+    @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
+    inline given derivedSystemPortNumberEq[F[*]: CatsEq, G[*]: CatsEq](using eqActual: G[Int]): F[SystemPortNumber] = {
+      internalDef.contraCoercible(eqActual.asInstanceOf[cats.Eq[Int]])
+    }.asInstanceOf[F[SystemPortNumber]] // scalafix:ok DisableSyntax.asInstanceOf
+
+    @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
+    inline given derivedSystemPortNumberShow[F[*]: CatsShow, G[*]: CatsShow](using showActual: G[Int]): F[SystemPortNumber] = {
+      internalDef.contraCoercible(showActual.asInstanceOf[cats.Show[Int]])
+    }.asInstanceOf[F[SystemPortNumber]] // scalafix:ok DisableSyntax.asInstanceOf
+
   }
 
   type NonSystemPortNumber = NonSystemPortNumber.Type
@@ -109,6 +141,17 @@ object network {
 
     override inline def predicate(a: Int): Boolean =
       1024 <= a && a <= 65535
+
+    @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
+    inline given derivedNonSystemPortNumberEq[F[*]: CatsEq, G[*]: CatsEq](using eqActual: G[Int]): F[NonSystemPortNumber] = {
+      internalDef.contraCoercible(eqActual.asInstanceOf[cats.Eq[Int]])
+    }.asInstanceOf[F[NonSystemPortNumber]] // scalafix:ok DisableSyntax.asInstanceOf
+
+    @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
+    inline given derivedNonSystemPortNumberShow[F[*]: CatsShow, G[*]: CatsShow](using showActual: G[Int]): F[NonSystemPortNumber] = {
+      internalDef.contraCoercible(showActual.asInstanceOf[cats.Show[Int]])
+    }.asInstanceOf[F[NonSystemPortNumber]] // scalafix:ok DisableSyntax.asInstanceOf
+
   }
 
   type UserPortNumber = UserPortNumber.Type
@@ -119,6 +162,16 @@ object network {
 
     override inline def predicate(a: Int): Boolean =
       1024 <= a && a <= 49151
+
+    @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
+    inline given derivedUserPortNumberEq[F[*]: CatsEq, G[*]: CatsEq](using eqActual: G[Int]): F[UserPortNumber] = {
+      internalDef.contraCoercible(eqActual.asInstanceOf[cats.Eq[Int]])
+    }.asInstanceOf[F[UserPortNumber]] // scalafix:ok DisableSyntax.asInstanceOf
+
+    @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
+    inline given derivedUserPortNumberShow[F[*]: CatsShow, G[*]: CatsShow](using showActual: G[Int]): F[UserPortNumber] = {
+      internalDef.contraCoercible(showActual.asInstanceOf[cats.Show[Int]])
+    }.asInstanceOf[F[UserPortNumber]] // scalafix:ok DisableSyntax.asInstanceOf
   }
 
   type DynamicPortNumber = DynamicPortNumber.Type
@@ -129,6 +182,17 @@ object network {
 
     override inline def predicate(a: Int): Boolean =
       49152 <= a && a <= 65535
+
+    @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
+    inline given derivedDynamicPortNumberEq[F[*]: CatsEq, G[*]: CatsEq](using eqActual: G[Int]): F[DynamicPortNumber] = {
+      internalDef.contraCoercible(eqActual.asInstanceOf[cats.Eq[Int]])
+    }.asInstanceOf[F[DynamicPortNumber]] // scalafix:ok DisableSyntax.asInstanceOf
+
+    @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
+    inline given derivedDynamicPortNumberShow[F[*]: CatsShow, G[*]: CatsShow](using showActual: G[Int]): F[DynamicPortNumber] = {
+      internalDef.contraCoercible(showActual.asInstanceOf[cats.Show[Int]])
+    }.asInstanceOf[F[DynamicPortNumber]] // scalafix:ok DisableSyntax.asInstanceOf
+
   }
 
 }

--- a/modules/test-refined4s-core-without-cats/shared/src/test/scala/refined4s/types/networkSpec.scala
+++ b/modules/test-refined4s-core-without-cats/shared/src/test/scala/refined4s/types/networkSpec.scala
@@ -1,0 +1,260 @@
+package refined4s.types
+
+import hedgehog.*
+import hedgehog.runner.*
+import refined4s.ExpectedErrorMessages
+
+/** @author Kevin Lee
+  * @since 2025-08-24
+  */
+object networkSpec extends Properties {
+  override def tests: List[Test] =
+    uriSpec.tests ++ urlSpec.tests ++ portNumberSpec.tests ++ systemPortNumberSpec.tests ++ nonSystemPortNumberSpec.tests ++ userPortNumberSpec.tests
+
+  object uriSpec {
+    def tests: List[Test] = List(
+      example("test Eq[Uri]", testEq),
+      example("test Show[Uri]", testShow),
+    )
+
+    def testEq: Result = {
+      import scala.compiletime.testing.typeCheckErrors
+      val expected = ExpectedErrorMessages.missingEq
+
+      val actual = typeCheckErrors(
+        """
+         val _ = refined4s.types.network.Uri.derivedUriEq
+      """
+      ).map(_.message).mkString
+
+      (actual ==== expected)
+        .log(
+          """The actual error message doesn't start with the expected one.
+            |""".stripMargin
+        )
+    }
+
+    def testShow: Result = {
+      import scala.compiletime.testing.typeCheckErrors
+      val expected = ExpectedErrorMessages.missingShow
+
+      val actual = typeCheckErrors(
+        """
+         val _ = refined4s.types.network.Uri.derivedUriShow
+      """
+      ).map(_.message).mkString
+
+      (actual ==== expected)
+        .log(
+          """The actual error message doesn't start with the expected one.
+            |""".stripMargin
+        )
+    }
+  }
+
+  object urlSpec {
+    def tests: List[Test] = List(
+      example("test Eq[Url]", testEq),
+      example("test Show[Url]", testShow),
+    )
+
+    def testEq: Result = {
+      import scala.compiletime.testing.typeCheckErrors
+      val expected = ExpectedErrorMessages.missingEq
+
+      val actual = typeCheckErrors(
+        """
+         val _ = refined4s.types.network.Url.derivedUrlEq
+      """
+      ).map(_.message).mkString
+
+      (actual ==== expected)
+        .log(
+          """The actual error message doesn't start with the expected one.
+            |""".stripMargin
+        )
+    }
+
+    def testShow: Result = {
+      import scala.compiletime.testing.typeCheckErrors
+      val expected = ExpectedErrorMessages.missingShow
+
+      val actual = typeCheckErrors(
+        """
+         val _ = refined4s.types.network.Url.derivedUrlShow
+      """
+      ).map(_.message).mkString
+
+      (actual ==== expected)
+        .log(
+          """The actual error message doesn't start with the expected one.
+            |""".stripMargin
+        )
+    }
+  }
+
+  object portNumberSpec {
+    def tests: List[Test] = List(
+      example("test Eq[PortNumber]", testEq),
+      example("test Show[PortNumber]", testShow),
+    )
+
+    def testEq: Result = {
+      import scala.compiletime.testing.typeCheckErrors
+      val expected = ExpectedErrorMessages.missingEq
+
+      val actual = typeCheckErrors(
+        """
+         val _ = refined4s.types.network.PortNumber.derivedPortNumberEq
+      """
+      ).map(_.message).mkString
+
+      (actual ==== expected)
+        .log(
+          """The actual error message doesn't start with the expected one.
+            |""".stripMargin
+        )
+    }
+
+    def testShow: Result = {
+      import scala.compiletime.testing.typeCheckErrors
+      val expected = ExpectedErrorMessages.missingShow
+
+      val actual = typeCheckErrors(
+        """
+         val _ = refined4s.types.network.PortNumber.derivedPortNumberShow
+      """
+      ).map(_.message).mkString
+
+      (actual ==== expected)
+        .log(
+          """The actual error message doesn't start with the expected one.
+            |""".stripMargin
+        )
+    }
+  }
+
+  object systemPortNumberSpec {
+    def tests: List[Test] = List(
+      example("test Eq[SystemPortNumber]", testEq),
+      example("test Show[SystemPortNumber]", testShow),
+    )
+
+    def testEq: Result = {
+      import scala.compiletime.testing.typeCheckErrors
+      val expected = ExpectedErrorMessages.missingEq
+
+      val actual = typeCheckErrors(
+        """
+         val _ = refined4s.types.network.SystemPortNumber.derivedSystemPortNumberEq
+      """
+      ).map(_.message).mkString
+
+      (actual ==== expected)
+        .log(
+          """The actual error message doesn't start with the expected one.
+            |""".stripMargin
+        )
+    }
+
+    def testShow: Result = {
+      import scala.compiletime.testing.typeCheckErrors
+      val expected = ExpectedErrorMessages.missingShow
+
+      val actual = typeCheckErrors(
+        """
+         val _ = refined4s.types.network.SystemPortNumber.derivedSystemPortNumberShow
+      """
+      ).map(_.message).mkString
+
+      (actual ==== expected)
+        .log(
+          """The actual error message doesn't start with the expected one.
+            |""".stripMargin
+        )
+    }
+  }
+
+  object nonSystemPortNumberSpec {
+    def tests: List[Test] = List(
+      example("test Eq[NonSystemPortNumber]", testEq),
+      example("test Show[NonSystemPortNumber]", testShow),
+    )
+
+    def testEq: Result = {
+      import scala.compiletime.testing.typeCheckErrors
+      val expected = ExpectedErrorMessages.missingEq
+
+      val actual = typeCheckErrors(
+        """
+         val _ = refined4s.types.network.NonSystemPortNumber.derivedNonSystemPortNumberEq
+      """
+      ).map(_.message).mkString
+
+      (actual ==== expected)
+        .log(
+          """The actual error message doesn't start with the expected one.
+            |""".stripMargin
+        )
+    }
+
+    def testShow: Result = {
+      import scala.compiletime.testing.typeCheckErrors
+      val expected = ExpectedErrorMessages.missingShow
+
+      val actual = typeCheckErrors(
+        """
+         val _ = refined4s.types.network.NonSystemPortNumber.derivedNonSystemPortNumberShow
+      """
+      ).map(_.message).mkString
+
+      (actual ==== expected)
+        .log(
+          """The actual error message doesn't start with the expected one.
+            |""".stripMargin
+        )
+    }
+  }
+
+  object userPortNumberSpec {
+    def tests: List[Test] = List(
+      example("test Eq[UserPortNumber]", testEq),
+      example("test Show[UserPortNumber]", testShow),
+    )
+
+    def testEq: Result = {
+      import scala.compiletime.testing.typeCheckErrors
+      val expected = ExpectedErrorMessages.missingEq
+
+      val actual = typeCheckErrors(
+        """
+         val _ = refined4s.types.network.UserPortNumber.derivedUserPortNumberEq
+      """
+      ).map(_.message).mkString
+
+      (actual ==== expected)
+        .log(
+          """The actual error message doesn't start with the expected one.
+            |""".stripMargin
+        )
+    }
+
+    def testShow: Result = {
+      import scala.compiletime.testing.typeCheckErrors
+      val expected = ExpectedErrorMessages.missingShow
+
+      val actual = typeCheckErrors(
+        """
+         val _ = refined4s.types.network.UserPortNumber.derivedUserPortNumberShow
+      """
+      ).map(_.message).mkString
+
+      (actual ==== expected)
+        .log(
+          """The actual error message doesn't start with the expected one.
+            |""".stripMargin
+        )
+    }
+  }
+
+}


### PR DESCRIPTION
## Close #464: Move `Eq` and `Show` type class instances for `refined4s.types.network` types from `refined4s-cats` to `refined4s-core` with `orphan-cats`

- Remove `Eq`/`Show` instances for network types from `refined4s-cats all`
- Add `Eq`/`Show` instances using `orphan-cats` pattern to `refined4s-core` `network` types
- Add comprehensive test coverage for `network` type instances without cats dependency
- Supports `Uri`, `Url`, and all `PortNumber` variants (`System`, `NonSystem`, `User`, `Dynamic`)

So `Eq` and `Show` type class instances for `network` types will be automatically available if the projects using `refined4s-core` have `cats` in its library dependencies.