### PR TITLE
Close #473: [`test-refined4s-core-without-cats`] Rename tests for `cats` type class instances of `refined4s.types.all` without `cats`

### DIFF
--- a/modules/test-refined4s-core-without-cats/shared/src/test/scala/refined4s/types/networkWithoutCatsSpec.scala
+++ b/modules/test-refined4s-core-without-cats/shared/src/test/scala/refined4s/types/networkWithoutCatsSpec.scala
@@ -7,7 +7,7 @@ import refined4s.ExpectedErrorMessages
 /** @author Kevin Lee
   * @since 2025-08-24
   */
-object networkSpec extends Properties {
+object networkWithoutCatsSpec extends Properties {
   override def tests: List[Test] =
     uriSpec.tests ++ urlSpec.tests ++ portNumberSpec.tests ++ systemPortNumberSpec.tests ++ nonSystemPortNumberSpec.tests ++ userPortNumberSpec.tests
 

--- a/modules/test-refined4s-core-without-cats/shared/src/test/scala/refined4s/types/numericWithoutCatsSpec.scala
+++ b/modules/test-refined4s-core-without-cats/shared/src/test/scala/refined4s/types/numericWithoutCatsSpec.scala
@@ -7,7 +7,7 @@ import refined4s.ExpectedErrorMessages
 /** @author Kevin Lee
   * @since 2025-08-24
   */
-object numericSpec extends Properties {
+object numericWithoutCatsSpec extends Properties {
   override def tests: List[Test] =
     negIntSpec.tests ++ nonNegIntSpec.tests ++ posIntSpec.tests ++ nonPosIntSpec.tests ++
       negLongSpec.tests ++ nonNegLongSpec.tests ++ posLongSpec.tests ++ nonPosLongSpec.tests ++

--- a/modules/test-refined4s-core-without-cats/shared/src/test/scala/refined4s/types/stringsWithoutCatsSpec.scala
+++ b/modules/test-refined4s-core-without-cats/shared/src/test/scala/refined4s/types/stringsWithoutCatsSpec.scala
@@ -7,7 +7,7 @@ import refined4s.*
 /** @author Kevin Lee
   * @since 2023-04-25
   */
-object stringsSpec extends Properties {
+object stringsWithoutCatsSpec extends Properties {
   override def tests: List[Test] = NonEmptyStringSpec.tests ++ NonBlankStringSpec.tests ++ UuidSpec.tests
 
   object NonEmptyStringSpec {


### PR DESCRIPTION
Close #473: [`test-refined4s-core-without-cats`] Rename tests for `cats` type class instances of `refined4s.types.all` without `cats`