### PR TITLE
Close #488: [`refined4s-core`] Add `cats.Hash` type class instances for `refined4s.types.strings` with `orphan-cats`

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -566,7 +566,7 @@ def commonModule(prefixedName: String, crossProject: CrossProject.Builder): Cros
         else
           ((ThisBuild / baseDirectory).value / ".scalafix-scala2.conf").some
       ),
-      scalacOptions ++= (if (isScala3(scalaVersion.value)) List("-no-indent") else List("-Xsource:3")),
+      scalacOptions ++= (if (isScala3(scalaVersion.value)) List("-no-indent", "-explain") else List("-Xsource:3")),
 //      scalacOptions ~= (ops => ops.filter(_ != "UTF-8")),
       libraryDependencies ++= libs.tests.hedgehog.value,
       wartremoverErrors ++= Warts.allBut(Wart.Any, Wart.Nothing, Wart.ImplicitConversion, Wart.ImplicitParameter),

--- a/modules/refined4s-cats/shared/src/test/scala/refined4s/modules/cats/derivation/types/allSpec.scala
+++ b/modules/refined4s-cats/shared/src/test/scala/refined4s/modules/cats/derivation/types/allSpec.scala
@@ -1887,6 +1887,7 @@ object allSpec extends Properties {
     def tests: List[Test] = List(
       property("test   Eq[NonEmptyString] === case", testEq),
       property("test   Eq[NonEmptyString] =!= case", testEqNotEqual),
+      property("test Hash[NonEmptyString]", testHash),
       property("test Show[NonEmptyString]", testShow),
     )
 
@@ -1913,6 +1914,24 @@ object allSpec extends Properties {
         Result.diffNamed("NonEmptyString(value) =!= NonEmptyString(value)", input1, input2)(_ =!= _)
       }
 
+    def testHash: Property =
+      for {
+        s <- Gen.string(Gen.unicode, Range.linear(1, 10)).log("s")
+      } yield {
+        val input = NonEmptyString.unsafeFrom(s)
+
+        val expected       = s.hashCode
+        val actual         = input.hash
+        val actualHashCode = input.##
+
+        Result.all(
+          List(
+            Result.diffNamed("NonEmptyString(value).hash === s.hashCode", actual, expected)(_ === _),
+            Result.diffNamed("NonEmptyString(value).## === s.hashCode", actualHashCode, expected)(_ === _),
+          )
+        )
+      }
+
     def testShow: Property =
       for {
         s <- Gen.string(Gen.unicode, Range.linear(1, 10)).log("s")
@@ -1934,6 +1953,7 @@ object allSpec extends Properties {
     def tests: List[Test] = List(
       property("test   Eq[NonBlankString] === case", testEq),
       property("test   Eq[NonBlankString] =!= case", testEqNotEqual),
+      property("test Hash[NonBlankString]", testHash),
       property("test Show[NonBlankString]", testShow),
     )
 
@@ -1978,6 +1998,32 @@ object allSpec extends Properties {
         Result.diffNamed("NonBlankString(value) =!= NonBlankString(value)", input1, input2)(_ =!= _)
       }
 
+    def testHash: Property =
+      for {
+        nonWhitespaceString <- Gen.string(hedgehog.extra.Gens.genNonWhitespaceChar, Range.linear(1, 10)).log("nonWhitespaceString")
+        whitespaceString    <- Gen
+                                 .string(
+                                   hedgehog.extra.Gens.genCharByRange(refined4s.types.strings.WhitespaceCharRange),
+                                   Range.linear(1, 10),
+                                 )
+                                 .log("whitespaceString")
+
+        s <- Gen.constant(scala.util.Random.shuffle((nonWhitespaceString + whitespaceString).toList).mkString).log("s")
+      } yield {
+        val input = NonBlankString.unsafeFrom(s)
+
+        val expected       = s.hashCode
+        val actual         = input.hash
+        val actualHashCode = input.##
+
+        Result.all(
+          List(
+            Result.diffNamed("NonBlankString(value).hash === s.hashCode", actual, expected)(_ === _),
+            Result.diffNamed("NonBlankString(value).## === s.hashCode", actualHashCode, expected)(_ === _),
+          )
+        )
+      }
+
     def testShow: Property =
       for {
         nonWhitespaceString <- Gen.string(hedgehog.extra.Gens.genNonWhitespaceChar, Range.linear(1, 10)).log("nonWhitespaceString")
@@ -2006,6 +2052,7 @@ object allSpec extends Properties {
     def tests: List[Test] = List(
       property("test   Eq[Uuid] === case", testEq),
       property("test   Eq[Uuid] =!= case", testEqNotEqual),
+      property("test Hash[Uuid]", testHash),
       property("test Show[Uuid]", testShow),
     )
 
@@ -2037,6 +2084,24 @@ object allSpec extends Properties {
         val input2 = Uuid(uuid2)
 
         Result.diffNamed("Uuid(value) =!= Uuid(different value)", input1, input2)(_ =!= _)
+      }
+
+    def testHash: Property =
+      for {
+        uuid <- Gen.constant(UUID.randomUUID()).log("uuid")
+      } yield {
+        val input = Uuid(uuid)
+
+        val expected       = uuid.toString.hashCode
+        val actual         = input.hash
+        val actualHashCode = input.##
+
+        Result.all(
+          List(
+            Result.diffNamed("Uuid(value).hash === UUID.toString.hashCode", actual, expected)(_ === _),
+            Result.diffNamed("Uuid(value).## === UUID.toString.hashCode", actualHashCode, expected)(_ === _),
+          )
+        )
       }
 
     def testShow: Property =

--- a/modules/refined4s-core/shared/src/main/scala/refined4s/types/strings.scala
+++ b/modules/refined4s-core/shared/src/main/scala/refined4s/types/strings.scala
@@ -28,11 +28,11 @@ trait strings {
   // scalafix:on
 
 }
-object strings extends OrphanCats, OrphanCatsKernel {
+object strings {
 
   type NonEmptyString = NonEmptyString.Type
   @SuppressWarnings(Array("org.wartremover.warts.Equals"))
-  object NonEmptyString extends Refined[String], CanBeOrdered[String] {
+  object NonEmptyString extends Refined[String], CanBeOrdered[String], NonEmptyStringTypeClassInstances {
 
     override inline def invalidReason(a: String): String =
       expectedMessage("a non-empty String")
@@ -44,14 +44,23 @@ object strings extends OrphanCats, OrphanCatsKernel {
       def ++(thatNes: NonEmptyString): NonEmptyString = NonEmptyString.unsafeFrom(thisNes.value + thatNes.value)
     }
 
+  }
+  private[types] trait NonEmptyStringTypeClassInstances extends NonEmptyStringTypeClassInstance2 {
     @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
     given derivedNonEmptyStringEq[F[*]: CatsEq, G[*]: CatsEq](using eqActual: G[String]): F[NonEmptyString] = {
-      internalDef.contraCoercible(eqActual.asInstanceOf[cats.Eq[String]])
+      internalDef.contraCoercible[cats.Eq, NonEmptyString, String, cats.Contravariant](eqActual.asInstanceOf[cats.Eq[String]])
     }.asInstanceOf[F[NonEmptyString]] // scalafix:ok DisableSyntax.asInstanceOf
-
+  }
+  private[types] trait NonEmptyStringTypeClassInstance2 extends NonEmptyStringTypeClassInstance1 {
+    @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
+    given derivedNonEmptyStringHash[F[*]: CatsHash, G[*]: CatsHash](using hashActual: G[String]): F[NonEmptyString] = {
+      internalDef.contraCoercible[cats.Hash, NonEmptyString, String, cats.Contravariant](hashActual.asInstanceOf[cats.Hash[String]])
+    }.asInstanceOf[F[NonEmptyString]] // scalafix:ok DisableSyntax.asInstanceOf
+  }
+  private[types] trait NonEmptyStringTypeClassInstance1 extends OrphanCats, OrphanCatsKernel {
     @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
     given derivedNonEmptyStringShow[F[*]: CatsShow, G[*]: CatsShow](using showActual: G[String]): F[NonEmptyString] = {
-      internalDef.contraCoercible(showActual.asInstanceOf[cats.Show[String]])
+      internalDef.contraCoercible[cats.Show, NonEmptyString, String, cats.Contravariant](showActual.asInstanceOf[cats.Show[String]])
     }.asInstanceOf[F[NonEmptyString]] // scalafix:ok DisableSyntax.asInstanceOf
 
   }
@@ -70,7 +79,7 @@ object strings extends OrphanCats, OrphanCatsKernel {
 
   type NonBlankString = NonBlankString.Type
   @SuppressWarnings(Array("org.wartremover.warts.Equals"))
-  object NonBlankString extends InlinedRefined[String], CanBeOrdered[String] {
+  object NonBlankString extends InlinedRefined[String], CanBeOrdered[String], NonBlankStringInstances {
 
     override inline val inlinedExpectedValue = "not all whitespace non-empty String"
 
@@ -100,20 +109,28 @@ object strings extends OrphanCats, OrphanCatsKernel {
       inline def appendString(that: String): Type = NonBlankString.unsafeFrom(thisNbs.value + that)
     }
 
+  }
+  private[types] trait NonBlankStringInstances extends NonBlankStringInstance2 {
     @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
     inline given derivedNonBlankStringEq[F[*]: CatsEq, G[*]: CatsEq](using eqActual: G[String]): F[NonBlankString] = {
-      internalDef.contraCoercible(eqActual.asInstanceOf[cats.Eq[String]])
+      internalDef.contraCoercible[cats.Eq, NonBlankString, String, cats.Contravariant](eqActual.asInstanceOf[cats.Eq[String]])
     }.asInstanceOf[F[NonBlankString]] // scalafix:ok DisableSyntax.asInstanceOf
-
+  }
+  private[types] trait NonBlankStringInstance2 extends NonBlankStringInstance1 {
+    @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
+    inline given derivedNonBlankStringHash[F[*]: CatsHash, G[*]: CatsHash](using hashActual: G[String]): F[NonBlankString] = {
+      internalDef.contraCoercible[cats.Hash, NonBlankString, String, cats.Contravariant](hashActual.asInstanceOf[cats.Hash[String]])
+    }.asInstanceOf[F[NonBlankString]] // scalafix:ok DisableSyntax.asInstanceOf
+  }
+  private[types] trait NonBlankStringInstance1 extends OrphanCats, OrphanCatsKernel {
     @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
     inline given derivedNonBlankStringShow[F[*]: CatsShow, G[*]: CatsShow](using showActual: G[String]): F[NonBlankString] = {
-      internalDef.contraCoercible(showActual.asInstanceOf[cats.Show[String]])
+      internalDef.contraCoercible[cats.Show, NonBlankString, String, cats.Contravariant](showActual.asInstanceOf[cats.Show[String]])
     }.asInstanceOf[F[NonBlankString]] // scalafix:ok DisableSyntax.asInstanceOf
-
   }
 
   type Uuid = Uuid.Type
-  object Uuid extends InlinedRefined[String], CanBeOrdered[String] {
+  object Uuid extends InlinedRefined[String], CanBeOrdered[String], UuidInstances {
     override inline val inlinedExpectedValue = "UUID"
 
     override inline def inlinedPredicate(inline a: String): Boolean = ${ isValidateUuid('a) }
@@ -135,17 +152,26 @@ object strings extends OrphanCats, OrphanCatsKernel {
     extension (uuid: Uuid) {
       def toUUID: UUID = UUID.fromString(uuid.value)
     }
-
+  }
+  private[types] trait UuidInstances extends UuidInstance2 {
     @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
     inline given derivedUuidEq[F[*]: CatsEq, G[*]: CatsEq](using eqActual: G[String]): F[Uuid] = {
-      internalDef.contraCoercible(eqActual.asInstanceOf[cats.Eq[String]])
+      internalDef.contraCoercible[cats.Eq, Uuid, String, cats.Contravariant](eqActual.asInstanceOf[cats.Eq[String]])
     }.asInstanceOf[F[Uuid]] // scalafix:ok DisableSyntax.asInstanceOf
+  }
 
+  private[types] trait UuidInstance2 extends UuidInstance1 {
+    @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
+    inline given derivedUuidHash[F[*]: CatsHash, G[*]: CatsHash](using hashActual: G[String]): F[Uuid] = {
+      internalDef.contraCoercible[cats.Hash, Uuid, String, cats.Contravariant](hashActual.asInstanceOf[cats.Hash[String]])
+    }.asInstanceOf[F[Uuid]] // scalafix:ok DisableSyntax.asInstanceOf
+  }
+
+  private[types] trait UuidInstance1 extends OrphanCats, OrphanCatsKernel {
     @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
     inline given derivedUuidShow[F[*]: CatsShow, G[*]: CatsShow](using showActual: G[String]): F[Uuid] = {
-      internalDef.contraCoercible(showActual.asInstanceOf[cats.Show[String]])
+      internalDef.contraCoercible[cats.Show, Uuid, String, cats.Contravariant](showActual.asInstanceOf[cats.Show[String]])
     }.asInstanceOf[F[Uuid]] // scalafix:ok DisableSyntax.asInstanceOf
-
   }
 
   @SuppressWarnings(Array("org.wartremover.warts.Equals"))

--- a/modules/test-refined4s-core-without-cats/shared/src/test/scala/refined4s/ExpectedErrorMessages.scala
+++ b/modules/test-refined4s-core-without-cats/shared/src/test/scala/refined4s/ExpectedErrorMessages.scala
@@ -8,6 +8,8 @@ import orphan.OrphanCatsMessages
 object ExpectedErrorMessages {
   def missingEq: String = OrphanCatsMessages.MissingCatsEq
 
+  def missingHash: String = OrphanCatsMessages.MissingCatsHash
+
   def missingShow: String = OrphanCatsMessages.MissingCatsShow
 
 }

--- a/modules/test-refined4s-core-without-cats/shared/src/test/scala/refined4s/types/stringsWithoutCatsSpec.scala
+++ b/modules/test-refined4s-core-without-cats/shared/src/test/scala/refined4s/types/stringsWithoutCatsSpec.scala
@@ -14,6 +14,7 @@ object stringsWithoutCatsSpec extends Properties {
 
     def tests: List[Test] = List(
       example("test Eq[NonEmptyString]", testEq),
+      example("test Hash[NonEmptyString]", testHash),
       example("test Show[NonEmptyString]", testShow),
     )
 
@@ -24,6 +25,24 @@ object stringsWithoutCatsSpec extends Properties {
       val actual = typeCheckErrors(
         """
           val _ = refined4s.types.strings.NonEmptyString.derivedNonEmptyStringEq
+        """
+      )
+
+      val actualErrorMessage = actual.map(_.message).mkString
+      (actualErrorMessage ==== expectedMessage)
+        .log(
+          """The actual error message doesn't start with the expected one.
+            |""".stripMargin
+        )
+    }
+
+    def testHash: Result = {
+      import scala.compiletime.testing.typeCheckErrors
+      val expectedMessage = ExpectedErrorMessages.missingHash
+
+      val actual = typeCheckErrors(
+        """
+          val _ = refined4s.types.strings.NonEmptyString.derivedNonEmptyStringHash
         """
       )
 
@@ -59,6 +78,7 @@ object stringsWithoutCatsSpec extends Properties {
 
     def tests: List[Test] = List(
       example("test Eq[NonBlankString]", testEq),
+      example("test Hash[NonBlankString]", testHash),
       example("test Show[NonBlankString]", testShow),
     )
 
@@ -69,6 +89,24 @@ object stringsWithoutCatsSpec extends Properties {
       val actual = typeCheckErrors(
         """
           val _ = refined4s.types.strings.NonBlankString.derivedNonBlankStringEq
+        """
+      )
+
+      val actualErrorMessage = actual.map(_.message).mkString
+      (actualErrorMessage ==== expectedMessage)
+        .log(
+          """The actual error message doesn't start with the expected one.
+            |""".stripMargin
+        )
+    }
+
+    def testHash: Result = {
+      import scala.compiletime.testing.typeCheckErrors
+      val expectedMessage = ExpectedErrorMessages.missingHash
+
+      val actual = typeCheckErrors(
+        """
+          val _ = refined4s.types.strings.NonBlankString.derivedNonBlankStringHash
         """
       )
 
@@ -105,6 +143,7 @@ object stringsWithoutCatsSpec extends Properties {
 
     def tests: List[Test] = List(
       example("test Eq[Uuid]", testEq),
+      example("test Hash[Uuid]", testHash),
       example("test Show[Uuid]", testShow),
     )
 
@@ -115,6 +154,24 @@ object stringsWithoutCatsSpec extends Properties {
       val actual = typeCheckErrors(
         """
           val _ = refined4s.types.strings.Uuid.derivedUuidEq
+        """
+      )
+
+      val actualErrorMessage = actual.map(_.message).mkString
+      (actualErrorMessage ==== expectedMessage)
+        .log(
+          """The actual error message doesn't start with the expected one.
+            |""".stripMargin
+        )
+    }
+
+    def testHash: Result = {
+      import scala.compiletime.testing.typeCheckErrors
+      val expectedMessage = ExpectedErrorMessages.missingHash
+
+      val actual = typeCheckErrors(
+        """
+          val _ = refined4s.types.strings.Uuid.derivedUuidHash
         """
       )
 


### PR DESCRIPTION
## Close #488: [`refined4s-core`] Add `cats.Hash` type class instances for `refined4s.types.strings` with `orphan-cats`

- core: Add derived cats `Hash` instances for
  - `NonEmptyString`
  - `NonBlankString`
  - `Uuid`
  
  via `internalDef.contraCoercible` with explicit type params.

- Refactor cats type class instances for `strings`, restructuring them into hierarchical traits to resolve ambiguous `Eq` and `Hash` instances.
- Add `Hash` tests for all string types
  - tests with cats: Add property tests asserting `hash` and `##` match the underlying string's `hashCode` for `NonEmptyString`, `NonBlankString` and `Uuid`.
  - tests without cats: Add expected compile-time failures for missing `Hash` instances
- Add missing Hash error message tests for builds without cats dependencies.
- Add `-explain` to Scala 3 `scalacOptions` for better error messages.