### PR TITLE
Close #465: Move `Eq` and `Show` type class instances for `refined4s.types.numeric` types from `refined4s-cats` to `refined4s-core` with `orphan-cats`

### DIFF
--- a/modules/refined4s-cats/shared/src/main/scala/refined4s/modules/cats/derivation/types/all.scala
+++ b/modules/refined4s-cats/shared/src/main/scala/refined4s/modules/cats/derivation/types/all.scala
@@ -1,113 +1,17 @@
 package refined4s.modules.cats.derivation.types
 
-import cats.*
-import refined4s.*
-import refined4s.types.all.*
-import refined4s.modules.cats.syntax.contraCoercible
-
 /** @author Kevin Lee
   * @since 2023-12-07
   */
-trait all {
-  inline given derivedNegIntEq(using eqActual: Eq[Int]): Eq[NegInt]         = contraCoercible(eqActual)
-  inline given derivedNegIntShow(using showActual: Show[Int]): Show[NegInt] = contraCoercible(showActual)
-
-  inline given derivedNonNegIntEq(using eqActual: Eq[Int]): Eq[NonNegInt]         = contraCoercible(eqActual)
-  inline given derivedNonNegIntShow(using showActual: Show[Int]): Show[NonNegInt] = contraCoercible(showActual)
-
-  inline given derivedPosIntEq(using eqActual: Eq[Int]): Eq[PosInt]         = contraCoercible(eqActual)
-  inline given derivedPosIntShow(using showActual: Show[Int]): Show[PosInt] = contraCoercible(showActual)
-
-  inline given derivedNonPosIntEq(using eqActual: Eq[Int]): Eq[NonPosInt]         = contraCoercible(eqActual)
-  inline given derivedNonPosIntShow(using showActual: Show[Int]): Show[NonPosInt] = contraCoercible(showActual)
-
-  inline given derivedNegLongEq(using eqActual: Eq[Long]): Eq[NegLong]         = contraCoercible(eqActual)
-  inline given derivedNegLongShow(using showActual: Show[Long]): Show[NegLong] = contraCoercible(showActual)
-
-  inline given derivedNonNegLongEq(using eqActual: Eq[Long]): Eq[NonNegLong]         = contraCoercible(eqActual)
-  inline given derivedNonNegLongShow(using showActual: Show[Long]): Show[NonNegLong] = contraCoercible(showActual)
-
-  inline given derivedPosLongEq(using eqActual: Eq[Long]): Eq[PosLong]         = contraCoercible(eqActual)
-  inline given derivedPosLongShow(using showActual: Show[Long]): Show[PosLong] = contraCoercible(showActual)
-
-  inline given derivedNonPosLongEq(using eqActual: Eq[Long]): Eq[NonPosLong]         = contraCoercible(eqActual)
-  inline given derivedNonPosLongShow(using showActual: Show[Long]): Show[NonPosLong] = contraCoercible(showActual)
-
-  inline given derivedNegShortEq(using eqActual: Eq[Short]): Eq[NegShort]         = contraCoercible(eqActual)
-  inline given derivedNegShortShow(using showActual: Show[Short]): Show[NegShort] = contraCoercible(showActual)
-
-  inline given derivedNonNegShortEq(using eqActual: Eq[Short]): Eq[NonNegShort]         = contraCoercible(eqActual)
-  inline given derivedNonNegShortShow(using showActual: Show[Short]): Show[NonNegShort] = contraCoercible(showActual)
-
-  inline given derivedPosShortEq(using eqActual: Eq[Short]): Eq[PosShort]         = contraCoercible(eqActual)
-  inline given derivedPosShortShow(using showActual: Show[Short]): Show[PosShort] = contraCoercible(showActual)
-
-  inline given derivedNonPosShortEq(using eqActual: Eq[Short]): Eq[NonPosShort]         = contraCoercible(eqActual)
-  inline given derivedNonPosShortShow(using showActual: Show[Short]): Show[NonPosShort] = contraCoercible(showActual)
-
-  inline given derivedNegByteEq(using eqActual: Eq[Byte]): Eq[NegByte]         = contraCoercible(eqActual)
-  inline given derivedNegByteShow(using showActual: Show[Byte]): Show[NegByte] = contraCoercible(showActual)
-
-  inline given derivedNonNegByteEq(using eqActual: Eq[Byte]): Eq[NonNegByte]         = contraCoercible(eqActual)
-  inline given derivedNonNegByteShow(using showActual: Show[Byte]): Show[NonNegByte] = contraCoercible(showActual)
-
-  inline given derivedPosByteEq(using eqActual: Eq[Byte]): Eq[PosByte]         = contraCoercible(eqActual)
-  inline given derivedPosByteShow(using showActual: Show[Byte]): Show[PosByte] = contraCoercible(showActual)
-
-  inline given derivedNonPosByteEq(using eqActual: Eq[Byte]): Eq[NonPosByte]         = contraCoercible(eqActual)
-  inline given derivedNonPosByteShow(using showActual: Show[Byte]): Show[NonPosByte] = contraCoercible(showActual)
-
-  inline given derivedNegFloatEq(using eqActual: Eq[Float]): Eq[NegFloat]         = contraCoercible(eqActual)
-  inline given derivedNegFloatShow(using showActual: Show[Float]): Show[NegFloat] = contraCoercible(showActual)
-
-  inline given derivedNonNegFloatEq(using eqActual: Eq[Float]): Eq[NonNegFloat]         = contraCoercible(eqActual)
-  inline given derivedNonNegFloatShow(using showActual: Show[Float]): Show[NonNegFloat] = contraCoercible(showActual)
-
-  inline given derivedPosFloatEq(using eqActual: Eq[Float]): Eq[PosFloat]         = contraCoercible(eqActual)
-  inline given derivedPosFloatShow(using showActual: Show[Float]): Show[PosFloat] = contraCoercible(showActual)
-
-  inline given derivedNonPosFloatEq(using eqActual: Eq[Float]): Eq[NonPosFloat]         = contraCoercible(eqActual)
-  inline given derivedNonPosFloatShow(using showActual: Show[Float]): Show[NonPosFloat] = contraCoercible(showActual)
-
-  inline given derivedNegDoubleEq(using eqActual: Eq[Double]): Eq[NegDouble]         = contraCoercible(eqActual)
-  inline given derivedNegDoubleShow(using showActual: Show[Double]): Show[NegDouble] = contraCoercible(showActual)
-
-  inline given derivedNonNegDoubleEq(using eqActual: Eq[Double]): Eq[NonNegDouble]         = contraCoercible(eqActual)
-  inline given derivedNonNegDoubleShow(using showActual: Show[Double]): Show[NonNegDouble] = contraCoercible(showActual)
-
-  inline given derivedPosDoubleEq(using eqActual: Eq[Double]): Eq[PosDouble]         = contraCoercible(eqActual)
-  inline given derivedPosDoubleShow(using showActual: Show[Double]): Show[PosDouble] = contraCoercible(showActual)
-
-  inline given derivedNonPosDoubleEq(using eqActual: Eq[Double]): Eq[NonPosDouble]         = contraCoercible(eqActual)
-  inline given derivedNonPosDoubleShow(using showActual: Show[Double]): Show[NonPosDouble] = contraCoercible(showActual)
-
-  inline given derivedNegBigIntEq(using eqActual: Eq[BigInt]): Eq[NegBigInt]         = contraCoercible(eqActual)
-  inline given derivedNegBigIntShow(using showActual: Show[BigInt]): Show[NegBigInt] = contraCoercible(showActual)
-
-  inline given derivedNonNegBigIntEq(using eqActual: Eq[BigInt]): Eq[NonNegBigInt]         = contraCoercible(eqActual)
-  inline given derivedNonNegBigIntShow(using showActual: Show[BigInt]): Show[NonNegBigInt] = contraCoercible(showActual)
-
-  inline given derivedPosBigIntEq(using eqActual: Eq[BigInt]): Eq[PosBigInt]         = contraCoercible(eqActual)
-  inline given derivedPosBigIntShow(using showActual: Show[BigInt]): Show[PosBigInt] = contraCoercible(showActual)
-
-  inline given derivedNonPosBigIntEq(using eqActual: Eq[BigInt]): Eq[NonPosBigInt]         = contraCoercible(eqActual)
-  inline given derivedNonPosBigIntShow(using showActual: Show[BigInt]): Show[NonPosBigInt] = contraCoercible(showActual)
-
-  inline given derivedNegBigDecimalEq(using eqActual: Eq[BigDecimal]): Eq[NegBigDecimal]         = contraCoercible(eqActual)
-  inline given derivedNegBigDecimalShow(using showActual: Show[BigDecimal]): Show[NegBigDecimal] = contraCoercible(showActual)
-
-  inline given derivedNonNegBigDecimalEq(using eqActual: Eq[BigDecimal]): Eq[NonNegBigDecimal]         = contraCoercible(eqActual)
-  inline given derivedNonNegBigDecimalShow(using showActual: Show[BigDecimal]): Show[NonNegBigDecimal] = contraCoercible(showActual)
-
-  inline given derivedPosBigDecimalEq(using eqActual: Eq[BigDecimal]): Eq[PosBigDecimal]         = contraCoercible(eqActual)
-  inline given derivedPosBigDecimalShow(using showActual: Show[BigDecimal]): Show[PosBigDecimal] = contraCoercible(showActual)
-
-  inline given derivedNonPosBigDecimalEq(using eqActual: Eq[BigDecimal]): Eq[NonPosBigDecimal]         = contraCoercible(eqActual)
-  inline given derivedNonPosBigDecimalShow(using showActual: Show[BigDecimal]): Show[NonPosBigDecimal] = contraCoercible(showActual)
-
-  // strings
-
-  // network
-
-}
+@deprecated(
+  message =
+    "It's no longer required. If your project has cats, the cats type-classes instances for refined4s's pre-defined types are automatically available without any import.",
+  since = "1.8.0",
+)
+trait all
+@deprecated(
+  message =
+    "It's no longer required. If your project has cats, the cats type-classes instances for refined4s's pre-defined types are automatically available without any import.",
+  since = "1.8.0",
+)
 object all extends all

--- a/modules/refined4s-cats/shared/src/test/scala/refined4s/modules/cats/derivation/types/CatsWithCustomTypeClassesSpec.scala
+++ b/modules/refined4s-cats/shared/src/test/scala/refined4s/modules/cats/derivation/types/CatsWithCustomTypeClassesSpec.scala
@@ -5,7 +5,6 @@ import cats.{Eq, Show}
 import hedgehog.*
 import hedgehog.runner.*
 import refined4s.*
-import refined4s.modules.cats.derivation.types.all.given
 import refined4s.types.all.*
 
 import java.time.Instant

--- a/modules/refined4s-cats/shared/src/test/scala/refined4s/modules/cats/derivation/types/allSpec.scala
+++ b/modules/refined4s-cats/shared/src/test/scala/refined4s/modules/cats/derivation/types/allSpec.scala
@@ -3,7 +3,6 @@ package refined4s.modules.cats.derivation.types
 import cats.syntax.all.*
 import hedgehog.*
 import hedgehog.runner.*
-import refined4s.modules.cats.derivation.types.all.given
 import refined4s.types.numeric.*
 import refined4s.types.network.*
 import refined4s.types.strings.*

--- a/modules/refined4s-core/shared/src/main/scala/refined4s/types/numeric.scala
+++ b/modules/refined4s-core/shared/src/main/scala/refined4s/types/numeric.scala
@@ -141,6 +141,9 @@ object numeric {
 
     override inline def predicate(a: Int): Boolean = a < 0
 
+    inline given derivedNegIntEq(using eqActual: cats.Eq[Int]): cats.Eq[NegInt]         = internalDef.contraCoercible(eqActual)
+    inline given derivedNegIntShow(using showActual: cats.Show[Int]): cats.Show[NegInt] = internalDef.contraCoercible(showActual)
+
   }
 
   type NonNegInt = NonNegInt.Type
@@ -151,6 +154,9 @@ object numeric {
     override inline def invalidReason(a: Int): String = expectedMessage("a non-negative Int")
 
     override inline def predicate(a: Int): Boolean = a >= 0
+
+    inline given derivedNonNegIntEq(using eqActual: cats.Eq[Int]): cats.Eq[NonNegInt]         = internalDef.contraCoercible(eqActual)
+    inline given derivedNonNegIntShow(using showActual: cats.Show[Int]): cats.Show[NonNegInt] = internalDef.contraCoercible(showActual)
 
   }
 
@@ -163,6 +169,9 @@ object numeric {
 
     override inline def predicate(a: Int): Boolean = a > 0
 
+    inline given derivedPosIntEq(using eqActual: cats.Eq[Int]): cats.Eq[PosInt]         = internalDef.contraCoercible(eqActual)
+    inline given derivedPosIntShow(using showActual: cats.Show[Int]): cats.Show[PosInt] = internalDef.contraCoercible(showActual)
+
   }
 
   type NonPosInt = NonPosInt.Type
@@ -173,6 +182,9 @@ object numeric {
     override inline def invalidReason(a: Int): String = expectedMessage("a non-positive Int")
 
     override inline def predicate(a: Int): Boolean = a <= 0
+
+    inline given derivedNonPosIntEq(using eqActual: cats.Eq[Int]): cats.Eq[NonPosInt]         = internalDef.contraCoercible(eqActual)
+    inline given derivedNonPosIntShow(using showActual: cats.Show[Int]): cats.Show[NonPosInt] = internalDef.contraCoercible(showActual)
 
   }
 
