### PR TITLE
refined4s v1.8.1

### DIFF
--- a/changelogs/1.8.1.md
+++ b/changelogs/1.8.1.md
@@ -1,0 +1,57 @@
+## [1.8.1](https://github.com/kevin-lee/refined4s/issues?q=is%3Aissue%20is%3Aclosed%20-label%3Ainvalid%20-label%3Awontfix%20milestone%3Am29) - 2025-08-27
+
+### Bug Fix
+
+* Fix: `refined4s` modules require `test-refined4s-core-without-cats` module due to the incorrect config in `dependsOn` (#480)
+
+  ```
+  [warn] 	Note: Unresolved dependencies path:
+  [error] stack trace is suppressed; run last docs / update for the full output
+  [error] (docs / update) sbt.librarymanagement.ResolveException: Error downloading io.kevinlee:test-refined4s-core-without-cats_3:1.8.0
+  [error]   Not found
+  [error]   Not found
+  [error]   not found: /Users/username/.ivy2/local/io.kevinlee/test-refined4s-core-without-cats_3/1.8.0/ivys/ivy.xml
+  [error]   not found: https://repo1.maven.org/maven2/io/kevinlee/test-refined4s-core-without-cats_3/1.8.0/test-refined4s-core-without-cats_3-1.8.0.pom
+  [error] Total time: 4 s, completed 27 Aug. 2025, 2:05:39 pm
+  ```
+
+  * Cause:
+  
+    ```sbt
+    val IncludeTest = "compile->compile;test->test"
+    ```
+    was used with `testCoreWithoutCats` in `dependsOn`, and that's why.
+    
+    e.g.)
+    ```sbt
+    lazy val cats = module("cats", crossProject(JVMPlatform, JSPlatform, NativePlatform))
+      .settings(
+        libraryDependencies ++= List(
+          libs.cats.value,
+          libs.extrasCore.value % Test,
+        )
+      )
+      .dependsOn(
+        core                % props.IncludeTest,
+        testCoreWithoutCats % props.IncludeTest, // <=== BECAUSE OF THIS
+      )
+    ```
+  
+  * Solution
+  
+    Replace `"compile->compile;test->test"` with `"test->test"`.
+
+    e.g.)
+    ```sbt
+    lazy val cats = module("cats", crossProject(JVMPlatform, JSPlatform, NativePlatform))
+      .settings(
+        libraryDependencies ++= List(
+          libs.cats.value,
+          libs.extrasCore.value % Test,
+        )
+      )
+      .dependsOn(
+        core                % props.IncludeTest,
+        testCoreWithoutCats % "test->test",
+      )
+    ```


### PR DESCRIPTION
# refined4s v1.8.1
## [1.8.1](https://github.com/kevin-lee/refined4s/issues?q=is%3Aissue%20is%3Aclosed%20-label%3Ainvalid%20-label%3Awontfix%20milestone%3Am29) - 2025-08-27

### Bug Fix

* Fix: `refined4s` modules require `test-refined4s-core-without-cats` module due to the incorrect config in `dependsOn` (#480)

  ```
  [warn] 	Note: Unresolved dependencies path:
  [error] stack trace is suppressed; run last docs / update for the full output
  [error] (docs / update) sbt.librarymanagement.ResolveException: Error downloading io.kevinlee:test-refined4s-core-without-cats_3:1.8.0
  [error]   Not found
  [error]   Not found
  [error]   not found: /Users/username/.ivy2/local/io.kevinlee/test-refined4s-core-without-cats_3/1.8.0/ivys/ivy.xml
  [error]   not found: https://repo1.maven.org/maven2/io/kevinlee/test-refined4s-core-without-cats_3/1.8.0/test-refined4s-core-without-cats_3-1.8.0.pom
  [error] Total time: 4 s, completed 27 Aug. 2025, 2:05:39 pm
  ```

  * Cause:
  
    ```sbt
    val IncludeTest = "compile->compile;test->test"
    ```
    was used with `testCoreWithoutCats` in `dependsOn`, and that's why.
    
    e.g.)
    ```sbt
    lazy val cats = module("cats", crossProject(JVMPlatform, JSPlatform, NativePlatform))
      .settings(
        libraryDependencies ++= List(
          libs.cats.value,
          libs.extrasCore.value % Test,
        )
      )
      .dependsOn(
        core                % props.IncludeTest,
        testCoreWithoutCats % props.IncludeTest, // <=== BECAUSE OF THIS
      )
    ```
  
  * Solution
  
    Replace `"compile->compile;test->test"` with `"test->test"`.

    e.g.)
    ```sbt
    lazy val cats = module("cats", crossProject(JVMPlatform, JSPlatform, NativePlatform))
      .settings(
        libraryDependencies ++= List(
          libs.cats.value,
          libs.extrasCore.value % Test,
        )
      )
      .dependsOn(
        core                % props.IncludeTest,
        testCoreWithoutCats % "test->test",
      )
    ```