### PR TITLE
Close #476: Move `Eq` and `Show` type class instances for `refined4s.types.time` types from `refined4s-cats` to `refined4s-core` with `orphan-cats`

### DIFF
--- a/modules/refined4s-cats/shared/src/test/scala/refined4s/modules/cats/derivation/types/allSpec.scala
+++ b/modules/refined4s-cats/shared/src/test/scala/refined4s/modules/cats/derivation/types/allSpec.scala
@@ -6,6 +6,7 @@ import hedgehog.runner.*
 import refined4s.types.numeric.*
 import refined4s.types.network.*
 import refined4s.types.strings.*
+import refined4s.types.time.*
 import refined4s.types.networkGens
 
 import java.util.UUID
@@ -143,7 +144,7 @@ object allSpec extends Properties {
     //
     property("test Eq[DynamicPortNumber]", testEqDynamicPortNumber),
     property("test Show[DynamicPortNumber]", testShowDynamicPortNumber),
-  )
+  ) ++ timeSpec.tests
 
   def testEqNegInt: Property =
     for {
@@ -1233,4 +1234,249 @@ object allSpec extends Properties {
       actual ==== expected
     }
 
+  object timeSpec {
+    def tests: List[Test] =
+      monthSpec.tests ++ daySpec.tests ++ hourSpec.tests ++ minuteSpec.tests ++ secondSpec.tests ++ millisSpec.tests
+
+    object monthSpec {
+      def tests: List[Test] = List(
+        property("test Eq[Month]", testEq),
+        property("test Show[Month]", testShow),
+      )
+
+      def testEq: Property =
+        for {
+          month1 <- Gen.int(Range.linear(1, 12)).log("month1")
+          month2 <- Gen
+                      .int(Range.linear(1, 12))
+                      .map {
+                        case `month1` => if month1 === 12 then month1 - 1 else month1 + 1
+                        case n => n
+                      }
+                      .log("month2")
+        } yield {
+          val input1 = Month.unsafeFrom(month1)
+          val input2 = Month.unsafeFrom(month2)
+          Result.all(
+            List(
+              Result.diffNamed("Comparing the same objects with ===", input1, input1)(_ === _),
+              Result.diffNamed("Comparing the different objects with =!=", input2, input2)(_ === _),
+            )
+          )
+        }
+
+      def testShow: Property =
+        for {
+          month <- Gen.int(Range.linear(1, 12)).log("month")
+        } yield {
+          val input = Month.unsafeFrom(month)
+
+          val expected = month.toString
+          val actual   = input.show
+
+          actual ==== expected
+        }
+    }
+
+    object daySpec {
+      def tests: List[Test] = List(
+        property("test Eq[Day]", testEq),
+        property("test Show[Day]", testShow),
+      )
+
+      def testEq: Property =
+        for {
+          day1 <- Gen.int(Range.linear(1, 31)).log("day1")
+          day2 <- Gen
+                    .int(Range.linear(1, 31))
+                    .map {
+                      case `day1` => if day1 === 31 then day1 - 1 else day1 + 1
+                      case n => n
+                    }
+                    .log("day2")
+        } yield {
+          val input1 = Day.unsafeFrom(day1)
+          val input2 = Day.unsafeFrom(day2)
+          Result.all(
+            List(
+              Result.diffNamed("Comparing the same objects with ===", input1, input1)(_ === _),
+              Result.diffNamed("Comparing the different objects with =!=", input2, input2)(_ === _),
+            )
+          )
+        }
+
+      def testShow: Property =
+        for {
+          day <- Gen.int(Range.linear(1, 31)).log("day")
+        } yield {
+          val input = Day.unsafeFrom(day)
+
+          val expected = day.toString
+          val actual   = input.show
+
+          actual ==== expected
+        }
+    }
+
+    object hourSpec {
+      def tests: List[Test] = List(
+        property("test Eq[Hour]", testEq),
+        property("test Show[Hour]", testShow),
+      )
+
+      def testEq: Property =
+        for {
+          hour1 <- Gen.int(Range.linear(0, 23)).log("hour1")
+          hour2 <- Gen
+                     .int(Range.linear(0, 23))
+                     .map {
+                       case `hour1` => if hour1 === 23 then hour1 - 1 else hour1 + 1
+                       case n => n
+                     }
+                     .log("hour2")
+        } yield {
+          val input1 = Hour.unsafeFrom(hour1)
+          val input2 = Hour.unsafeFrom(hour2)
+          Result.all(
+            List(
+              Result.diffNamed("Comparing the same objects with ===", input1, input1)(_ === _),
+              Result.diffNamed("Comparing the different objects with =!=", input2, input2)(_ === _),
+            )
+          )
+        }
+
+      def testShow: Property =
+        for {
+          hour <- Gen.int(Range.linear(0, 23)).log("hour")
+        } yield {
+          val input = Hour.unsafeFrom(hour)
+
+          val expected = hour.toString
+          val actual   = input.show
+
+          actual ==== expected
+        }
+    }
+
+    object minuteSpec {
+      def tests: List[Test] = List(
+        property("test Eq[Minute]", testEq),
+        property("test Show[Minute]", testShow),
+      )
+
+      def testEq: Property =
+        for {
+          minute1 <- Gen.int(Range.linear(0, 59)).log("minute1")
+          minute2 <- Gen
+                       .int(Range.linear(0, 59))
+                       .map {
+                         case `minute1` => if minute1 === 59 then minute1 - 1 else minute1 + 1
+                         case n => n
+                       }
+                       .log("minute2")
+        } yield {
+          val input1 = Minute.unsafeFrom(minute1)
+          val input2 = Minute.unsafeFrom(minute2)
+          Result.all(
+            List(
+              Result.diffNamed("Comparing the same objects with ===", input1, input1)(_ === _),
+              Result.diffNamed("Comparing the different objects with =!=", input2, input2)(_ === _),
+            )
+          )
+        }
+
+      def testShow: Property =
+        for {
+          minute <- Gen.int(Range.linear(0, 59)).log("minute")
+        } yield {
+          val input = Minute.unsafeFrom(minute)
+
+          val expected = minute.toString
+          val actual   = input.show
+
+          actual ==== expected
+        }
+    }
+
+    object secondSpec {
+      def tests: List[Test] = List(
+        property("test Eq[Second]", testEq),
+        property("test Show[Second]", testShow),
+      )
+
+      def testEq: Property =
+        for {
+          second1 <- Gen.int(Range.linear(0, 59)).log("second1")
+          second2 <- Gen
+                       .int(Range.linear(0, 59))
+                       .map {
+                         case `second1` => if second1 === 59 then second1 - 1 else second1 + 1
+                         case n => n
+                       }
+                       .log("second2")
+        } yield {
+          val input1 = Second.unsafeFrom(second1)
+          val input2 = Second.unsafeFrom(second2)
+          Result.all(
+            List(
+              Result.diffNamed("Comparing the same objects with ===", input1, input1)(_ === _),
+              Result.diffNamed("Comparing the different objects with =!=", input2, input2)(_ === _),
+            )
+          )
+        }
+
+      def testShow: Property =
+        for {
+          second <- Gen.int(Range.linear(0, 59)).log("second")
+        } yield {
+          val input = Second.unsafeFrom(second)
+
+          val expected = second.toString
+          val actual   = input.show
+
+          actual ==== expected
+        }
+    }
+
+    object millisSpec {
+      def tests: List[Test] = List(
+        property("test Eq[Millis]", testEq),
+        property("test Show[Millis]", testShow),
+      )
+
+      def testEq: Property =
+        for {
+          millis1 <- Gen.int(Range.linear(0, 999)).log("millis1")
+          millis2 <- Gen
+                       .int(Range.linear(0, 999))
+                       .map {
+                         case `millis1` => if millis1 === 59 then millis1 - 1 else millis1 + 1
+                         case n => n
+                       }
+                       .log("millis2")
+        } yield {
+          val input1 = Millis.unsafeFrom(millis1)
+          val input2 = Millis.unsafeFrom(millis2)
+          Result.all(
+            List(
+              Result.diffNamed("Comparing the same objects with ===", input1, input1)(_ === _),
+              Result.diffNamed("Comparing the different objects with =!=", input2, input2)(_ === _),
+            )
+          )
+        }
+
+      def testShow: Property =
+        for {
+          millis <- Gen.int(Range.linear(0, 999)).log("millis")
+        } yield {
+          val input = Millis.unsafeFrom(millis)
+
+          val expected = millis.toString
+          val actual   = input.show
+
+          actual ==== expected
+        }
+    }
+
+  }
 }