@@ -185,6 +197,9 @@ object numeric {
 
     override inline def predicate(a: Long): Boolean = a < 0L
 
+    inline given derivedNegLongEq(using eqActual: cats.Eq[Long]): cats.Eq[NegLong]         = internalDef.contraCoercible(eqActual)
+    inline given derivedNegLongShow(using showActual: cats.Show[Long]): cats.Show[NegLong] = internalDef.contraCoercible(showActual)
+
   }
 
   type NonNegLong = NonNegLong.Type
@@ -195,6 +210,9 @@ object numeric {
     override inline def invalidReason(a: Long): String = expectedMessage("a non-negative Long")
 
     override inline def predicate(a: Long): Boolean = a >= 0L
+
+    inline given derivedNonNegLongEq(using eqActual: cats.Eq[Long]): cats.Eq[NonNegLong]         = internalDef.contraCoercible(eqActual)
+    inline given derivedNonNegLongShow(using showActual: cats.Show[Long]): cats.Show[NonNegLong] = internalDef.contraCoercible(showActual)
 
   }
 
@@ -207,6 +225,9 @@ object numeric {
 
     override inline def predicate(a: Long): Boolean = a > 0L
 
+    inline given derivedPosLongEq(using eqActual: cats.Eq[Long]): cats.Eq[PosLong]         = internalDef.contraCoercible(eqActual)
+    inline given derivedPosLongShow(using showActual: cats.Show[Long]): cats.Show[PosLong] = internalDef.contraCoercible(showActual)
+
   }
 
   type NonPosLong = NonPosLong.Type
@@ -217,6 +238,9 @@ object numeric {
     override inline def invalidReason(a: Long): String = expectedMessage("a non-positive Long")
 
     override inline def predicate(a: Long): Boolean = a <= 0L
+
+    inline given derivedNonPosLongEq(using eqActual: cats.Eq[Long]): cats.Eq[NonPosLong]         = internalDef.contraCoercible(eqActual)
+    inline given derivedNonPosLongShow(using showActual: cats.Show[Long]): cats.Show[NonPosLong] = internalDef.contraCoercible(showActual)
 
   }
 
@@ -229,6 +253,9 @@ object numeric {
 
     override inline def predicate(a: Short): Boolean = a < 0
 
+    inline given derivedNegShortEq(using eqActual: cats.Eq[Short]): cats.Eq[NegShort]         = internalDef.contraCoercible(eqActual)
+    inline given derivedNegShortShow(using showActual: cats.Show[Short]): cats.Show[NegShort] = internalDef.contraCoercible(showActual)
+
   }
 
   type NonNegShort = NonNegShort.Type
@@ -239,6 +266,10 @@ object numeric {
     override inline def invalidReason(a: Short): String = expectedMessage("a non-negative Short")
 
     override inline def predicate(a: Short): Boolean = a >= 0
+
+    inline given derivedNonNegShortEq(using eqActual: cats.Eq[Short]): cats.Eq[NonNegShort]         = internalDef.contraCoercible(eqActual)
+    inline given derivedNonNegShortShow(using showActual: cats.Show[Short]): cats.Show[NonNegShort] =
+      internalDef.contraCoercible(showActual)
 
   }
 
@@ -251,6 +282,9 @@ object numeric {
 
     override inline def predicate(a: Short): Boolean = a > 0
 
+    inline given derivedPosShortEq(using eqActual: cats.Eq[Short]): cats.Eq[PosShort]         = internalDef.contraCoercible(eqActual)
+    inline given derivedPosShortShow(using showActual: cats.Show[Short]): cats.Show[PosShort] = internalDef.contraCoercible(showActual)
+
   }
 
   type NonPosShort = NonPosShort.Type
@@ -261,6 +295,10 @@ object numeric {
     override inline def invalidReason(a: Short): String = expectedMessage("a non-positive Short")
 
     override inline def predicate(a: Short): Boolean = a <= 0
+
+    inline given derivedNonPosShortEq(using eqActual: cats.Eq[Short]): cats.Eq[NonPosShort]         = internalDef.contraCoercible(eqActual)
+    inline given derivedNonPosShortShow(using showActual: cats.Show[Short]): cats.Show[NonPosShort] =
+      internalDef.contraCoercible(showActual)
 
   }
 
@@ -273,6 +311,9 @@ object numeric {
 
     override inline def predicate(a: Byte): Boolean = a < 0
 
+    inline given derivedNegByteEq(using eqActual: cats.Eq[Byte]): cats.Eq[NegByte]         = internalDef.contraCoercible(eqActual)
+    inline given derivedNegByteShow(using showActual: cats.Show[Byte]): cats.Show[NegByte] = internalDef.contraCoercible(showActual)
+
   }
 
   type NonNegByte = NonNegByte.Type
@@ -283,6 +324,9 @@ object numeric {
     override inline def invalidReason(a: Byte): String = expectedMessage("a non-negative Byte")
 
     override inline def predicate(a: Byte): Boolean = a >= 0
+
+    inline given derivedNonNegByteEq(using eqActual: cats.Eq[Byte]): cats.Eq[NonNegByte]         = internalDef.contraCoercible(eqActual)
+    inline given derivedNonNegByteShow(using showActual: cats.Show[Byte]): cats.Show[NonNegByte] = internalDef.contraCoercible(showActual)
 
   }
 
@@ -295,6 +339,9 @@ object numeric {
 
     override inline def predicate(a: Byte): Boolean = a > 0
 
+    inline given derivedPosByteEq(using eqActual: cats.Eq[Byte]): cats.Eq[PosByte]         = internalDef.contraCoercible(eqActual)
+    inline given derivedPosByteShow(using showActual: cats.Show[Byte]): cats.Show[PosByte] = internalDef.contraCoercible(showActual)
+
   }
 
   type NonPosByte = NonPosByte.Type
@@ -305,6 +352,9 @@ object numeric {
     override inline def invalidReason(a: Byte): String = expectedMessage("a non-positive Byte")
 
     override inline def predicate(a: Byte): Boolean = a <= 0
+
+    inline given derivedNonPosByteEq(using eqActual: cats.Eq[Byte]): cats.Eq[NonPosByte]         = internalDef.contraCoercible(eqActual)
+    inline given derivedNonPosByteShow(using showActual: cats.Show[Byte]): cats.Show[NonPosByte] = internalDef.contraCoercible(showActual)
 
   }
 
@@ -317,6 +367,9 @@ object numeric {
 
     override inline def predicate(a: Float): Boolean = a < 0f
 
+    inline given derivedNegFloatEq(using eqActual: cats.Eq[Float]): cats.Eq[NegFloat]         = internalDef.contraCoercible(eqActual)
+    inline given derivedNegFloatShow(using showActual: cats.Show[Float]): cats.Show[NegFloat] = internalDef.contraCoercible(showActual)
+
   }
 
   type NonNegFloat = NonNegFloat.Type
@@ -327,6 +380,10 @@ object numeric {
     override inline def invalidReason(a: Float): String = expectedMessage("a non-negative Float")
 
     override inline def predicate(a: Float): Boolean = a >= 0f
+
+    inline given derivedNonNegFloatEq(using eqActual: cats.Eq[Float]): cats.Eq[NonNegFloat]         = internalDef.contraCoercible(eqActual)
+    inline given derivedNonNegFloatShow(using showActual: cats.Show[Float]): cats.Show[NonNegFloat] =
+      internalDef.contraCoercible(showActual)
 
   }
 
@@ -339,6 +396,9 @@ object numeric {
 
     override inline def predicate(a: Float): Boolean = a > 0f
 
+    inline given derivedPosFloatEq(using eqActual: cats.Eq[Float]): cats.Eq[PosFloat]         = internalDef.contraCoercible(eqActual)
+    inline given derivedPosFloatShow(using showActual: cats.Show[Float]): cats.Show[PosFloat] = internalDef.contraCoercible(showActual)
+
   }
 
   type NonPosFloat = NonPosFloat.Type
@@ -349,6 +409,10 @@ object numeric {
     override inline def invalidReason(a: Float): String = expectedMessage("a non-positive Float")
 
     override inline def predicate(a: Float): Boolean = a <= 0f
+
+    inline given derivedNonPosFloatEq(using eqActual: cats.Eq[Float]): cats.Eq[NonPosFloat]         = internalDef.contraCoercible(eqActual)
+    inline given derivedNonPosFloatShow(using showActual: cats.Show[Float]): cats.Show[NonPosFloat] =
+      internalDef.contraCoercible(showActual)
 
   }
 
@@ -361,6 +425,9 @@ object numeric {
 
     override inline def predicate(a: Double): Boolean = a < 0d
 
+    inline given derivedNegDoubleEq(using eqActual: cats.Eq[Double]): cats.Eq[NegDouble]         = internalDef.contraCoercible(eqActual)
+    inline given derivedNegDoubleShow(using showActual: cats.Show[Double]): cats.Show[NegDouble] = internalDef.contraCoercible(showActual)
+
   }
 
   type NonNegDouble = NonNegDouble.Type
@@ -371,6 +438,10 @@ object numeric {
     override inline def invalidReason(a: Double): String = expectedMessage("a non-negative Double")
 
     override inline def predicate(a: Double): Boolean = a >= 0d
+
+    inline given derivedNonNegDoubleEq(using eqActual: cats.Eq[Double]): cats.Eq[NonNegDouble] = internalDef.contraCoercible(eqActual)
+    inline given derivedNonNegDoubleShow(using showActual: cats.Show[Double]): cats.Show[NonNegDouble] =
+      internalDef.contraCoercible(showActual)
 
   }
 
@@ -383,6 +454,9 @@ object numeric {
 
     override inline def predicate(a: Double): Boolean = a > 0d
 
+    inline given derivedPosDoubleEq(using eqActual: cats.Eq[Double]): cats.Eq[PosDouble]         = internalDef.contraCoercible(eqActual)
+    inline given derivedPosDoubleShow(using showActual: cats.Show[Double]): cats.Show[PosDouble] = internalDef.contraCoercible(showActual)
+
   }
 
   type NonPosDouble = NonPosDouble.Type
@@ -393,6 +467,10 @@ object numeric {
     override inline def invalidReason(a: Double): String = expectedMessage("a non-positive Double")
 
     override inline def predicate(a: Double): Boolean = a <= 0d
+
+    inline given derivedNonPosDoubleEq(using eqActual: cats.Eq[Double]): cats.Eq[NonPosDouble] = internalDef.contraCoercible(eqActual)
+    inline given derivedNonPosDoubleShow(using showActual: cats.Show[Double]): cats.Show[NonPosDouble] =
+      internalDef.contraCoercible(showActual)
 
   }
 
@@ -419,6 +497,9 @@ object numeric {
 
     inline def apply(inline a: String): Type = apply(BigInt(a))
 
+    inline given derivedNegBigIntEq(using eqActual: cats.Eq[BigInt]): cats.Eq[NegBigInt]         = internalDef.contraCoercible(eqActual)
+    inline given derivedNegBigIntShow(using showActual: cats.Show[BigInt]): cats.Show[NegBigInt] = internalDef.contraCoercible(showActual)
+
   }
 
   type NonNegBigInt = NonNegBigInt.Type
@@ -437,6 +518,11 @@ object numeric {
     inline def apply(inline a: Long): Type = apply(BigInt(a))
 
     inline def apply(inline a: String): Type = apply(BigInt(a))
+
+    inline given derivedNonNegBigIntEq(using eqActual: cats.Eq[BigInt]): cats.Eq[NonNegBigInt] = internalDef.contraCoercible(eqActual)
+    inline given derivedNonNegBigIntShow(using showActual: cats.Show[BigInt]): cats.Show[NonNegBigInt] =
+      internalDef.contraCoercible(showActual)
+
   }
 
   type PosBigInt = PosBigInt.Type
@@ -455,6 +541,10 @@ object numeric {
     inline def apply(inline a: Long): Type = apply(BigInt(a))
 
     inline def apply(inline a: String): Type = apply(BigInt(a))
+
+    inline given derivedPosBigIntEq(using eqActual: cats.Eq[BigInt]): cats.Eq[PosBigInt]         = internalDef.contraCoercible(eqActual)
+    inline given derivedPosBigIntShow(using showActual: cats.Show[BigInt]): cats.Show[PosBigInt] = internalDef.contraCoercible(showActual)
+
   }
 
   type NonPosBigInt = NonPosBigInt.Type
@@ -473,6 +563,11 @@ object numeric {
     inline def apply(inline a: Long): Type = apply(BigInt(a))
 
     inline def apply(inline a: String): Type = apply(BigInt(a))
+
+    inline given derivedNonPosBigIntEq(using eqActual: cats.Eq[BigInt]): cats.Eq[NonPosBigInt] = internalDef.contraCoercible(eqActual)
+    inline given derivedNonPosBigIntShow(using showActual: cats.Show[BigInt]): cats.Show[NonPosBigInt] =
+      internalDef.contraCoercible(showActual)
+
   }
 
   type NegBigDecimal = NegBigDecimal.Type
@@ -495,6 +590,11 @@ object numeric {
     inline def apply(inline a: Double): Type = apply(BigDecimal(a))
 
     inline def apply(inline a: String): Type = apply(BigDecimal(a))
+
+    inline given derivedNegBigDecimalEq(using eqActual: cats.Eq[BigDecimal]): cats.Eq[NegBigDecimal] = internalDef.contraCoercible(eqActual)
+    inline given derivedNegBigDecimalShow(using showActual: cats.Show[BigDecimal]): cats.Show[NegBigDecimal] =
+      internalDef.contraCoercible(showActual)
+
   }
 
   type NonNegBigDecimal = NonNegBigDecimal.Type
