### PR TITLE
refined4s v1.8.0

### DIFF
--- a/changelogs/1.8.0.md
+++ b/changelogs/1.8.0.md
@@ -1,0 +1,54 @@
+## [1.8.0](https://github.com/kevin-lee/refined4s/issues?q=is%3Aissue%20is%3Aclosed%20-label%3Ainvalid%20-label%3Awontfix%20milestone%3Am28) - 2025-08-27
+
+### New Features
+
+#### No more `import refined4s.modules.cats.derivation.types.all.given`
+As of `refined4s` `1.8.0`, `refined4s.modules.cats.derivation.types.all.given` is no longer needed.
+As soon as your project add `cats` as its library dependency, the type class instances for `refined4s.types.all` will be automatically available.
+It is possible with the following changes:
+
+* Move `Eq` and `Show` type class instances for `refined4s.types.strings` types from `refined4s-cats` to `refined4s-core` with `orphan-cats` (#463)
+  - Add `internalDef.contraCoercible` (which uses `cats.Contravariant` and `refined4s.Coercible`) to derive type class instances without exposing `cats` in `core`.
+  - The following typeclass instances for strings are moved from `refined4s-cats` and rewritten with `orphan-cats`:
+    - `NonEmptyString`: `derivedNonEmptyStringEq`, `derivedNonEmptyStringShow`
+    - `NonBlankString`: `derivedNonBlankStringEq`, `derivedNonBlankStringShow`
+    - `Uuid`: `derivedUuidEq`, `derivedUuidShow`
+  - tests (`test-refined4s-core-without-cats`: JVM/JS/Native):
+    - `internalDefSpec` validates `MissingCatsContravariant` message for `contraCoercible`
+    - `stringsSpec` validates `MissingCatsEq` and `MissingCatsShow` messages for derived type class instances.
+  
+  No breaking changes. Compile-time tests cover absence-of-cats scenarios.
+
+
+* Move `Eq` and `Show` type class instances for `refined4s.types.network` types from `refined4s-cats` to `refined4s-core` with `orphan-cats` (#464)
+  - Remove `Eq`/`Show` instances for network types from `refined4s-cats all`
+  - Add `Eq`/`Show` instances using `orphan-cats` pattern to `refined4s-core` `network` types
+  - Add comprehensive test coverage for `network` type instances without cats dependency
+  - Supports `Uri`, `Url`, and all `PortNumber` variants (`System`, `NonSystem`, `User`, `Dynamic`)
+  
+  So `Eq` and `Show` type class instances for `network` types will be automatically available if the projects using `refined4s-core` have `cats` in its library dependencies.
+
+
+* Move `Eq` and `Show` type class instances for `refined4s.types.numeric` types from `refined4s-cats` to `refined4s-core` with `orphan-cats` (#465)
+  - Move `Eq` and `Show` type class instances for `refined4s.types.numeric` types from `refined4s-cats` to `refined4s-core` then
+  - Generalize derived instances for refined `numeric` types from concrete `cats.Eq`/`cats.Show` given instances to polymorphic givens constrained by `CatsEq`/`CatsShow`, decoupling the `core` API surface from `cats` while keeping derivation possible if `cats` is available on the classpath (i.e., added via sbt `libraryDependencies`).
+
+
+* Add `Eq` and `Show` type class instances for `refined4s.types.time` types to `refined4s-core` with `orphan-cats` (#476)
+***
+
+
+### Other Changes
+* [`refined4s-core`] Include `refined4s.types.time` in `refined4s.types.all` (#471)
+***
+
+
+### Internal Changes
+* [`test-refined4s-core-without-cats`] Run `core` tests for `refined4s.types.all` to ensure the `core` doesn't require `cats` (#472)
+***
+
+* [`test-refined4s-core-without-cats`] Rename tests for cats type class instances of `refined4s.types.all` without cats (#473)
+
+  * `networkSpec` => `networkWithoutCatsSpec`
+  * `numericSpec` => `numericWithoutCatsSpec`
+  * `stringsSpec` => `stringsWithoutCatsSpec`


### PR DESCRIPTION
# refined4s v1.8.0
## [1.8.0](https://github.com/kevin-lee/refined4s/issues?q=is%3Aissue%20is%3Aclosed%20-label%3Ainvalid%20-label%3Awontfix%20milestone%3Am28) - 2025-08-27

### New Features

#### No more `import refined4s.modules.cats.derivation.types.all.given`
As of `refined4s` `1.8.0`, `refined4s.modules.cats.derivation.types.all.given` is no longer needed.
As soon as your project add `cats` as its library dependency, the type class instances for `refined4s.types.all` will be automatically available.
It is possible with the following changes:

* Move `Eq` and `Show` type class instances for `refined4s.types.strings` types from `refined4s-cats` to `refined4s-core` with `orphan-cats` (#463)
  - Add `internalDef.contraCoercible` (which uses `cats.Contravariant` and `refined4s.Coercible`) to derive type class instances without exposing `cats` in `core`.
  - The following typeclass instances for strings are moved from `refined4s-cats` and rewritten with `orphan-cats`:
    - `NonEmptyString`: `derivedNonEmptyStringEq`, `derivedNonEmptyStringShow`
    - `NonBlankString`: `derivedNonBlankStringEq`, `derivedNonBlankStringShow`
    - `Uuid`: `derivedUuidEq`, `derivedUuidShow`
  - tests (`test-refined4s-core-without-cats`: JVM/JS/Native):
    - `internalDefSpec` validates `MissingCatsContravariant` message for `contraCoercible`
    - `stringsSpec` validates `MissingCatsEq` and `MissingCatsShow` messages for derived type class instances.
  
  No breaking changes. Compile-time tests cover absence-of-cats scenarios.


* Move `Eq` and `Show` type class instances for `refined4s.types.network` types from `refined4s-cats` to `refined4s-core` with `orphan-cats` (#464)
  - Remove `Eq`/`Show` instances for network types from `refined4s-cats all`
  - Add `Eq`/`Show` instances using `orphan-cats` pattern to `refined4s-core` `network` types
  - Add comprehensive test coverage for `network` type instances without cats dependency
  - Supports `Uri`, `Url`, and all `PortNumber` variants (`System`, `NonSystem`, `User`, `Dynamic`)
  
  So `Eq` and `Show` type class instances for `network` types will be automatically available if the projects using `refined4s-core` have `cats` in its library dependencies.


* Move `Eq` and `Show` type class instances for `refined4s.types.numeric` types from `refined4s-cats` to `refined4s-core` with `orphan-cats` (#465)
  - Move `Eq` and `Show` type class instances for `refined4s.types.numeric` types from `refined4s-cats` to `refined4s-core` then
  - Generalize derived instances for refined `numeric` types from concrete `cats.Eq`/`cats.Show` given instances to polymorphic givens constrained by `CatsEq`/`CatsShow`, decoupling the `core` API surface from `cats` while keeping derivation possible if `cats` is available on the classpath (i.e., added via sbt `libraryDependencies`).


* Add `Eq` and `Show` type class instances for `refined4s.types.time` types to `refined4s-core` with `orphan-cats` (#476)
***


### Other Changes
* [`refined4s-core`] Include `refined4s.types.time` in `refined4s.types.all` (#471)
***


### Internal Changes
* [`test-refined4s-core-without-cats`] Run `core` tests for `refined4s.types.all` to ensure the `core` doesn't require `cats` (#472)
***

* [`test-refined4s-core-without-cats`] Rename tests for cats type class instances of `refined4s.types.all` without cats (#473)

  * `networkSpec` => `networkWithoutCatsSpec`
  * `numericSpec` => `numericWithoutCatsSpec`
  * `stringsSpec` => `stringsWithoutCatsSpec`