--- a/modules/refined4s-core/shared/src/main/scala/refined4s/types/time.scala
+++ b/modules/refined4s-core/shared/src/main/scala/refined4s/types/time.scala
@@ -1,5 +1,6 @@
 package refined4s.types
 
+import orphan.{OrphanCats, OrphanCatsKernel}
 import refined4s.types
 import refined4s.types.numeric.{InlinedNumeric, MinMax}
 
@@ -26,7 +27,7 @@ trait time {
   final val Millis = time.Millis // scalafix:ok DisableSyntax.noFinalVal
 
 }
-object time {
+object time extends OrphanCats, OrphanCatsKernel {
   type Month = Month.Type
   object Month extends InlinedNumeric[Int], MinMax[Int] {
 
@@ -41,6 +42,17 @@ object time {
     override def invalidReason(a: Int): String = expectedMessage(inlinedExpectedValue)
 
     override def predicate(a: Int): Boolean = a >= 1 && a <= 12
+
+    @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
+    inline given derivedMonthEq[F[*]: CatsEq, G[*]: CatsEq](using eqActual: G[Int]): F[Month] = {
+      internalDef.contraCoercible(eqActual.asInstanceOf[cats.Eq[Int]])
+    }.asInstanceOf[F[Month]] // scalafix:ok DisableSyntax.asInstanceOf
+
+    @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
+    inline given derivedMonthShow[F[*]: CatsShow, G[*]: CatsShow](using showActual: G[Int]): F[Month] = {
+      internalDef.contraCoercible(showActual.asInstanceOf[cats.Show[Int]])
+    }.asInstanceOf[F[Month]] // scalafix:ok DisableSyntax.asInstanceOf
+
   }
 
   type Day = Day.Type
@@ -57,6 +69,17 @@ object time {
     override def invalidReason(a: Int): String = expectedMessage(inlinedExpectedValue)
 
     override def predicate(a: Int): Boolean = a >= 1 && a <= 31
+
+    @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
+    inline given derivedDayEq[F[*]: CatsEq, G[*]: CatsEq](using eqActual: G[Int]): F[Day] = {
+      internalDef.contraCoercible(eqActual.asInstanceOf[cats.Eq[Int]])
+    }.asInstanceOf[F[Day]] // scalafix:ok DisableSyntax.asInstanceOf
+
+    @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
+    inline given derivedDayShow[F[*]: CatsShow, G[*]: CatsShow](using showActual: G[Int]): F[Day] = {
+      internalDef.contraCoercible(showActual.asInstanceOf[cats.Show[Int]])
+    }.asInstanceOf[F[Day]] // scalafix:ok DisableSyntax.asInstanceOf
+
   }
 
   type Hour = Hour.Type
@@ -73,6 +96,17 @@ object time {
     override def invalidReason(a: Int): String = expectedMessage(inlinedExpectedValue)
 
     override def predicate(a: Int): Boolean = a >= 0 && a <= 23
+
+    @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
+    inline given derivedHourEq[F[*]: CatsEq, G[*]: CatsEq](using eqActual: G[Int]): F[Hour] = {
+      internalDef.contraCoercible(eqActual.asInstanceOf[cats.Eq[Int]])
+    }.asInstanceOf[F[Hour]] // scalafix:ok DisableSyntax.asInstanceOf
+
+    @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
+    inline given derivedHourShow[F[*]: CatsShow, G[*]: CatsShow](using showActual: G[Int]): F[Hour] = {
+      internalDef.contraCoercible(showActual.asInstanceOf[cats.Show[Int]])
+    }.asInstanceOf[F[Hour]] // scalafix:ok DisableSyntax.asInstanceOf
+
   }
 
   type Minute = Minute.Type
@@ -89,6 +123,17 @@ object time {
     override def invalidReason(a: Int): String = expectedMessage(inlinedExpectedValue)
 
     override def predicate(a: Int): Boolean = a >= 0 && a <= 59
+
+    @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
+    inline given derivedMinuteEq[F[*]: CatsEq, G[*]: CatsEq](using eqActual: G[Int]): F[Minute] = {
+      internalDef.contraCoercible(eqActual.asInstanceOf[cats.Eq[Int]])
+    }.asInstanceOf[F[Minute]] // scalafix:ok DisableSyntax.asInstanceOf
+
+    @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
+    inline given derivedMinuteShow[F[*]: CatsShow, G[*]: CatsShow](using showActual: G[Int]): F[Minute] = {
+      internalDef.contraCoercible(showActual.asInstanceOf[cats.Show[Int]])
+    }.asInstanceOf[F[Minute]] // scalafix:ok DisableSyntax.asInstanceOf
+
   }
 
   type Second = Second.Type
@@ -105,6 +150,17 @@ object time {
     override def invalidReason(a: Int): String = expectedMessage(inlinedExpectedValue)
 
     override def predicate(a: Int): Boolean = a >= 0 && a <= 59
+
+    @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
+    inline given derivedSecondEq[F[*]: CatsEq, G[*]: CatsEq](using eqActual: G[Int]): F[Second] = {
+      internalDef.contraCoercible(eqActual.asInstanceOf[cats.Eq[Int]])
+    }.asInstanceOf[F[Second]] // scalafix:ok DisableSyntax.asInstanceOf
+
+    @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
+    inline given derivedSecondShow[F[*]: CatsShow, G[*]: CatsShow](using showActual: G[Int]): F[Second] = {
+      internalDef.contraCoercible(showActual.asInstanceOf[cats.Show[Int]])
+    }.asInstanceOf[F[Second]] // scalafix:ok DisableSyntax.asInstanceOf
+
   }
 
   type Millis = Millis.Type
@@ -121,6 +177,17 @@ object time {
     override def invalidReason(a: Int): String = expectedMessage(inlinedExpectedValue)
 
     override def predicate(a: Int): Boolean = a >= 0 && a <= 999
+
+    @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
+    inline given derivedMillisEq[F[*]: CatsEq, G[*]: CatsEq](using eqActual: G[Int]): F[Millis] = {
+      internalDef.contraCoercible(eqActual.asInstanceOf[cats.Eq[Int]])
+    }.asInstanceOf[F[Millis]] // scalafix:ok DisableSyntax.asInstanceOf
+
+    @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
+    inline given derivedMillisShow[F[*]: CatsShow, G[*]: CatsShow](using showActual: G[Int]): F[Millis] = {
+      internalDef.contraCoercible(showActual.asInstanceOf[cats.Show[Int]])
+    }.asInstanceOf[F[Millis]] // scalafix:ok DisableSyntax.asInstanceOf
+
   }
 
 }

--- a/modules/test-refined4s-core-without-cats/shared/src/test/scala/refined4s/types/allSpec.scala
+++ b/modules/test-refined4s-core-without-cats/shared/src/test/scala/refined4s/types/allSpec.scala
@@ -7,5 +7,5 @@ import hedgehog.runner.*
   * @since 2025-08-26
   */
 object allSpec extends Properties {
-  override def tests: List[Test] = networkSpec.tests ++ stringsSpec.tests ++ numericSpec.tests
+  override def tests: List[Test] = networkSpec.tests ++ stringsSpec.tests ++ numericSpec.tests ++ timeSpec.tests
 }

--- a/modules/test-refined4s-core-without-cats/shared/src/test/scala/refined4s/types/timeWithoutCatsSpec.scala
+++ b/modules/test-refined4s-core-without-cats/shared/src/test/scala/refined4s/types/timeWithoutCatsSpec.scala
@@ -1,0 +1,260 @@
+package refined4s.types
+
+import hedgehog.*
+import hedgehog.runner.*
+import refined4s.ExpectedErrorMessages
+
+/** @author Kevin Lee
+  * @since 2025-08-24
+  */
+object timeWithoutCatsSpec extends Properties {
+  override def tests: List[Test] =
+    monthSpec.tests ++ daySpec.tests ++ hourSpec.tests ++ minuteSpec.tests ++ secondSpec.tests ++ millisSpec.tests
+
+  object monthSpec {
+    def tests: List[Test] = List(
+      example("test Eq[Month]", testEq),
+      example("test Show[Month]", testShow),
+    )
+
+    def testEq: Result = {
+      import scala.compiletime.testing.typeCheckErrors
+      val expected = ExpectedErrorMessages.missingEq
+
+      val actual = typeCheckErrors(
+        """
+         val _ = refined4s.types.time.Month.derivedMonthEq
+      """
+      ).map(_.message).mkString
+
+      (actual ==== expected)
+        .log(
+          """The actual error message doesn't start with the expected one.
+            |""".stripMargin
+        )
+    }
+
+    def testShow: Result = {
+      import scala.compiletime.testing.typeCheckErrors
+      val expected = ExpectedErrorMessages.missingShow
+
+      val actual = typeCheckErrors(
+        """
+         val _ = refined4s.types.time.Month.derivedMonthShow
+      """
+      ).map(_.message).mkString
+
+      (actual ==== expected)
+        .log(
+          """The actual error message doesn't start with the expected one.
+            |""".stripMargin
+        )
+    }
+  }
+
+  object daySpec {
+    def tests: List[Test] = List(
+      example("test Eq[Day]", testEq),
+      example("test Show[Day]", testShow),
+    )
+
+    def testEq: Result = {
+      import scala.compiletime.testing.typeCheckErrors
+      val expected = ExpectedErrorMessages.missingEq
+
+      val actual = typeCheckErrors(
+        """
+         val _ = refined4s.types.time.Day.derivedDayEq
+      """
+      ).map(_.message).mkString
+
+      (actual ==== expected)
+        .log(
+          """The actual error message doesn't start with the expected one.
+            |""".stripMargin
+        )
+    }
+
+    def testShow: Result = {
+      import scala.compiletime.testing.typeCheckErrors
+      val expected = ExpectedErrorMessages.missingShow
+
+      val actual = typeCheckErrors(
+        """
+         val _ = refined4s.types.time.Day.derivedDayShow
+      """
+      ).map(_.message).mkString
+
+      (actual ==== expected)
+        .log(
+          """The actual error message doesn't start with the expected one.
+            |""".stripMargin
+        )
+    }
+  }
+
+  object hourSpec {
+    def tests: List[Test] = List(
+      example("test Eq[Hour]", testEq),
+      example("test Show[Hour]", testShow),
+    )
+
+    def testEq: Result = {
+      import scala.compiletime.testing.typeCheckErrors
+      val expected = ExpectedErrorMessages.missingEq
+
+      val actual = typeCheckErrors(
+        """
+         val _ = refined4s.types.time.Hour.derivedHourEq
+      """
+      ).map(_.message).mkString
+
+      (actual ==== expected)
+        .log(
+          """The actual error message doesn't start with the expected one.
+            |""".stripMargin
+        )
+    }
+
+    def testShow: Result = {
+      import scala.compiletime.testing.typeCheckErrors
+      val expected = ExpectedErrorMessages.missingShow
+
+      val actual = typeCheckErrors(
+        """
+         val _ = refined4s.types.time.Hour.derivedHourShow
+      """
+      ).map(_.message).mkString
+
+      (actual ==== expected)
+        .log(
+          """The actual error message doesn't start with the expected one.
+            |""".stripMargin
+        )
+    }
+  }
+
+  object minuteSpec {
+    def tests: List[Test] = List(
+      example("test Eq[Minute]", testEq),
+      example("test Show[Minute]", testShow),
+    )
+
+    def testEq: Result = {
+      import scala.compiletime.testing.typeCheckErrors
+      val expected = ExpectedErrorMessages.missingEq
+
+      val actual = typeCheckErrors(
+        """
+         val _ = refined4s.types.time.Minute.derivedMinuteEq
+      """
+      ).map(_.message).mkString
+
+      (actual ==== expected)
+        .log(
+          """The actual error message doesn't start with the expected one.
+            |""".stripMargin
+        )
+    }
+
+    def testShow: Result = {
+      import scala.compiletime.testing.typeCheckErrors
+      val expected = ExpectedErrorMessages.missingShow
+
+      val actual = typeCheckErrors(
+        """
+         val _ = refined4s.types.time.Minute.derivedMinuteShow
+      """
+      ).map(_.message).mkString
+
+      (actual ==== expected)
+        .log(
+          """The actual error message doesn't start with the expected one.
+            |""".stripMargin
+        )
+    }
+  }
+
+  object secondSpec {
+    def tests: List[Test] = List(
+      example("test Eq[Second]", testEq),
+      example("test Show[Second]", testShow),
+    )
+
+    def testEq: Result = {
+      import scala.compiletime.testing.typeCheckErrors
+      val expected = ExpectedErrorMessages.missingEq
+
+      val actual = typeCheckErrors(
+        """
+         val _ = refined4s.types.time.Second.derivedSecondEq
+      """
+      ).map(_.message).mkString
+
+      (actual ==== expected)
+        .log(
+          """The actual error message doesn't start with the expected one.
+            |""".stripMargin
+        )
+    }
+
+    def testShow: Result = {
+      import scala.compiletime.testing.typeCheckErrors
+      val expected = ExpectedErrorMessages.missingShow
+
+      val actual = typeCheckErrors(
+        """
+         val _ = refined4s.types.time.Second.derivedSecondShow
+      """
+      ).map(_.message).mkString
+
+      (actual ==== expected)
+        .log(
+          """The actual error message doesn't start with the expected one.
+            |""".stripMargin
+        )
+    }
+  }
+
+  object millisSpec {
+    def tests: List[Test] = List(
+      example("test Eq[Millis]", testEq),
+      example("test Show[Millis]", testShow),
+    )
+
+    def testEq: Result = {
+      import scala.compiletime.testing.typeCheckErrors
+      val expected = ExpectedErrorMessages.missingEq
+
+      val actual = typeCheckErrors(
+        """
+         val _ = refined4s.types.time.Millis.derivedMillisEq
+      """
+      ).map(_.message).mkString
+
+      (actual ==== expected)
+        .log(
+          """The actual error message doesn't start with the expected one.
+            |""".stripMargin
+        )
+    }
+
+    def testShow: Result = {
+      import scala.compiletime.testing.typeCheckErrors
+      val expected = ExpectedErrorMessages.missingShow
+
+      val actual = typeCheckErrors(
+        """
+         val _ = refined4s.types.time.Millis.derivedMillisShow
+      """
+      ).map(_.message).mkString
+
+      (actual ==== expected)
+        .log(
+          """The actual error message doesn't start with the expected one.
+            |""".stripMargin
+        )
+    }
+  }
+
+}


### PR DESCRIPTION
Close #476: Move `Eq` and `Show` type class instances for `refined4s.types.time` types from `refined4s-cats` to `refined4s-core` with `orphan-cats`