@@ -517,6 +617,12 @@ object numeric {
     inline def apply(inline a: Double): Type = apply(BigDecimal(a))
 
     inline def apply(inline a: String): Type = apply(BigDecimal(a))
+
+    inline given derivedNonNegBigDecimalEq(using eqActual: cats.Eq[BigDecimal]): cats.Eq[NonNegBigDecimal]         =
+      internalDef.contraCoercible(eqActual)
+    inline given derivedNonNegBigDecimalShow(using showActual: cats.Show[BigDecimal]): cats.Show[NonNegBigDecimal] =
+      internalDef.contraCoercible(showActual)
+
   }
 
   type PosBigDecimal = PosBigDecimal.Type
@@ -539,6 +645,11 @@ object numeric {
     inline def apply(inline a: Double): Type = apply(BigDecimal(a))
 
     inline def apply(inline a: String): Type = apply(BigDecimal(a))
+
+    inline given derivedPosBigDecimalEq(using eqActual: cats.Eq[BigDecimal]): cats.Eq[PosBigDecimal] = internalDef.contraCoercible(eqActual)
+    inline given derivedPosBigDecimalShow(using showActual: cats.Show[BigDecimal]): cats.Show[PosBigDecimal] =
+      internalDef.contraCoercible(showActual)
+
   }
 
   type NonPosBigDecimal = NonPosBigDecimal.Type
@@ -561,6 +672,12 @@ object numeric {
     inline def apply(inline a: Double): Type = apply(BigDecimal(a))
 
     inline def apply(inline a: String): Type = apply(BigDecimal(a))
+
+    inline given derivedNonPosBigDecimalEq(using eqActual: cats.Eq[BigDecimal]): cats.Eq[NonPosBigDecimal]         =
+      internalDef.contraCoercible(eqActual)
+    inline given derivedNonPosBigDecimalShow(using showActual: cats.Show[BigDecimal]): cats.Show[NonPosBigDecimal] =
+      internalDef.contraCoercible(showActual)
+
   }
 
 }

--- a/modules/refined4s-core/shared/src/main/scala/refined4s/types/numeric.scala
+++ b/modules/refined4s-core/shared/src/main/scala/refined4s/types/numeric.scala
@@ -1,5 +1,6 @@
 package refined4s.types
 
+import orphan.{OrphanCats, OrphanCatsKernel}
 import refined4s.*
 import refined4s.internal.numericTools
 
@@ -108,7 +109,7 @@ trait numeric {
 
   // scalafix:on
 }
