### PR TITLE
Close #484: Do not use `java.net.URL`'s constructors as they have been deprecated since Java 20

### DIFF
--- a/modules/refined4s-core/jvm/src/main/scala/refined4s/types/networkCompat.scala
+++ b/modules/refined4s-core/jvm/src/main/scala/refined4s/types/networkCompat.scala
@@ -20,10 +20,9 @@ object networkCompat extends OrphanCats, OrphanCatsKernel {
     override def invalidReason(a: String): String =
       expectedMessage(inlinedExpectedValue)
 
-    @SuppressWarnings(Array("org.wartremover.warts.JavaNetURLConstructors"))
     override def predicate(a: String): Boolean =
       try {
-        new URL(a)
+        new URI(a).toURL
         true
       } catch {
         case NonFatal(_) =>
@@ -38,8 +37,7 @@ object networkCompat extends OrphanCats, OrphanCatsKernel {
     def apply(a: URL): Type = unsafeFrom(a.toString)
 
     extension (url: Type) {
-      @SuppressWarnings(Array("org.wartremover.warts.JavaNetURLConstructors"))
-      def toURL: URL = new URL(url.value)
+      def toURL: URL = new URI(url.value).toURL
 
       def toUri: Uri = Uri(toURL.toURI)
 
@@ -58,13 +56,12 @@ object networkCompat extends OrphanCats, OrphanCatsKernel {
 
   }
 
-  @SuppressWarnings(Array("org.wartremover.warts.JavaNetURLConstructors"))
   def isValidateUrl(urlExpr: Expr[String])(using Quotes): Expr[Boolean] = {
     import quotes.reflect.*
     urlExpr.asTerm match {
       case Inlined(_, _, Literal(StringConstant(urlStr))) =>
         try {
-          new java.net.URL(urlStr)
+          new java.net.URI(urlStr).toURL
           Expr(true)
         } catch {
           case _: Throwable => Expr(false)

--- a/modules/test-refined4s-core-without-cats/jvm/src/test/scala/refined4s/types/networkCompatSpec.scala
+++ b/modules/test-refined4s-core-without-cats/jvm/src/test/scala/refined4s/types/networkCompatSpec.scala
@@ -1,10 +1,10 @@
 package refined4s.types
 
-import refined4s.predef4testing.*
 import hedgehog.*
 import hedgehog.runner.*
+import refined4s.predef4testing.*
 
-import java.net.{URI, URL}
+import java.net.URI
 
 /** @author Kevin Lee
   * @since 2024-09-05
@@ -50,7 +50,7 @@ trait networkCompatSpec {
       uri <- networkGens.genUrlString.log("uri")
     } yield {
       @SuppressWarnings(Array("org.wartremover.warts.JavaNetURLConstructors"))
-      val expected = new URL(uri)
+      val expected = new URI(uri).toURL
       val actual   = Uri.unsafeFrom(uri).toURL
 
       actual ==== expected
@@ -60,7 +60,7 @@ trait networkCompatSpec {
 
   def testUrlApply: Result = {
     @SuppressWarnings(Array("org.wartremover.warts.JavaNetURLConstructors"))
-    val expected = new URL("https://github.com/kevin-lee/refined4s")
+    val expected = new URI("https://github.com/kevin-lee/refined4s").toURL
     val actual   = Url("https://github.com/kevin-lee/refined4s")
     Result.all(
       List(
@@ -72,7 +72,7 @@ trait networkCompatSpec {
 
   def testUrlApplyURL: Result = {
     @SuppressWarnings(Array("org.wartremover.warts.JavaNetURLConstructors"))
-    val url      = new URL("https://github.com/kevin-lee/refined4s")
+    val url      = new URI("https://github.com/kevin-lee/refined4s").toURL
     val expected = url
     val actual   = Url(url)
     Result.all(
@@ -116,7 +116,7 @@ trait networkCompatSpec {
       val actual   = Url.from(uri)
 
       @SuppressWarnings(Array("org.wartremover.warts.JavaNetURLConstructors"))
-      val expectedUrl = new URL(uri).asRight
+      val expectedUrl = new URI(uri).toURL.asRight
       val actualUrl   = actual.map(_.toURL)
 
       Result.all(
@@ -160,7 +160,7 @@ trait networkCompatSpec {
       val actual   = Url.unsafeFrom(uri)
 
       @SuppressWarnings(Array("org.wartremover.warts.JavaNetURLConstructors"))
-      val expectedUrl = new URL(uri)
+      val expectedUrl = new URI(uri).toURL
       val actualUrl   = actual.toURL
 
       Result.all(
@@ -231,7 +231,7 @@ trait networkCompatSpec {
       uri <- networkGens.genUrlString.log("uri")
     } yield {
       @SuppressWarnings(Array("org.wartremover.warts.JavaNetURLConstructors"))
-      val expected = new URL(uri)
+      val expected = new URI(uri).toURL
       val actual   = Url.unsafeFrom(uri).toURL
 
       actual ==== expected


### PR DESCRIPTION
## Close #484: Do not use `java.net.URL`'s constructors as they have been deprecated since Java 20

- Replace `new URL(url)` with `new URI(url).toURL` as `new URL()`s were deprecated in Java 20.