-object numeric {
+object numeric extends OrphanCats, OrphanCatsKernel {
 
   trait Numeric[@specialized(Int, Long, Short, Byte, Float, Double) A: math.Ordering] extends Refined[A], CanBeOrdered[A]
 
@@ -141,8 +142,15 @@ object numeric {
 
     override inline def predicate(a: Int): Boolean = a < 0
 
-    inline given derivedNegIntEq(using eqActual: cats.Eq[Int]): cats.Eq[NegInt]         = internalDef.contraCoercible(eqActual)
-    inline given derivedNegIntShow(using showActual: cats.Show[Int]): cats.Show[NegInt] = internalDef.contraCoercible(showActual)
+    @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
+    inline given derivedNegIntEq[F[*]: CatsEq, G[*]: CatsEq](using eqActual: G[Int]): F[NegInt] = {
+      internalDef.contraCoercible(eqActual.asInstanceOf[cats.Eq[Int]])
+    }.asInstanceOf[F[NegInt]] // scalafix:ok DisableSyntax.asInstanceOf
+
+    @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
+    inline given derivedNegIntShow[F[*]: CatsShow, G[*]: CatsShow](using showActual: G[Int]): F[NegInt] = {
+      internalDef.contraCoercible(showActual.asInstanceOf[cats.Show[Int]])
+    }.asInstanceOf[F[NegInt]] // scalafix:ok DisableSyntax.asInstanceOf
 
   }
 
@@ -155,8 +163,15 @@ object numeric {
 
     override inline def predicate(a: Int): Boolean = a >= 0
 
-    inline given derivedNonNegIntEq(using eqActual: cats.Eq[Int]): cats.Eq[NonNegInt]         = internalDef.contraCoercible(eqActual)
-    inline given derivedNonNegIntShow(using showActual: cats.Show[Int]): cats.Show[NonNegInt] = internalDef.contraCoercible(showActual)
+    @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
+    inline given derivedNonNegIntEq[F[*]: CatsEq, G[*]: CatsEq](using eqActual: G[Int]): F[NonNegInt] = {
+      internalDef.contraCoercible(eqActual.asInstanceOf[cats.Eq[Int]])
+    }.asInstanceOf[F[NonNegInt]] // scalafix:ok DisableSyntax.asInstanceOf
+
+    @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
+    inline given derivedNonNegIntShow[F[*]: CatsShow, G[*]: CatsShow](using showActual: G[Int]): F[NonNegInt] = {
+      internalDef.contraCoercible(showActual.asInstanceOf[cats.Show[Int]])
+    }.asInstanceOf[F[NonNegInt]] // scalafix:ok DisableSyntax.asInstanceOf
 
   }
 
@@ -169,8 +184,15 @@ object numeric {
 
     override inline def predicate(a: Int): Boolean = a > 0
 
-    inline given derivedPosIntEq(using eqActual: cats.Eq[Int]): cats.Eq[PosInt]         = internalDef.contraCoercible(eqActual)
-    inline given derivedPosIntShow(using showActual: cats.Show[Int]): cats.Show[PosInt] = internalDef.contraCoercible(showActual)
+    @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
+    inline given derivedPosIntEq[F[*]: CatsEq, G[*]: CatsEq](using eqActual: G[Int]): F[PosInt] = {
+      internalDef.contraCoercible(eqActual.asInstanceOf[cats.Eq[Int]])
+    }.asInstanceOf[F[PosInt]] // scalafix:ok DisableSyntax.asInstanceOf
+
+    @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
+    inline given derivedPosIntShow[F[*]: CatsShow, G[*]: CatsShow](using showActual: G[Int]): F[PosInt] = {
+      internalDef.contraCoercible(showActual.asInstanceOf[cats.Show[Int]])
+    }.asInstanceOf[F[PosInt]] // scalafix:ok DisableSyntax.asInstanceOf
 
   }
 
@@ -183,8 +205,15 @@ object numeric {
 
     override inline def predicate(a: Int): Boolean = a <= 0
 
-    inline given derivedNonPosIntEq(using eqActual: cats.Eq[Int]): cats.Eq[NonPosInt]         = internalDef.contraCoercible(eqActual)
-    inline given derivedNonPosIntShow(using showActual: cats.Show[Int]): cats.Show[NonPosInt] = internalDef.contraCoercible(showActual)
+    @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
+    inline given derivedNonPosIntEq[F[*]: CatsEq, G[*]: CatsEq](using eqActual: G[Int]): F[NonPosInt] = {
+      internalDef.contraCoercible(eqActual.asInstanceOf[cats.Eq[Int]])
+    }.asInstanceOf[F[NonPosInt]] // scalafix:ok DisableSyntax.asInstanceOf
+
+    @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
+    inline given derivedNonPosIntShow[F[*]: CatsShow, G[*]: CatsShow](using showActual: G[Int]): F[NonPosInt] = {
+      internalDef.contraCoercible(showActual.asInstanceOf[cats.Show[Int]])
+    }.asInstanceOf[F[NonPosInt]] // scalafix:ok DisableSyntax.asInstanceOf
 
   }
 
@@ -197,8 +226,15 @@ object numeric {
 
     override inline def predicate(a: Long): Boolean = a < 0L
 
-    inline given derivedNegLongEq(using eqActual: cats.Eq[Long]): cats.Eq[NegLong]         = internalDef.contraCoercible(eqActual)
-    inline given derivedNegLongShow(using showActual: cats.Show[Long]): cats.Show[NegLong] = internalDef.contraCoercible(showActual)
+    @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
+    inline given derivedNegLongEq[F[*]: CatsEq, G[*]: CatsEq](using eqActual: G[Long]): F[NegLong] = {
+      internalDef.contraCoercible(eqActual.asInstanceOf[cats.Eq[Long]])
+    }.asInstanceOf[F[NegLong]] // scalafix:ok DisableSyntax.asInstanceOf
+
+    @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
+    inline given derivedNegLongShow[F[*]: CatsShow, G[*]: CatsShow](using showActual: G[Long]): F[NegLong] = {
+      internalDef.contraCoercible(showActual.asInstanceOf[cats.Show[Long]])
+    }.asInstanceOf[F[NegLong]] // scalafix:ok DisableSyntax.asInstanceOf
 
   }
 
@@ -211,8 +247,15 @@ object numeric {
 
     override inline def predicate(a: Long): Boolean = a >= 0L
 
-    inline given derivedNonNegLongEq(using eqActual: cats.Eq[Long]): cats.Eq[NonNegLong]         = internalDef.contraCoercible(eqActual)
-    inline given derivedNonNegLongShow(using showActual: cats.Show[Long]): cats.Show[NonNegLong] = internalDef.contraCoercible(showActual)
+    @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
+    inline given derivedNonNegLongEq[F[*]: CatsEq, G[*]: CatsEq](using eqActual: G[Long]): F[NonNegLong] = {
+      internalDef.contraCoercible(eqActual.asInstanceOf[cats.Eq[Long]])
+    }.asInstanceOf[F[NonNegLong]] // scalafix:ok DisableSyntax.asInstanceOf
+
+    @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
+    inline given derivedNonNegLongShow[F[*]: CatsShow, G[*]: CatsShow](using showActual: G[Long]): F[NonNegLong] = {
+      internalDef.contraCoercible(showActual.asInstanceOf[cats.Show[Long]])
+    }.asInstanceOf[F[NonNegLong]] // scalafix:ok DisableSyntax.asInstanceOf
 
   }
 
@@ -225,8 +268,15 @@ object numeric {
 
     override inline def predicate(a: Long): Boolean = a > 0L
 
-    inline given derivedPosLongEq(using eqActual: cats.Eq[Long]): cats.Eq[PosLong]         = internalDef.contraCoercible(eqActual)
-    inline given derivedPosLongShow(using showActual: cats.Show[Long]): cats.Show[PosLong] = internalDef.contraCoercible(showActual)
+    @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
+    inline given derivedPosLongEq[F[*]: CatsEq, G[*]: CatsEq](using eqActual: G[Long]): F[PosLong] = {
+      internalDef.contraCoercible(eqActual.asInstanceOf[cats.Eq[Long]])
+    }.asInstanceOf[F[PosLong]] // scalafix:ok DisableSyntax.asInstanceOf
+
+    @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
+    inline given derivedPosLongShow[F[*]: CatsShow, G[*]: CatsShow](using showActual: G[Long]): F[PosLong] = {
+      internalDef.contraCoercible(showActual.asInstanceOf[cats.Show[Long]])
+    }.asInstanceOf[F[PosLong]] // scalafix:ok DisableSyntax.asInstanceOf
 
   }
 
@@ -239,8 +289,15 @@ object numeric {
 
     override inline def predicate(a: Long): Boolean = a <= 0L
 
-    inline given derivedNonPosLongEq(using eqActual: cats.Eq[Long]): cats.Eq[NonPosLong]         = internalDef.contraCoercible(eqActual)
-    inline given derivedNonPosLongShow(using showActual: cats.Show[Long]): cats.Show[NonPosLong] = internalDef.contraCoercible(showActual)
+    @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
+    inline given derivedNonPosLongEq[F[*]: CatsEq, G[*]: CatsEq](using eqActual: G[Long]): F[NonPosLong] = {
+      internalDef.contraCoercible(eqActual.asInstanceOf[cats.Eq[Long]])
+    }.asInstanceOf[F[NonPosLong]] // scalafix:ok DisableSyntax.asInstanceOf
+
+    @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
+    inline given derivedNonPosLongShow[F[*]: CatsShow, G[*]: CatsShow](using showActual: G[Long]): F[NonPosLong] = {
+      internalDef.contraCoercible(showActual.asInstanceOf[cats.Show[Long]])
+    }.asInstanceOf[F[NonPosLong]] // scalafix:ok DisableSyntax.asInstanceOf
 
   }
 
@@ -253,8 +310,15 @@ object numeric {
 
     override inline def predicate(a: Short): Boolean = a < 0
 
-    inline given derivedNegShortEq(using eqActual: cats.Eq[Short]): cats.Eq[NegShort]         = internalDef.contraCoercible(eqActual)
-    inline given derivedNegShortShow(using showActual: cats.Show[Short]): cats.Show[NegShort] = internalDef.contraCoercible(showActual)
+    @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
+    inline given derivedNegShortEq[F[*]: CatsEq, G[*]: CatsEq](using eqActual: G[Short]): F[NegShort] = {
+      internalDef.contraCoercible(eqActual.asInstanceOf[cats.Eq[Short]])
+    }.asInstanceOf[F[NegShort]] // scalafix:ok DisableSyntax.asInstanceOf
+
+    @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
+    inline given derivedNegShortShow[F[*]: CatsShow, G[*]: CatsShow](using showActual: G[Short]): F[NegShort] = {
+      internalDef.contraCoercible(showActual.asInstanceOf[cats.Show[Short]])
+    }.asInstanceOf[F[NegShort]] // scalafix:ok DisableSyntax.asInstanceOf
 
   }
 
@@ -267,9 +331,15 @@ object numeric {
 
     override inline def predicate(a: Short): Boolean = a >= 0
 
-    inline given derivedNonNegShortEq(using eqActual: cats.Eq[Short]): cats.Eq[NonNegShort]         = internalDef.contraCoercible(eqActual)
-    inline given derivedNonNegShortShow(using showActual: cats.Show[Short]): cats.Show[NonNegShort] =
-      internalDef.contraCoercible(showActual)
+    @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
+    inline given derivedNonNegShortEq[F[*]: CatsEq, G[*]: CatsEq](using eqActual: G[Short]): F[NonNegShort] = {
+      internalDef.contraCoercible(eqActual.asInstanceOf[cats.Eq[Short]])
+    }.asInstanceOf[F[NonNegShort]] // scalafix:ok DisableSyntax.asInstanceOf
+
+    @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
+    inline given derivedNonNegShortShow[F[*]: CatsShow, G[*]: CatsShow](using showActual: G[Short]): F[NonNegShort] = {
+      internalDef.contraCoercible(showActual.asInstanceOf[cats.Show[Short]])
+    }.asInstanceOf[F[NonNegShort]] // scalafix:ok DisableSyntax.asInstanceOf
 
   }
 
@@ -282,8 +352,15 @@ object numeric {
 
     override inline def predicate(a: Short): Boolean = a > 0
 
-    inline given derivedPosShortEq(using eqActual: cats.Eq[Short]): cats.Eq[PosShort]         = internalDef.contraCoercible(eqActual)
-    inline given derivedPosShortShow(using showActual: cats.Show[Short]): cats.Show[PosShort] = internalDef.contraCoercible(showActual)
+    @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
+    inline given derivedPosShortEq[F[*]: CatsEq, G[*]: CatsEq](using eqActual: G[Short]): F[PosShort] = {
+      internalDef.contraCoercible(eqActual.asInstanceOf[cats.Eq[Short]])
+    }.asInstanceOf[F[PosShort]] // scalafix:ok DisableSyntax.asInstanceOf
+
+    @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
+    inline given derivedPosShortShow[F[*]: CatsShow, G[*]: CatsShow](using showActual: G[Short]): F[PosShort] = {
+      internalDef.contraCoercible(showActual.asInstanceOf[cats.Show[Short]])
+    }.asInstanceOf[F[PosShort]] // scalafix:ok DisableSyntax.asInstanceOf
 
   }
 
@@ -296,9 +373,15 @@ object numeric {
 
     override inline def predicate(a: Short): Boolean = a <= 0
 
-    inline given derivedNonPosShortEq(using eqActual: cats.Eq[Short]): cats.Eq[NonPosShort]         = internalDef.contraCoercible(eqActual)
-    inline given derivedNonPosShortShow(using showActual: cats.Show[Short]): cats.Show[NonPosShort] =
-      internalDef.contraCoercible(showActual)
+    @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
+    inline given derivedNonPosShortEq[F[*]: CatsEq, G[*]: CatsEq](using eqActual: G[Short]): F[NonPosShort] = {
+      internalDef.contraCoercible(eqActual.asInstanceOf[cats.Eq[Short]])
+    }.asInstanceOf[F[NonPosShort]] // scalafix:ok DisableSyntax.asInstanceOf
+
+    @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
+    inline given derivedNonPosShortShow[F[*]: CatsShow, G[*]: CatsShow](using showActual: G[Short]): F[NonPosShort] = {
+      internalDef.contraCoercible(showActual.asInstanceOf[cats.Show[Short]])
+    }.asInstanceOf[F[NonPosShort]] // scalafix:ok DisableSyntax.asInstanceOf
 
   }
 
@@ -311,8 +394,15 @@ object numeric {
 
     override inline def predicate(a: Byte): Boolean = a < 0
 
-    inline given derivedNegByteEq(using eqActual: cats.Eq[Byte]): cats.Eq[NegByte]         = internalDef.contraCoercible(eqActual)
-    inline given derivedNegByteShow(using showActual: cats.Show[Byte]): cats.Show[NegByte] = internalDef.contraCoercible(showActual)
+    @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
+    inline given derivedNegByteEq[F[*]: CatsEq, G[*]: CatsEq](using eqActual: G[Byte]): F[NegByte] = {
+      internalDef.contraCoercible(eqActual.asInstanceOf[cats.Eq[Byte]])
+    }.asInstanceOf[F[NegByte]] // scalafix:ok DisableSyntax.asInstanceOf
+
+    @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
+    inline given derivedNegByteShow[F[*]: CatsShow, G[*]: CatsShow](using showActual: G[Byte]): F[NegByte] = {
+      internalDef.contraCoercible(showActual.asInstanceOf[cats.Show[Byte]])
+    }.asInstanceOf[F[NegByte]] // scalafix:ok DisableSyntax.asInstanceOf
 
   }
 
@@ -325,8 +415,15 @@ object numeric {
 
     override inline def predicate(a: Byte): Boolean = a >= 0
 
-    inline given derivedNonNegByteEq(using eqActual: cats.Eq[Byte]): cats.Eq[NonNegByte]         = internalDef.contraCoercible(eqActual)
-    inline given derivedNonNegByteShow(using showActual: cats.Show[Byte]): cats.Show[NonNegByte] = internalDef.contraCoercible(showActual)
+    @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
+    inline given derivedNonNegByteEq[F[*]: CatsEq, G[*]: CatsEq](using eqActual: G[Byte]): F[NonNegByte] = {
+      internalDef.contraCoercible(eqActual.asInstanceOf[cats.Eq[Byte]])
+    }.asInstanceOf[F[NonNegByte]] // scalafix:ok DisableSyntax.asInstanceOf
+
+    @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
+    inline given derivedNonNegByteShow[F[*]: CatsShow, G[*]: CatsShow](using showActual: G[Byte]): F[NonNegByte] = {
+      internalDef.contraCoercible(showActual.asInstanceOf[cats.Show[Byte]])
+    }.asInstanceOf[F[NonNegByte]] // scalafix:ok DisableSyntax.asInstanceOf
 
   }
 
@@ -339,8 +436,15 @@ object numeric {
 
     override inline def predicate(a: Byte): Boolean = a > 0
 
-    inline given derivedPosByteEq(using eqActual: cats.Eq[Byte]): cats.Eq[PosByte]         = internalDef.contraCoercible(eqActual)
-    inline given derivedPosByteShow(using showActual: cats.Show[Byte]): cats.Show[PosByte] = internalDef.contraCoercible(showActual)
+    @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
+    inline given derivedPosByteEq[F[*]: CatsEq, G[*]: CatsEq](using eqActual: G[Byte]): F[PosByte] = {
+      internalDef.contraCoercible(eqActual.asInstanceOf[cats.Eq[Byte]])
+    }.asInstanceOf[F[PosByte]] // scalafix:ok DisableSyntax.asInstanceOf
+
+    @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
+    inline given derivedPosByteShow[F[*]: CatsShow, G[*]: CatsShow](using showActual: G[Byte]): F[PosByte] = {
+      internalDef.contraCoercible(showActual.asInstanceOf[cats.Show[Byte]])
+    }.asInstanceOf[F[PosByte]] // scalafix:ok DisableSyntax.asInstanceOf
 
   }
 
@@ -353,8 +457,15 @@ object numeric {
 
     override inline def predicate(a: Byte): Boolean = a <= 0
 
-    inline given derivedNonPosByteEq(using eqActual: cats.Eq[Byte]): cats.Eq[NonPosByte]         = internalDef.contraCoercible(eqActual)
-    inline given derivedNonPosByteShow(using showActual: cats.Show[Byte]): cats.Show[NonPosByte] = internalDef.contraCoercible(showActual)
+    @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
+    inline given derivedNonPosByteEq[F[*]: CatsEq, G[*]: CatsEq](using eqActual: G[Byte]): F[NonPosByte] = {
+      internalDef.contraCoercible(eqActual.asInstanceOf[cats.Eq[Byte]])
+    }.asInstanceOf[F[NonPosByte]] // scalafix:ok DisableSyntax.asInstanceOf
+
+    @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
+    inline given derivedNonPosByteShow[F[*]: CatsShow, G[*]: CatsShow](using showActual: G[Byte]): F[NonPosByte] = {
+      internalDef.contraCoercible(showActual.asInstanceOf[cats.Show[Byte]])
+    }.asInstanceOf[F[NonPosByte]] // scalafix:ok DisableSyntax.asInstanceOf
 
   }
 
@@ -367,8 +478,15 @@ object numeric {
 
     override inline def predicate(a: Float): Boolean = a < 0f
 
-    inline given derivedNegFloatEq(using eqActual: cats.Eq[Float]): cats.Eq[NegFloat]         = internalDef.contraCoercible(eqActual)
-    inline given derivedNegFloatShow(using showActual: cats.Show[Float]): cats.Show[NegFloat] = internalDef.contraCoercible(showActual)
+    @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
+    inline given derivedNegFloatEq[F[*]: CatsEq, G[*]: CatsEq](using eqActual: G[Float]): F[NegFloat] = {
+      internalDef.contraCoercible(eqActual.asInstanceOf[cats.Eq[Float]])
+    }.asInstanceOf[F[NegFloat]] // scalafix:ok DisableSyntax.asInstanceOf
+
+    @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
+    inline given derivedNegFloatShow[F[*]: CatsShow, G[*]: CatsShow](using showActual: G[Float]): F[NegFloat] = {
+      internalDef.contraCoercible(showActual.asInstanceOf[cats.Show[Float]])
+    }.asInstanceOf[F[NegFloat]] // scalafix:ok DisableSyntax.asInstanceOf
 
   }
 
@@ -381,9 +499,15 @@ object numeric {
 
     override inline def predicate(a: Float): Boolean = a >= 0f
 
-    inline given derivedNonNegFloatEq(using eqActual: cats.Eq[Float]): cats.Eq[NonNegFloat]         = internalDef.contraCoercible(eqActual)
-    inline given derivedNonNegFloatShow(using showActual: cats.Show[Float]): cats.Show[NonNegFloat] =
-      internalDef.contraCoercible(showActual)
+    @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
+    inline given derivedNonNegFloatEq[F[*]: CatsEq, G[*]: CatsEq](using eqActual: G[Float]): F[NonNegFloat] = {
+      internalDef.contraCoercible(eqActual.asInstanceOf[cats.Eq[Float]])
+    }.asInstanceOf[F[NonNegFloat]] // scalafix:ok DisableSyntax.asInstanceOf
+
+    @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
+    inline given derivedNonNegFloatShow[F[*]: CatsShow, G[*]: CatsShow](using showActual: G[Float]): F[NonNegFloat] = {
+      internalDef.contraCoercible(showActual.asInstanceOf[cats.Show[Float]])
+    }.asInstanceOf[F[NonNegFloat]] // scalafix:ok DisableSyntax.asInstanceOf
 
   }
 
@@ -396,8 +520,15 @@ object numeric {
 
     override inline def predicate(a: Float): Boolean = a > 0f
 
-    inline given derivedPosFloatEq(using eqActual: cats.Eq[Float]): cats.Eq[PosFloat]         = internalDef.contraCoercible(eqActual)
-    inline given derivedPosFloatShow(using showActual: cats.Show[Float]): cats.Show[PosFloat] = internalDef.contraCoercible(showActual)
+    @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
+    inline given derivedPosFloatEq[F[*]: CatsEq, G[*]: CatsEq](using eqActual: G[Float]): F[PosFloat] = {
+      internalDef.contraCoercible(eqActual.asInstanceOf[cats.Eq[Float]])
+    }.asInstanceOf[F[PosFloat]] // scalafix:ok DisableSyntax.asInstanceOf
+
+    @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
+    inline given derivedPosFloatShow[F[*]: CatsShow, G[*]: CatsShow](using showActual: G[Float]): F[PosFloat] = {
+      internalDef.contraCoercible(showActual.asInstanceOf[cats.Show[Float]])
+    }.asInstanceOf[F[PosFloat]] // scalafix:ok DisableSyntax.asInstanceOf
 
   }
 
@@ -410,9 +541,15 @@ object numeric {
 
     override inline def predicate(a: Float): Boolean = a <= 0f
 
-    inline given derivedNonPosFloatEq(using eqActual: cats.Eq[Float]): cats.Eq[NonPosFloat]         = internalDef.contraCoercible(eqActual)
-    inline given derivedNonPosFloatShow(using showActual: cats.Show[Float]): cats.Show[NonPosFloat] =
-      internalDef.contraCoercible(showActual)
+    @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
+    inline given derivedNonPosFloatEq[F[*]: CatsEq, G[*]: CatsEq](using eqActual: G[Float]): F[NonPosFloat] = {
+      internalDef.contraCoercible(eqActual.asInstanceOf[cats.Eq[Float]])
+    }.asInstanceOf[F[NonPosFloat]] // scalafix:ok DisableSyntax.asInstanceOf
+
+    @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
+    inline given derivedNonPosFloatShow[F[*]: CatsShow, G[*]: CatsShow](using showActual: G[Float]): F[NonPosFloat] = {
+      internalDef.contraCoercible(showActual.asInstanceOf[cats.Show[Float]])
+    }.asInstanceOf[F[NonPosFloat]] // scalafix:ok DisableSyntax.asInstanceOf
 
   }
 
@@ -425,8 +562,15 @@ object numeric {
 
     override inline def predicate(a: Double): Boolean = a < 0d
 
-    inline given derivedNegDoubleEq(using eqActual: cats.Eq[Double]): cats.Eq[NegDouble]         = internalDef.contraCoercible(eqActual)
-    inline given derivedNegDoubleShow(using showActual: cats.Show[Double]): cats.Show[NegDouble] = internalDef.contraCoercible(showActual)
+    @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
+    inline given derivedNegDoubleEq[F[*]: CatsEq, G[*]: CatsEq](using eqActual: G[Double]): F[NegDouble] = {
+      internalDef.contraCoercible(eqActual.asInstanceOf[cats.Eq[Double]])
+    }.asInstanceOf[F[NegDouble]] // scalafix:ok DisableSyntax.asInstanceOf
+
+    @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
+    inline given derivedNegDoubleShow[F[*]: CatsShow, G[*]: CatsShow](using showActual: G[Double]): F[NegDouble] = {
+      internalDef.contraCoercible(showActual.asInstanceOf[cats.Show[Double]])
+    }.asInstanceOf[F[NegDouble]] // scalafix:ok DisableSyntax.asInstanceOf
 
   }
 
@@ -439,9 +583,15 @@ object numeric {
 
     override inline def predicate(a: Double): Boolean = a >= 0d
 
-    inline given derivedNonNegDoubleEq(using eqActual: cats.Eq[Double]): cats.Eq[NonNegDouble] = internalDef.contraCoercible(eqActual)
-    inline given derivedNonNegDoubleShow(using showActual: cats.Show[Double]): cats.Show[NonNegDouble] =
-      internalDef.contraCoercible(showActual)
+    @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
+    inline given derivedNonNegDoubleEq[F[*]: CatsEq, G[*]: CatsEq](using eqActual: G[Double]): F[NonNegDouble] = {
+      internalDef.contraCoercible(eqActual.asInstanceOf[cats.Eq[Double]])
+    }.asInstanceOf[F[NonNegDouble]] // scalafix:ok DisableSyntax.asInstanceOf
+
+    @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
+    inline given derivedNonNegDoubleShow[F[*]: CatsShow, G[*]: CatsShow](using showActual: G[Double]): F[NonNegDouble] = {
+      internalDef.contraCoercible(showActual.asInstanceOf[cats.Show[Double]])
+    }.asInstanceOf[F[NonNegDouble]] // scalafix:ok DisableSyntax.asInstanceOf
 
   }
 
@@ -454,8 +604,15 @@ object numeric {
 
     override inline def predicate(a: Double): Boolean = a > 0d
 
-    inline given derivedPosDoubleEq(using eqActual: cats.Eq[Double]): cats.Eq[PosDouble]         = internalDef.contraCoercible(eqActual)
-    inline given derivedPosDoubleShow(using showActual: cats.Show[Double]): cats.Show[PosDouble] = internalDef.contraCoercible(showActual)
+    @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
+    inline given derivedPosDoubleEq[F[*]: CatsEq, G[*]: CatsEq](using eqActual: G[Double]): F[PosDouble] = {
+      internalDef.contraCoercible(eqActual.asInstanceOf[cats.Eq[Double]])
+    }.asInstanceOf[F[PosDouble]] // scalafix:ok DisableSyntax.asInstanceOf
+
+    @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
+    inline given derivedPosDoubleShow[F[*]: CatsShow, G[*]: CatsShow](using showActual: G[Double]): F[PosDouble] = {
+      internalDef.contraCoercible(showActual.asInstanceOf[cats.Show[Double]])
+    }.asInstanceOf[F[PosDouble]] // scalafix:ok DisableSyntax.asInstanceOf
 
   }
 
@@ -468,9 +625,15 @@ object numeric {
 
     override inline def predicate(a: Double): Boolean = a <= 0d
 
-    inline given derivedNonPosDoubleEq(using eqActual: cats.Eq[Double]): cats.Eq[NonPosDouble] = internalDef.contraCoercible(eqActual)
-    inline given derivedNonPosDoubleShow(using showActual: cats.Show[Double]): cats.Show[NonPosDouble] =
-      internalDef.contraCoercible(showActual)
+    @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
+    inline given derivedNonPosDoubleEq[F[*]: CatsEq, G[*]: CatsEq](using eqActual: G[Double]): F[NonPosDouble] = {
+      internalDef.contraCoercible(eqActual.asInstanceOf[cats.Eq[Double]])
+    }.asInstanceOf[F[NonPosDouble]] // scalafix:ok DisableSyntax.asInstanceOf
+
+    @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
+    inline given derivedNonPosDoubleShow[F[*]: CatsShow, G[*]: CatsShow](using showActual: G[Double]): F[NonPosDouble] = {
+      internalDef.contraCoercible(showActual.asInstanceOf[cats.Show[Double]])
+    }.asInstanceOf[F[NonPosDouble]] // scalafix:ok DisableSyntax.asInstanceOf
 
   }
 
@@ -497,8 +660,15 @@ object numeric {
 
     inline def apply(inline a: String): Type = apply(BigInt(a))
 
-    inline given derivedNegBigIntEq(using eqActual: cats.Eq[BigInt]): cats.Eq[NegBigInt]         = internalDef.contraCoercible(eqActual)
-    inline given derivedNegBigIntShow(using showActual: cats.Show[BigInt]): cats.Show[NegBigInt] = internalDef.contraCoercible(showActual)
+    @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
+    inline given derivedNegBigIntEq[F[*]: CatsEq, G[*]: CatsEq](using eqActual: G[BigInt]): F[NegBigInt] = {
+      internalDef.contraCoercible(eqActual.asInstanceOf[cats.Eq[BigInt]])
+    }.asInstanceOf[F[NegBigInt]] // scalafix:ok DisableSyntax.asInstanceOf
+
+    @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
+    inline given derivedNegBigIntShow[F[*]: CatsShow, G[*]: CatsShow](using showActual: G[BigInt]): F[NegBigInt] = {
+      internalDef.contraCoercible(showActual.asInstanceOf[cats.Show[BigInt]])
+    }.asInstanceOf[F[NegBigInt]] // scalafix:ok DisableSyntax.asInstanceOf
 
   }
 
@@ -519,9 +689,15 @@ object numeric {
 
     inline def apply(inline a: String): Type = apply(BigInt(a))
 
-    inline given derivedNonNegBigIntEq(using eqActual: cats.Eq[BigInt]): cats.Eq[NonNegBigInt] = internalDef.contraCoercible(eqActual)
-    inline given derivedNonNegBigIntShow(using showActual: cats.Show[BigInt]): cats.Show[NonNegBigInt] =
-      internalDef.contraCoercible(showActual)
+    @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
+    inline given derivedNonNegBigIntEq[F[*]: CatsEq, G[*]: CatsEq](using eqActual: G[BigInt]): F[NonNegBigInt] = {
+      internalDef.contraCoercible(eqActual.asInstanceOf[cats.Eq[BigInt]])
+    }.asInstanceOf[F[NonNegBigInt]] // scalafix:ok DisableSyntax.asInstanceOf
+
+    @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
+    inline given derivedNonNegBigIntShow[F[*]: CatsShow, G[*]: CatsShow](using showActual: G[BigInt]): F[NonNegBigInt] = {
+      internalDef.contraCoercible(showActual.asInstanceOf[cats.Show[BigInt]])
+    }.asInstanceOf[F[NonNegBigInt]] // scalafix:ok DisableSyntax.asInstanceOf
 
   }
 
@@ -542,8 +718,15 @@ object numeric {
 
     inline def apply(inline a: String): Type = apply(BigInt(a))
 
-    inline given derivedPosBigIntEq(using eqActual: cats.Eq[BigInt]): cats.Eq[PosBigInt]         = internalDef.contraCoercible(eqActual)
-    inline given derivedPosBigIntShow(using showActual: cats.Show[BigInt]): cats.Show[PosBigInt] = internalDef.contraCoercible(showActual)
+    @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
+    inline given derivedPosBigIntEq[F[*]: CatsEq, G[*]: CatsEq](using eqActual: G[BigInt]): F[PosBigInt] = {
+      internalDef.contraCoercible(eqActual.asInstanceOf[cats.Eq[BigInt]])
+    }.asInstanceOf[F[PosBigInt]] // scalafix:ok DisableSyntax.asInstanceOf
+
+    @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
+    inline given derivedPosBigIntShow[F[*]: CatsShow, G[*]: CatsShow](using showActual: G[BigInt]): F[PosBigInt] = {
+      internalDef.contraCoercible(showActual.asInstanceOf[cats.Show[BigInt]])
+    }.asInstanceOf[F[PosBigInt]] // scalafix:ok DisableSyntax.asInstanceOf
 
   }
 
@@ -564,9 +747,15 @@ object numeric {
 
     inline def apply(inline a: String): Type = apply(BigInt(a))
 
-    inline given derivedNonPosBigIntEq(using eqActual: cats.Eq[BigInt]): cats.Eq[NonPosBigInt] = internalDef.contraCoercible(eqActual)
-    inline given derivedNonPosBigIntShow(using showActual: cats.Show[BigInt]): cats.Show[NonPosBigInt] =
-      internalDef.contraCoercible(showActual)
+    @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
+    inline given derivedNonPosBigIntEq[F[*]: CatsEq, G[*]: CatsEq](using eqActual: G[BigInt]): F[NonPosBigInt] = {
+      internalDef.contraCoercible(eqActual.asInstanceOf[cats.Eq[BigInt]])
+    }.asInstanceOf[F[NonPosBigInt]] // scalafix:ok DisableSyntax.asInstanceOf
+
+    @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
+    inline given derivedNonPosBigIntShow[F[*]: CatsShow, G[*]: CatsShow](using showActual: G[BigInt]): F[NonPosBigInt] = {
+      internalDef.contraCoercible(showActual.asInstanceOf[cats.Show[BigInt]])
+    }.asInstanceOf[F[NonPosBigInt]] // scalafix:ok DisableSyntax.asInstanceOf
 
   }
 
@@ -591,9 +780,15 @@ object numeric {
 
     inline def apply(inline a: String): Type = apply(BigDecimal(a))
 
-    inline given derivedNegBigDecimalEq(using eqActual: cats.Eq[BigDecimal]): cats.Eq[NegBigDecimal] = internalDef.contraCoercible(eqActual)
-    inline given derivedNegBigDecimalShow(using showActual: cats.Show[BigDecimal]): cats.Show[NegBigDecimal] =
-      internalDef.contraCoercible(showActual)
+    @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
+    inline given derivedNegBigDecimalEq[F[*]: CatsEq, G[*]: CatsEq](using eqActual: G[BigDecimal]): F[NegBigDecimal] = {
+      internalDef.contraCoercible(eqActual.asInstanceOf[cats.Eq[BigDecimal]])
+    }.asInstanceOf[F[NegBigDecimal]] // scalafix:ok DisableSyntax.asInstanceOf
+
+    @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
+    inline given derivedNegBigDecimalShow[F[*]: CatsShow, G[*]: CatsShow](using showActual: G[BigDecimal]): F[NegBigDecimal] = {
+      internalDef.contraCoercible(showActual.asInstanceOf[cats.Show[BigDecimal]])
+    }.asInstanceOf[F[NegBigDecimal]] // scalafix:ok DisableSyntax.asInstanceOf
 
   }
 
@@ -618,10 +813,15 @@ object numeric {
 
     inline def apply(inline a: String): Type = apply(BigDecimal(a))
 
-    inline given derivedNonNegBigDecimalEq(using eqActual: cats.Eq[BigDecimal]): cats.Eq[NonNegBigDecimal]         =
-      internalDef.contraCoercible(eqActual)
-    inline given derivedNonNegBigDecimalShow(using showActual: cats.Show[BigDecimal]): cats.Show[NonNegBigDecimal] =
-      internalDef.contraCoercible(showActual)
+    @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
+    inline given derivedNonNegBigDecimalEq[F[*]: CatsEq, G[*]: CatsEq](using eqActual: G[BigDecimal]): F[NonNegBigDecimal] = {
+      internalDef.contraCoercible(eqActual.asInstanceOf[cats.Eq[BigDecimal]])
+    }.asInstanceOf[F[NonNegBigDecimal]] // scalafix:ok DisableSyntax.asInstanceOf
+
+    @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
+    inline given derivedNonNegBigDecimalShow[F[*]: CatsShow, G[*]: CatsShow](using showActual: G[BigDecimal]): F[NonNegBigDecimal] = {
+      internalDef.contraCoercible(showActual.asInstanceOf[cats.Show[BigDecimal]])
+    }.asInstanceOf[F[NonNegBigDecimal]] // scalafix:ok DisableSyntax.asInstanceOf
 
   }
 
@@ -646,9 +846,15 @@ object numeric {
 
     inline def apply(inline a: String): Type = apply(BigDecimal(a))
 
-    inline given derivedPosBigDecimalEq(using eqActual: cats.Eq[BigDecimal]): cats.Eq[PosBigDecimal] = internalDef.contraCoercible(eqActual)
-    inline given derivedPosBigDecimalShow(using showActual: cats.Show[BigDecimal]): cats.Show[PosBigDecimal] =
-      internalDef.contraCoercible(showActual)
+    @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
+    inline given derivedPosBigDecimalEq[F[*]: CatsEq, G[*]: CatsEq](using eqActual: G[BigDecimal]): F[PosBigDecimal] = {
+      internalDef.contraCoercible(eqActual.asInstanceOf[cats.Eq[BigDecimal]])
+    }.asInstanceOf[F[PosBigDecimal]] // scalafix:ok DisableSyntax.asInstanceOf
+
+    @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
+    inline given derivedPosBigDecimalShow[F[*]: CatsShow, G[*]: CatsShow](using showActual: G[BigDecimal]): F[PosBigDecimal] = {
+      internalDef.contraCoercible(showActual.asInstanceOf[cats.Show[BigDecimal]])
+    }.asInstanceOf[F[PosBigDecimal]] // scalafix:ok DisableSyntax.asInstanceOf
 
   }
 
@@ -673,10 +879,15 @@ object numeric {
 
     inline def apply(inline a: String): Type = apply(BigDecimal(a))
 
-    inline given derivedNonPosBigDecimalEq(using eqActual: cats.Eq[BigDecimal]): cats.Eq[NonPosBigDecimal]         =
-      internalDef.contraCoercible(eqActual)
-    inline given derivedNonPosBigDecimalShow(using showActual: cats.Show[BigDecimal]): cats.Show[NonPosBigDecimal] =
-      internalDef.contraCoercible(showActual)
+    @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
+    inline given derivedNonPosBigDecimalEq[F[*]: CatsEq, G[*]: CatsEq](using eqActual: G[BigDecimal]): F[NonPosBigDecimal] = {
+      internalDef.contraCoercible(eqActual.asInstanceOf[cats.Eq[BigDecimal]])
+    }.asInstanceOf[F[NonPosBigDecimal]] // scalafix:ok DisableSyntax.asInstanceOf
+
+    @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
+    inline given derivedNonPosBigDecimalShow[F[*]: CatsShow, G[*]: CatsShow](using showActual: G[BigDecimal]): F[NonPosBigDecimal] = {
+      internalDef.contraCoercible(showActual.asInstanceOf[cats.Show[BigDecimal]])
+    }.asInstanceOf[F[NonPosBigDecimal]] // scalafix:ok DisableSyntax.asInstanceOf
 
   }
 

--- a/modules/test-refined4s-core-without-cats/shared/src/test/scala/refined4s/types/numericSpec.scala
+++ b/modules/test-refined4s-core-without-cats/shared/src/test/scala/refined4s/types/numericSpec.scala
@@ -1,0 +1,1333 @@
+package refined4s.types
+
+import hedgehog.*
+import hedgehog.runner.*
+import refined4s.ExpectedErrorMessages
+
+/** @author Kevin Lee
+  * @since 2025-08-24
+  */
+object numericSpec extends Properties {
+  override def tests: List[Test] =
+    negIntSpec.tests ++ nonNegIntSpec.tests ++ posIntSpec.tests ++ nonPosIntSpec.tests ++
+      negLongSpec.tests ++ nonNegLongSpec.tests ++ posLongSpec.tests ++ nonPosLongSpec.tests ++
+      negShortSpec.tests ++ nonNegShortSpec.tests ++ posShortSpec.tests ++ nonPosShortSpec.tests ++
+      negByteSpec.tests ++ nonNegByteSpec.tests ++ posByteSpec.tests ++ nonPosByteSpec.tests ++
+      negFloatSpec.tests ++ nonNegFloatSpec.tests ++ posFloatSpec.tests ++ nonPosFloatSpec.tests ++
+      negDoubleSpec.tests ++ nonNegDoubleSpec.tests ++ posDoubleSpec.tests ++ nonPosDoubleSpec.tests ++
+      negBigIntSpec.tests ++ nonNegBigIntSpec.tests ++ posBigIntSpec.tests ++ nonPosBigIntSpec.tests ++
+      negBigDecimalSpec.tests ++ nonNegBigDecimalSpec.tests ++ posBigDecimalSpec.tests ++ nonPosBigDecimalSpec.tests
+
+  object negIntSpec {
+    def tests: List[Test] = List(
+      example("test Eq[NegInt]", testEq),
+      example("test Show[NegInt]", testShow),
+    )
+
+    def testEq: Result = {
+      import scala.compiletime.testing.typeCheckErrors
+      val expected = ExpectedErrorMessages.missingEq
+
+      val actual = typeCheckErrors(
+        """
+         val _ = refined4s.types.numeric.NegInt.derivedNegIntEq
+      """
+      ).map(_.message).mkString
+
+      (actual ==== expected)
+        .log(
+          """The actual error message doesn't start with the expected one.
+            |""".stripMargin
+        )
+    }
+
+    def testShow: Result = {
+      import scala.compiletime.testing.typeCheckErrors
+      val expected = ExpectedErrorMessages.missingShow
+
+      val actual = typeCheckErrors(
+        """
+         val _ = refined4s.types.numeric.NegInt.derivedNegIntShow
+      """
+      ).map(_.message).mkString
+
+      (actual ==== expected)
+        .log(
+          """The actual error message doesn't start with the expected one.
+            |""".stripMargin
+        )
+    }
+  }
+
+  object nonNegIntSpec {
+    def tests: List[Test] = List(
+      example("test Eq[NonNegInt]", testEq),
+      example("test Show[NonNegInt]", testShow),
+    )
+
+    def testEq: Result = {
+      import scala.compiletime.testing.typeCheckErrors
+      val expected = ExpectedErrorMessages.missingEq
+
+      val actual = typeCheckErrors(
+        """
+         val _ = refined4s.types.numeric.NonNegInt.derivedNonNegIntEq
+      """
+      ).map(_.message).mkString
+
+      (actual ==== expected)
+        .log(
+          """The actual error message doesn't start with the expected one.
+            |""".stripMargin
+        )
+    }
+
+    def testShow: Result = {
+      import scala.compiletime.testing.typeCheckErrors
+      val expected = ExpectedErrorMessages.missingShow
+
+      val actual = typeCheckErrors(
+        """
+         val _ = refined4s.types.numeric.NonNegInt.derivedNonNegIntShow
+      """
+      ).map(_.message).mkString
+
+      (actual ==== expected)
+        .log(
+          """The actual error message doesn't start with the expected one.
+            |""".stripMargin
+        )
+    }
+  }
+
+  object posIntSpec {
+    def tests: List[Test] = List(
+      example("test Eq[PosInt]", testEq),
+      example("test Show[PosInt]", testShow),
+    )
+
+    def testEq: Result = {
+      import scala.compiletime.testing.typeCheckErrors
+      val expected = ExpectedErrorMessages.missingEq
+
+      val actual = typeCheckErrors(
+        """
+         val _ = refined4s.types.numeric.PosInt.derivedPosIntEq
+      """
+      ).map(_.message).mkString
+
+      (actual ==== expected)
+        .log(
+          """The actual error message doesn't start with the expected one.
+            |""".stripMargin
+        )
+    }
+
+    def testShow: Result = {
+      import scala.compiletime.testing.typeCheckErrors
+      val expected = ExpectedErrorMessages.missingShow
+
+      val actual = typeCheckErrors(
+        """
+         val _ = refined4s.types.numeric.PosInt.derivedPosIntShow
+      """
+      ).map(_.message).mkString
+
+      (actual ==== expected)
+        .log(
+          """The actual error message doesn't start with the expected one.
+            |""".stripMargin
+        )
+    }
+  }
+
+  object nonPosIntSpec {
+    def tests: List[Test] = List(
+      example("test Eq[NonPosInt]", testEq),
+      example("test Show[NonPosInt]", testShow),
+    )
+
+    def testEq: Result = {
+      import scala.compiletime.testing.typeCheckErrors
+      val expected = ExpectedErrorMessages.missingEq
+
+      val actual = typeCheckErrors(
+        """
+         val _ = refined4s.types.numeric.NonPosInt.derivedNonPosIntEq
+      """
+      ).map(_.message).mkString
+
+      (actual ==== expected)
+        .log(
+          """The actual error message doesn't start with the expected one.
+            |""".stripMargin
+        )
+    }
+
+    def testShow: Result = {
+      import scala.compiletime.testing.typeCheckErrors
+      val expected = ExpectedErrorMessages.missingShow
+
+      val actual = typeCheckErrors(
+        """
+         val _ = refined4s.types.numeric.NonPosInt.derivedNonPosIntShow
+      """
+      ).map(_.message).mkString
+
+      (actual ==== expected)
+        .log(
+          """The actual error message doesn't start with the expected one.
+            |""".stripMargin
+        )
+    }
+  }
+
+  object negLongSpec {
+    def tests: List[Test] = List(
+      example("test Eq[NegLong]", testEq),
+      example("test Show[NegLong]", testShow),
+    )
+
+    def testEq: Result = {
+      import scala.compiletime.testing.typeCheckErrors
+      val expected = ExpectedErrorMessages.missingEq
+
+      val actual = typeCheckErrors(
+        """
+         val _ = refined4s.types.numeric.NegLong.derivedNegLongEq
+      """
+      ).map(_.message).mkString
+
+      (actual ==== expected)
+        .log(
+          """The actual error message doesn't start with the expected one.
+            |""".stripMargin
+        )
+    }
+
+    def testShow: Result = {
+      import scala.compiletime.testing.typeCheckErrors
+      val expected = ExpectedErrorMessages.missingShow
+
+      val actual = typeCheckErrors(
+        """
+         val _ = refined4s.types.numeric.NegLong.derivedNegLongShow
+      """
+      ).map(_.message).mkString
+
+      (actual ==== expected)
+        .log(
+          """The actual error message doesn't start with the expected one.
+            |""".stripMargin
+        )
+    }
+  }
+
+  object nonNegLongSpec {
+    def tests: List[Test] = List(
+      example("test Eq[NonNegLong]", testEq),
+      example("test Show[NonNegLong]", testShow),
+    )
+
+    def testEq: Result = {
+      import scala.compiletime.testing.typeCheckErrors
+      val expected = ExpectedErrorMessages.missingEq
+
+      val actual = typeCheckErrors(
+        """
+         val _ = refined4s.types.numeric.NonNegLong.derivedNonNegLongEq
+      """
+      ).map(_.message).mkString
+
+      (actual ==== expected)
+        .log(
+          """The actual error message doesn't start with the expected one.
+            |""".stripMargin
+        )
+    }
+
+    def testShow: Result = {
+      import scala.compiletime.testing.typeCheckErrors
+      val expected = ExpectedErrorMessages.missingShow
+
+      val actual = typeCheckErrors(
+        """
+         val _ = refined4s.types.numeric.NonNegLong.derivedNonNegLongShow
+      """
+      ).map(_.message).mkString
+
+      (actual ==== expected)
+        .log(
+          """The actual error message doesn't start with the expected one.
+            |""".stripMargin
+        )
+    }
+  }
+
+  object posLongSpec {
+    def tests: List[Test] = List(
+      example("test Eq[PosLong]", testEq),
+      example("test Show[PosLong]", testShow),
+    )
+
+    def testEq: Result = {
+      import scala.compiletime.testing.typeCheckErrors
+      val expected = ExpectedErrorMessages.missingEq
+
+      val actual = typeCheckErrors(
+        """
+         val _ = refined4s.types.numeric.PosLong.derivedPosLongEq
+      """
+      ).map(_.message).mkString
+
+      (actual ==== expected)
+        .log(
+          """The actual error message doesn't start with the expected one.
+            |""".stripMargin
+        )
+    }
+
+    def testShow: Result = {
+      import scala.compiletime.testing.typeCheckErrors
+      val expected = ExpectedErrorMessages.missingShow
+
+      val actual = typeCheckErrors(
+        """
+         val _ = refined4s.types.numeric.PosLong.derivedPosLongShow
+      """
+      ).map(_.message).mkString
+
+      (actual ==== expected)
+        .log(
+          """The actual error message doesn't start with the expected one.
+            |""".stripMargin
+        )
+    }
+  }
+
+  object nonPosLongSpec {
+    def tests: List[Test] = List(
+      example("test Eq[NonPosLong]", testEq),
+      example("test Show[NonPosLong]", testShow),
+    )
+
+    def testEq: Result = {
+      import scala.compiletime.testing.typeCheckErrors
+      val expected = ExpectedErrorMessages.missingEq
+
+      val actual = typeCheckErrors(
+        """
+         val _ = refined4s.types.numeric.NonPosLong.derivedNonPosLongEq
+      """
+      ).map(_.message).mkString
+
+      (actual ==== expected)
+        .log(
+          """The actual error message doesn't start with the expected one.
+            |""".stripMargin
+        )
+    }
+
+    def testShow: Result = {
+      import scala.compiletime.testing.typeCheckErrors
+      val expected = ExpectedErrorMessages.missingShow
+
+      val actual = typeCheckErrors(
+        """
+         val _ = refined4s.types.numeric.NonPosLong.derivedNonPosLongShow
+      """
+      ).map(_.message).mkString
+
+      (actual ==== expected)
+        .log(
+          """The actual error message doesn't start with the expected one.
+            |""".stripMargin
+        )
+    }
+  }
+
+  object negShortSpec {
+    def tests: List[Test] = List(
+      example("test Eq[NegShort]", testEq),
+      example("test Show[NegShort]", testShow),
+    )
+
+    def testEq: Result = {
+      import scala.compiletime.testing.typeCheckErrors
+      val expected = ExpectedErrorMessages.missingEq
+
+      val actual = typeCheckErrors(
+        """
+         val _ = refined4s.types.numeric.NegShort.derivedNegShortEq
+      """
+      ).map(_.message).mkString
+
+      (actual ==== expected)
+        .log(
+          """The actual error message doesn't start with the expected one.
+            |""".stripMargin
+        )
+    }
+
+    def testShow: Result = {
+      import scala.compiletime.testing.typeCheckErrors
+      val expected = ExpectedErrorMessages.missingShow
+
+      val actual = typeCheckErrors(
+        """
+         val _ = refined4s.types.numeric.NegShort.derivedNegShortShow
+      """
+      ).map(_.message).mkString
+
+      (actual ==== expected)
+        .log(
+          """The actual error message doesn't start with the expected one.
+            |""".stripMargin
+        )
+    }
+  }
+
+  object nonNegShortSpec {
+    def tests: List[Test] = List(
+      example("test Eq[NonNegShort]", testEq),
+      example("test Show[NonNegShort]", testShow),
+    )
+
+    def testEq: Result = {
+      import scala.compiletime.testing.typeCheckErrors
+      val expected = ExpectedErrorMessages.missingEq
+
+      val actual = typeCheckErrors(
+        """
+         val _ = refined4s.types.numeric.NonNegShort.derivedNonNegShortEq
+      """
+      ).map(_.message).mkString
+
+      (actual ==== expected)
+        .log(
+          """The actual error message doesn't start with the expected one.
+            |""".stripMargin
+        )
+    }
+
+    def testShow: Result = {
+      import scala.compiletime.testing.typeCheckErrors
+      val expected = ExpectedErrorMessages.missingShow
+
+      val actual = typeCheckErrors(
+        """
+         val _ = refined4s.types.numeric.NonNegShort.derivedNonNegShortShow
+      """
+      ).map(_.message).mkString
+
+      (actual ==== expected)
+        .log(
+          """The actual error message doesn't start with the expected one.
+            |""".stripMargin
+        )
+    }
+  }
+
+  object posShortSpec {
+    def tests: List[Test] = List(
+      example("test Eq[PosShort]", testEq),
+      example("test Show[PosShort]", testShow),
+    )
+
+    def testEq: Result = {
+      import scala.compiletime.testing.typeCheckErrors
+      val expected = ExpectedErrorMessages.missingEq
+
+      val actual = typeCheckErrors(
+        """
+         val _ = refined4s.types.numeric.PosShort.derivedPosShortEq
+      """
+      ).map(_.message).mkString
+
+      (actual ==== expected)
+        .log(
+          """The actual error message doesn't start with the expected one.
+            |""".stripMargin
+        )
+    }
+
+    def testShow: Result = {
+      import scala.compiletime.testing.typeCheckErrors
+      val expected = ExpectedErrorMessages.missingShow
+
+      val actual = typeCheckErrors(
+        """
+         val _ = refined4s.types.numeric.PosShort.derivedPosShortShow
+      """
+      ).map(_.message).mkString
+
+      (actual ==== expected)
+        .log(
+          """The actual error message doesn't start with the expected one.
+            |""".stripMargin
+        )
+    }
+  }
+
+  object nonPosShortSpec {
+    def tests: List[Test] = List(
+      example("test Eq[NonPosShort]", testEq),
+      example("test Show[NonPosShort]", testShow),
+    )
+
+    def testEq: Result = {
+      import scala.compiletime.testing.typeCheckErrors
+      val expected = ExpectedErrorMessages.missingEq
+
+      val actual = typeCheckErrors(
+        """
+         val _ = refined4s.types.numeric.NonPosShort.derivedNonPosShortEq
+      """
+      ).map(_.message).mkString
+
+      (actual ==== expected)
+        .log(
+          """The actual error message doesn't start with the expected one.
+            |""".stripMargin
+        )
+    }
+
+    def testShow: Result = {
+      import scala.compiletime.testing.typeCheckErrors
+      val expected = ExpectedErrorMessages.missingShow
+
+      val actual = typeCheckErrors(
+        """
+         val _ = refined4s.types.numeric.NonPosShort.derivedNonPosShortShow
+      """
+      ).map(_.message).mkString
+
+      (actual ==== expected)
+        .log(
+          """The actual error message doesn't start with the expected one.
+            |""".stripMargin
+        )
+    }
+  }
+
+  object negByteSpec {
+    def tests: List[Test] = List(
+      example("test Eq[NegByte]", testEq),
+      example("test Show[NegByte]", testShow),
+    )
+
+    def testEq: Result = {
+      import scala.compiletime.testing.typeCheckErrors
+      val expected = ExpectedErrorMessages.missingEq
+
+      val actual = typeCheckErrors(
+        """
+         val _ = refined4s.types.numeric.NegByte.derivedNegByteEq
+      """
+      ).map(_.message).mkString
+
+      (actual ==== expected)
+        .log(
+          """The actual error message doesn't start with the expected one.
+            |""".stripMargin
+        )
+    }
+
+    def testShow: Result = {
+      import scala.compiletime.testing.typeCheckErrors
+      val expected = ExpectedErrorMessages.missingShow
+
+      val actual = typeCheckErrors(
+        """
+         val _ = refined4s.types.numeric.NegByte.derivedNegByteShow
+      """
+      ).map(_.message).mkString
+
+      (actual ==== expected)
+        .log(
+          """The actual error message doesn't start with the expected one.
+            |""".stripMargin
+        )
+    }
+  }
+
+  object nonNegByteSpec {
+    def tests: List[Test] = List(
+      example("test Eq[NonNegByte]", testEq),
+      example("test Show[NonNegByte]", testShow),
+    )
+
+    def testEq: Result = {
+      import scala.compiletime.testing.typeCheckErrors
+      val expected = ExpectedErrorMessages.missingEq
+
+      val actual = typeCheckErrors(
+        """
+         val _ = refined4s.types.numeric.NonNegByte.derivedNonNegByteEq
+      """
+      ).map(_.message).mkString
+
+      (actual ==== expected)
+        .log(
+          """The actual error message doesn't start with the expected one.
+            |""".stripMargin
+        )
+    }
+
+    def testShow: Result = {
+      import scala.compiletime.testing.typeCheckErrors
+      val expected = ExpectedErrorMessages.missingShow
+
+      val actual = typeCheckErrors(
+        """
+         val _ = refined4s.types.numeric.NonNegByte.derivedNonNegByteShow
+      """
+      ).map(_.message).mkString
+
+      (actual ==== expected)
+        .log(
+          """The actual error message doesn't start with the expected one.
+            |""".stripMargin
+        )
+    }
+  }
+
+  object posByteSpec {
+    def tests: List[Test] = List(
+      example("test Eq[PosByte]", testEq),
+      example("test Show[PosByte]", testShow),
+    )
+
+    def testEq: Result = {
+      import scala.compiletime.testing.typeCheckErrors
+      val expected = ExpectedErrorMessages.missingEq
+
+      val actual = typeCheckErrors(
+        """
+         val _ = refined4s.types.numeric.PosByte.derivedPosByteEq
+      """
+      ).map(_.message).mkString
+
+      (actual ==== expected)
+        .log(
+          """The actual error message doesn't start with the expected one.
+            |""".stripMargin
+        )
+    }
+
+    def testShow: Result = {
+      import scala.compiletime.testing.typeCheckErrors
+      val expected = ExpectedErrorMessages.missingShow
+
+      val actual = typeCheckErrors(
+        """
+         val _ = refined4s.types.numeric.PosByte.derivedPosByteShow
+      """
+      ).map(_.message).mkString
+
+      (actual ==== expected)
+        .log(
+          """The actual error message doesn't start with the expected one.
+            |""".stripMargin
+        )
+    }
+  }
+
+  object nonPosByteSpec {
+    def tests: List[Test] = List(
+      example("test Eq[NonPosByte]", testEq),
+      example("test Show[NonPosByte]", testShow),
+    )
+
+    def testEq: Result = {
+      import scala.compiletime.testing.typeCheckErrors
+      val expected = ExpectedErrorMessages.missingEq
+
+      val actual = typeCheckErrors(
+        """
+         val _ = refined4s.types.numeric.NonPosByte.derivedNonPosByteEq
+      """
+      ).map(_.message).mkString
+
+      (actual ==== expected)
+        .log(
+          """The actual error message doesn't start with the expected one.
+            |""".stripMargin
+        )
+    }
+
+    def testShow: Result = {
+      import scala.compiletime.testing.typeCheckErrors
+      val expected = ExpectedErrorMessages.missingShow
+
+      val actual = typeCheckErrors(
+        """
+         val _ = refined4s.types.numeric.NonPosByte.derivedNonPosByteShow
+      """
+      ).map(_.message).mkString
+
+      (actual ==== expected)
+        .log(
+          """The actual error message doesn't start with the expected one.
+            |""".stripMargin
+        )
+    }
+  }
+
+  object negFloatSpec {
+    def tests: List[Test] = List(
+      example("test Eq[NegFloat]", testEq),
+      example("test Show[NegFloat]", testShow),
+    )
+
+    def testEq: Result = {
+      import scala.compiletime.testing.typeCheckErrors
+      val expected = ExpectedErrorMessages.missingEq
+
+      val actual = typeCheckErrors(
+        """
+         val _ = refined4s.types.numeric.NegFloat.derivedNegFloatEq
+      """
+      ).map(_.message).mkString
+
+      (actual ==== expected)
+        .log(
+          """The actual error message doesn't start with the expected one.
+            |""".stripMargin
+        )
+    }
+
+    def testShow: Result = {
+      import scala.compiletime.testing.typeCheckErrors
+      val expected = ExpectedErrorMessages.missingShow
+
+      val actual = typeCheckErrors(
+        """
+         val _ = refined4s.types.numeric.NegFloat.derivedNegFloatShow
+      """
+      ).map(_.message).mkString
+
+      (actual ==== expected)
+        .log(
+          """The actual error message doesn't start with the expected one.
+            |""".stripMargin
+        )
+    }
+  }
+
+  object nonNegFloatSpec {
+    def tests: List[Test] = List(
+      example("test Eq[NonNegFloat]", testEq),
+      example("test Show[NonNegFloat]", testShow),
+    )
+
+    def testEq: Result = {
+      import scala.compiletime.testing.typeCheckErrors
+      val expected = ExpectedErrorMessages.missingEq
+
+      val actual = typeCheckErrors(
+        """
+         val _ = refined4s.types.numeric.NonNegFloat.derivedNonNegFloatEq
+      """
+      ).map(_.message).mkString
+
+      (actual ==== expected)
+        .log(
+          """The actual error message doesn't start with the expected one.
+            |""".stripMargin
+        )
+    }
+
+    def testShow: Result = {
+      import scala.compiletime.testing.typeCheckErrors
+      val expected = ExpectedErrorMessages.missingShow
+
+      val actual = typeCheckErrors(
+        """
+         val _ = refined4s.types.numeric.NonNegFloat.derivedNonNegFloatShow
+      """
+      ).map(_.message).mkString
+
+      (actual ==== expected)
+        .log(
+          """The actual error message doesn't start with the expected one.
+            |""".stripMargin
+        )
+    }
+  }
+
+  object posFloatSpec {
+    def tests: List[Test] = List(
+      example("test Eq[PosFloat]", testEq),
+      example("test Show[PosFloat]", testShow),
+    )
+
+    def testEq: Result = {
+      import scala.compiletime.testing.typeCheckErrors
+      val expected = ExpectedErrorMessages.missingEq
+
+      val actual = typeCheckErrors(
+        """
+         val _ = refined4s.types.numeric.PosFloat.derivedPosFloatEq
+      """
+      ).map(_.message).mkString
+
+      (actual ==== expected)
+        .log(
+          """The actual error message doesn't start with the expected one.
+            |""".stripMargin
+        )
+    }
+
+    def testShow: Result = {
+      import scala.compiletime.testing.typeCheckErrors
+      val expected = ExpectedErrorMessages.missingShow
+
+      val actual = typeCheckErrors(
+        """
+         val _ = refined4s.types.numeric.PosFloat.derivedPosFloatShow
+      """
+      ).map(_.message).mkString
+
+      (actual ==== expected)
+        .log(
+          """The actual error message doesn't start with the expected one.
+            |""".stripMargin
+        )
+    }
+  }
+
+  object nonPosFloatSpec {
+    def tests: List[Test] = List(
+      example("test Eq[NonPosFloat]", testEq),
+      example("test Show[NonPosFloat]", testShow),
+    )
+
+    def testEq: Result = {
+      import scala.compiletime.testing.typeCheckErrors
+      val expected = ExpectedErrorMessages.missingEq
+
+      val actual = typeCheckErrors(
+        """
+         val _ = refined4s.types.numeric.NonPosFloat.derivedNonPosFloatEq
+      """
+      ).map(_.message).mkString
+
+      (actual ==== expected)
+        .log(
+          """The actual error message doesn't start with the expected one.
+            |""".stripMargin
+        )
+    }
+
+    def testShow: Result = {
+      import scala.compiletime.testing.typeCheckErrors
+      val expected = ExpectedErrorMessages.missingShow
+
+      val actual = typeCheckErrors(
+        """
+         val _ = refined4s.types.numeric.NonPosFloat.derivedNonPosFloatShow
+      """
+      ).map(_.message).mkString
+
+      (actual ==== expected)
+        .log(
+          """The actual error message doesn't start with the expected one.
+            |""".stripMargin
+        )
+    }
+  }
+
+  object negDoubleSpec {
+    def tests: List[Test] = List(
+      example("test Eq[NegDouble]", testEq),
+      example("test Show[NegDouble]", testShow),
+    )
+
+    def testEq: Result = {
+      import scala.compiletime.testing.typeCheckErrors
+      val expected = ExpectedErrorMessages.missingEq
+
+      val actual = typeCheckErrors(
+        """
+         val _ = refined4s.types.numeric.NegDouble.derivedNegDoubleEq
+      """
+      ).map(_.message).mkString
+
+      (actual ==== expected)
+        .log(
+          """The actual error message doesn't start with the expected one.
+            |""".stripMargin
+        )
+    }
+
+    def testShow: Result = {
+      import scala.compiletime.testing.typeCheckErrors
+      val expected = ExpectedErrorMessages.missingShow
+
+      val actual = typeCheckErrors(
+        """
+         val _ = refined4s.types.numeric.NegDouble.derivedNegDoubleShow
+      """
+      ).map(_.message).mkString
+
+      (actual ==== expected)
+        .log(
+          """The actual error message doesn't start with the expected one.
+            |""".stripMargin
+        )
+    }
+  }
+
+  object nonNegDoubleSpec {
+    def tests: List[Test] = List(
+      example("test Eq[NonNegDouble]", testEq),
+      example("test Show[NonNegDouble]", testShow),
+    )
+
+    def testEq: Result = {
+      import scala.compiletime.testing.typeCheckErrors
+      val expected = ExpectedErrorMessages.missingEq
+
+      val actual = typeCheckErrors(
+        """
+         val _ = refined4s.types.numeric.NonNegDouble.derivedNonNegDoubleEq
+      """
+      ).map(_.message).mkString
+
+      (actual ==== expected)
+        .log(
+          """The actual error message doesn't start with the expected one.
+            |""".stripMargin
+        )
+    }
+
+    def testShow: Result = {
+      import scala.compiletime.testing.typeCheckErrors
+      val expected = ExpectedErrorMessages.missingShow
+
+      val actual = typeCheckErrors(
+        """
+         val _ = refined4s.types.numeric.NonNegDouble.derivedNonNegDoubleShow
+      """
+      ).map(_.message).mkString
+
+      (actual ==== expected)
+        .log(
+          """The actual error message doesn't start with the expected one.
+            |""".stripMargin
+        )
+    }
+  }
+
+  object posDoubleSpec {
+    def tests: List[Test] = List(
+      example("test Eq[PosDouble]", testEq),
+      example("test Show[PosDouble]", testShow),
+    )
+
+    def testEq: Result = {
+      import scala.compiletime.testing.typeCheckErrors
+      val expected = ExpectedErrorMessages.missingEq
+
+      val actual = typeCheckErrors(
+        """
+         val _ = refined4s.types.numeric.PosDouble.derivedPosDoubleEq
+      """
+      ).map(_.message).mkString
+
+      (actual ==== expected)
+        .log(
+          """The actual error message doesn't start with the expected one.
+            |""".stripMargin
+        )
+    }
+
+    def testShow: Result = {
+      import scala.compiletime.testing.typeCheckErrors
+      val expected = ExpectedErrorMessages.missingShow
+
+      val actual = typeCheckErrors(
+        """
+         val _ = refined4s.types.numeric.PosDouble.derivedPosDoubleShow
+      """
+      ).map(_.message).mkString
+
+      (actual ==== expected)
+        .log(
+          """The actual error message doesn't start with the expected one.
+            |""".stripMargin
+        )
+    }
+  }
+
+  object nonPosDoubleSpec {
+    def tests: List[Test] = List(
+      example("test Eq[NonPosDouble]", testEq),
+      example("test Show[NonPosDouble]", testShow),
+    )
+
+    def testEq: Result = {
+      import scala.compiletime.testing.typeCheckErrors
+      val expected = ExpectedErrorMessages.missingEq
+
+      val actual = typeCheckErrors(
+        """
+         val _ = refined4s.types.numeric.NonPosDouble.derivedNonPosDoubleEq
+      """
+      ).map(_.message).mkString
+
+      (actual ==== expected)
+        .log(
+          """The actual error message doesn't start with the expected one.
+            |""".stripMargin
+        )
+    }
+
+    def testShow: Result = {
+      import scala.compiletime.testing.typeCheckErrors
+      val expected = ExpectedErrorMessages.missingShow
+
+      val actual = typeCheckErrors(
+        """
+         val _ = refined4s.types.numeric.NonPosDouble.derivedNonPosDoubleShow
+      """
+      ).map(_.message).mkString
+
+      (actual ==== expected)
+        .log(
+          """The actual error message doesn't start with the expected one.
+            |""".stripMargin
+        )
+    }
+  }
+
+  object negBigIntSpec {
+    def tests: List[Test] = List(
+      example("test Eq[NegBigInt]", testEq),
+      example("test Show[NegBigInt]", testShow),
+    )
+
+    def testEq: Result = {
+      import scala.compiletime.testing.typeCheckErrors
+      val expected = ExpectedErrorMessages.missingEq
+
+      val actual = typeCheckErrors(
+        """
+         val _ = refined4s.types.numeric.NegBigInt.derivedNegBigIntEq
+      """
+      ).map(_.message).mkString
+
+      (actual ==== expected)
+        .log(
+          """The actual error message doesn't start with the expected one.
+            |""".stripMargin
+        )
+    }
+
+    def testShow: Result = {
+      import scala.compiletime.testing.typeCheckErrors
+      val expected = ExpectedErrorMessages.missingShow
+
+      val actual = typeCheckErrors(
+        """
+         val _ = refined4s.types.numeric.NegBigInt.derivedNegBigIntShow
+      """
+      ).map(_.message).mkString
+
+      (actual ==== expected)
+        .log(
+          """The actual error message doesn't start with the expected one.
+            |""".stripMargin
+        )
+    }
+  }
+
+  object nonNegBigIntSpec {
+    def tests: List[Test] = List(
+      example("test Eq[NonNegBigInt]", testEq),
+      example("test Show[NonNegBigInt]", testShow),
+    )
+
+    def testEq: Result = {
+      import scala.compiletime.testing.typeCheckErrors
+      val expected = ExpectedErrorMessages.missingEq
+
+      val actual = typeCheckErrors(
+        """
+         val _ = refined4s.types.numeric.NonNegBigInt.derivedNonNegBigIntEq
+      """
+      ).map(_.message).mkString
+
+      (actual ==== expected)
+        .log(
+          """The actual error message doesn't start with the expected one.
+            |""".stripMargin
+        )
+    }
+
+    def testShow: Result = {
+      import scala.compiletime.testing.typeCheckErrors
+      val expected = ExpectedErrorMessages.missingShow
+
+      val actual = typeCheckErrors(
+        """
+         val _ = refined4s.types.numeric.NonNegBigInt.derivedNonNegBigIntShow
+      """
+      ).map(_.message).mkString
+
+      (actual ==== expected)
+        .log(
+          """The actual error message doesn't start with the expected one.
+            |""".stripMargin
+        )
+    }
+  }
+
+  object posBigIntSpec {
+    def tests: List[Test] = List(
+      example("test Eq[PosBigInt]", testEq),
+      example("test Show[PosBigInt]", testShow),
+    )
+
+    def testEq: Result = {
+      import scala.compiletime.testing.typeCheckErrors
+      val expected = ExpectedErrorMessages.missingEq
+
+      val actual = typeCheckErrors(
+        """
+         val _ = refined4s.types.numeric.PosBigInt.derivedPosBigIntEq
+      """
+      ).map(_.message).mkString
+
+      (actual ==== expected)
+        .log(
+          """The actual error message doesn't start with the expected one.
+            |""".stripMargin
+        )
+    }
+
+    def testShow: Result = {
+      import scala.compiletime.testing.typeCheckErrors
+      val expected = ExpectedErrorMessages.missingShow
+
+      val actual = typeCheckErrors(
+        """
+         val _ = refined4s.types.numeric.PosBigInt.derivedPosBigIntShow
+      """
+      ).map(_.message).mkString
+
+      (actual ==== expected)
+        .log(
+          """The actual error message doesn't start with the expected one.
+            |""".stripMargin
+        )
+    }
+  }
+
+  object nonPosBigIntSpec {
+    def tests: List[Test] = List(
+      example("test Eq[NonPosBigInt]", testEq),
+      example("test Show[NonPosBigInt]", testShow),
+    )
+
+    def testEq: Result = {
+      import scala.compiletime.testing.typeCheckErrors
+      val expected = ExpectedErrorMessages.missingEq
+
+      val actual = typeCheckErrors(
+        """
+         val _ = refined4s.types.numeric.NonPosBigInt.derivedNonPosBigIntEq
+      """
+      ).map(_.message).mkString
+
+      (actual ==== expected)
+        .log(
+          """The actual error message doesn't start with the expected one.
+            |""".stripMargin
+        )
+    }
+
+    def testShow: Result = {
+      import scala.compiletime.testing.typeCheckErrors
+      val expected = ExpectedErrorMessages.missingShow
+
+      val actual = typeCheckErrors(
+        """
+         val _ = refined4s.types.numeric.NonPosBigInt.derivedNonPosBigIntShow
+      """
+      ).map(_.message).mkString
+
+      (actual ==== expected)
+        .log(
+          """The actual error message doesn't start with the expected one.
+            |""".stripMargin
+        )
+    }
+  }
+
+  object negBigDecimalSpec {
+    def tests: List[Test] = List(
+      example("test Eq[NegBigDecimal]", testEq),
+      example("test Show[NegBigDecimal]", testShow),
+    )
+
+    def testEq: Result = {
+      import scala.compiletime.testing.typeCheckErrors
+      val expected = ExpectedErrorMessages.missingEq
+
+      val actual = typeCheckErrors(
+        """
+         val _ = refined4s.types.numeric.NegBigDecimal.derivedNegBigDecimalEq
+      """
+      ).map(_.message).mkString
+
+      (actual ==== expected)
+        .log(
+          """The actual error message doesn't start with the expected one.
+            |""".stripMargin
+        )
+    }
+
+    def testShow: Result = {
+      import scala.compiletime.testing.typeCheckErrors
+      val expected = ExpectedErrorMessages.missingShow
+
+      val actual = typeCheckErrors(
+        """
+         val _ = refined4s.types.numeric.NegBigDecimal.derivedNegBigDecimalShow
+      """
+      ).map(_.message).mkString
+
+      (actual ==== expected)
+        .log(
+          """The actual error message doesn't start with the expected one.
+            |""".stripMargin
+        )
+    }
+  }
+
+  object nonNegBigDecimalSpec {
+    def tests: List[Test] = List(
+      example("test Eq[NonNegBigDecimal]", testEq),
+      example("test Show[NonNegBigDecimal]", testShow),
+    )
+
+    def testEq: Result = {
+      import scala.compiletime.testing.typeCheckErrors
+      val expected = ExpectedErrorMessages.missingEq
+
+      val actual = typeCheckErrors(
+        """
+         val _ = refined4s.types.numeric.NonNegBigDecimal.derivedNonNegBigDecimalEq
+      """
+      ).map(_.message).mkString
+
+      (actual ==== expected)
+        .log(
+          """The actual error message doesn't start with the expected one.
+            |""".stripMargin
+        )
+    }
+
+    def testShow: Result = {
+      import scala.compiletime.testing.typeCheckErrors
+      val expected = ExpectedErrorMessages.missingShow
+
+      val actual = typeCheckErrors(
+        """
+         val _ = refined4s.types.numeric.NonNegBigDecimal.derivedNonNegBigDecimalShow
+      """
+      ).map(_.message).mkString
+
+      (actual ==== expected)
+        .log(
+          """The actual error message doesn't start with the expected one.
+            |""".stripMargin
+        )
+    }
+  }
+
+  object posBigDecimalSpec {
+    def tests: List[Test] = List(
+      example("test Eq[PosBigDecimal]", testEq),
+      example("test Show[PosBigDecimal]", testShow),
+    )
+
+    def testEq: Result = {
+      import scala.compiletime.testing.typeCheckErrors
+      val expected = ExpectedErrorMessages.missingEq
+
+      val actual = typeCheckErrors(
+        """
+         val _ = refined4s.types.numeric.PosBigDecimal.derivedPosBigDecimalEq
+      """
+      ).map(_.message).mkString
+
+      (actual ==== expected)
+        .log(
+          """The actual error message doesn't start with the expected one.
+            |""".stripMargin
+        )
+    }
+
+    def testShow: Result = {
+      import scala.compiletime.testing.typeCheckErrors
+      val expected = ExpectedErrorMessages.missingShow
+
+      val actual = typeCheckErrors(
+        """
+         val _ = refined4s.types.numeric.PosBigDecimal.derivedPosBigDecimalShow
+      """
+      ).map(_.message).mkString
+
+      (actual ==== expected)
+        .log(
+          """The actual error message doesn't start with the expected one.
+            |""".stripMargin
+        )
+    }
+  }
+
+  object nonPosBigDecimalSpec {
+    def tests: List[Test] = List(
+      example("test Eq[NonPosBigDecimal]", testEq),
+      example("test Show[NonPosBigDecimal]", testShow),
+    )
+
+    def testEq: Result = {
+      import scala.compiletime.testing.typeCheckErrors
+      val expected = ExpectedErrorMessages.missingEq
+
+      val actual = typeCheckErrors(
+        """
+         val _ = refined4s.types.numeric.NonPosBigDecimal.derivedNonPosBigDecimalEq
+      """
+      ).map(_.message).mkString
+
+      (actual ==== expected)
+        .log(
+          """The actual error message doesn't start with the expected one.
+            |""".stripMargin
+        )
+    }
+
+    def testShow: Result = {
+      import scala.compiletime.testing.typeCheckErrors
+      val expected = ExpectedErrorMessages.missingShow
+
+      val actual = typeCheckErrors(
+        """
+         val _ = refined4s.types.numeric.NonPosBigDecimal.derivedNonPosBigDecimalShow
+      """
+      ).map(_.message).mkString
+
+      (actual ==== expected)
+        .log(
+          """The actual error message doesn't start with the expected one.
+            |""".stripMargin
+        )
+    }
+  }
+
+}


### PR DESCRIPTION
## Close #465: Move `Eq` and `Show` type class instances for `refined4s.types.numeric` types from `refined4s-cats` to `refined4s-core` with `orphan-cats`

- Move `Eq` and `Show` type class instances for `refined4s.types.numeric` types from `refined4s-cats` to `refined4s-core` then
- Generalize derived instances for refined `numeric` types from concrete `cats.Eq`/`cats.Show` given instances to polymorphic givens constrained by `CatsEq`/`CatsShow`, decoupling the `core` API surface from `cats` while keeping derivation possible if `cats` is available on the classpath (i.e., added via sbt `libraryDependencies`).