### PR TITLE
Close #490: [`refined4s-core`] Add `cats.Hash` type class instances for `refined4s.types.network` with `orphan-cats`

### DIFF
--- a/modules/refined4s-cats/shared/src/test/scala/refined4s/modules/cats/derivation/types/allSpec.scala
+++ b/modules/refined4s-cats/shared/src/test/scala/refined4s/modules/cats/derivation/types/allSpec.scala
@@ -2124,6 +2124,7 @@ object allSpec extends Properties {
     def tests: List[Test] = List(
       property("test   Eq[Uri] === case", testEq),
       property("test   Eq[Uri] =!= case", testEqNotEqual),
+      property("test Hash[Uri]", testHash),
       property("test Show[Uri]", testShow),
     )
 
@@ -2150,6 +2151,24 @@ object allSpec extends Properties {
         Result.diffNamed("Uri(value) =!= Uri(different value)", input1, input2)(_ =!= _)
       }
 
+    def testHash: Property =
+      for {
+        uri <- networkGens.genUriString.log("uri")
+      } yield {
+        val input = Uri.unsafeFrom(uri)
+
+        val expected       = uri.hashCode
+        val actual         = input.hash
+        val actualHashCode = input.##
+
+        Result.all(
+          List(
+            Result.diffNamed("Uri(value).hash === uri.hashCode", actual, expected)(_ === _),
+            Result.diffNamed("Uri(value).## === uri.hashCode", actualHashCode, expected)(_ === _),
+          )
+        )
+      }
+
     def testShow: Property =
       for {
         uri <- networkGens.genUriString.log("uri")
@@ -2170,6 +2189,7 @@ object allSpec extends Properties {
     def tests: List[Test] = List(
       property("test   Eq[Url] === case", testEq),
       property("test   Eq[Url] =!= case", testEqNotEqual),
+      property("test Hash[Url]", testHash),
       property("test Show[Url]", testShow),
     )
 
@@ -2196,6 +2216,24 @@ object allSpec extends Properties {
         Result.diffNamed("Uri(value) =!= Uri(different value)", input1, input2)(_ =!= _)
       }
 
+    def testHash: Property =
+      for {
+        url <- networkGens.genUrlString.log("url")
+      } yield {
+        val input = Url.unsafeFrom(url)
+
+        val expected       = url.hashCode
+        val actual         = input.hash
+        val actualHashCode = input.##
+
+        Result.all(
+          List(
+            Result.diffNamed("Uri(value).hash === url.hashCode", actual, expected)(_ === _),
+            Result.diffNamed("Uri(value).## === url.hashCode", actualHashCode, expected)(_ === _),
+          )
+        )
+      }
+
     def testShow: Property =
       for {
         url <- networkGens.genUrlString.log("url")
@@ -2217,6 +2255,7 @@ object allSpec extends Properties {
     def tests: List[Test] = List(
       property("test   Eq[PortNumber] === case", testEq),
       property("test   Eq[PortNumber] =!= case", testEqNotEqual),
+      property("test Hash[PortNumber]", testHash),
       property("test Show[PortNumber]", testShow),
     )
 
@@ -2256,6 +2295,24 @@ object allSpec extends Properties {
       Result.diffNamed("PortNumber(value) =!= PortNumber(different value)", input1, input2)(_ =!= _)
     }
 
+    def testHash: Property =
+      for {
+        portNumber <- networkGens.genPortNumberInt.log("portNumber")
+      } yield {
+        val input = PortNumber.unsafeFrom(portNumber)
+
+        val expected       = portNumber.hashCode
+        val actual         = input.hash
+        val actualHashCode = input.##
+
+        Result.all(
+          List(
+            Result.diffNamed("PortNumber(value).hash === portNumber.hashCode", actual, expected)(_ === _),
+            Result.diffNamed("PortNumber(value).## === portNumber.hashCode", actualHashCode, expected)(_ === _),
+          )
+        )
+      }
+
     def testShow: Property =
       for {
         portNumber <- networkGens.genPortNumberInt.log("portNumber")
@@ -2276,6 +2333,7 @@ object allSpec extends Properties {
     def tests: List[Test] = List(
       property("test   Eq[SystemPortNumber] === case", testEq),
       property("test   Eq[SystemPortNumber] =!= case", testEqNotEqual),
+      property("test Hash[SystemPortNumber]", testHash),
       property("test Show[SystemPortNumber]", testShow),
     )
 
@@ -2316,6 +2374,24 @@ object allSpec extends Properties {
       Result.diffNamed("SystemPortNumber(value) =!= SystemPortNumber(different value)", input1, input2)(_ =!= _)
     }
 
+    def testHash: Property =
+      for {
+        systemPortNumber <- networkGens.genSystemPortNumberInt.log("systemPortNumber")
+      } yield {
+        val input = SystemPortNumber.unsafeFrom(systemPortNumber)
+
+        val expected       = systemPortNumber.hashCode
+        val actual         = input.hash
+        val actualHashCode = input.##
+
+        Result.all(
+          List(
+            Result.diffNamed("SystemPortNumber(value).hash === systemPortNumber.hashCode", actual, expected)(_ === _),
+            Result.diffNamed("SystemPortNumber(value).## === systemPortNumber.hashCode", actualHashCode, expected)(_ === _),
+          )
+        )
+      }
+
     def testShow: Property = for {
       systemPortNumber <- networkGens.genSystemPortNumberInt.log("systemPortNumber")
     } yield {
@@ -2335,6 +2411,7 @@ object allSpec extends Properties {
     def tests: List[Test] = List(
       property("test   Eq[NonSystemPortNumber] === case", testEq),
       property("test   Eq[NonSystemPortNumber] =!= case", testEqNotEqual),
+      property("test Hash[NonSystemPortNumber]", testHash),
       property("test Show[NonSystemPortNumber]", testShow),
     )
 
@@ -2374,6 +2451,24 @@ object allSpec extends Properties {
       Result.diffNamed("NonSystemPortNumber(value) =!= NonSystemPortNumber(different value)", input1, input2)(_ =!= _)
     }
 
+    def testHash: Property =
+      for {
+        nonSystemPortNumber <- networkGens.genNonSystemPortNumberInt.log("nonSystemPortNumber")
+      } yield {
+        val input = NonSystemPortNumber.unsafeFrom(nonSystemPortNumber)
+
+        val expected       = nonSystemPortNumber.hashCode
+        val actual         = input.hash
+        val actualHashCode = input.##
+
+        Result.all(
+          List(
+            Result.diffNamed("NonSystemPortNumber(value).hash === nonSystemPortNumber.hashCode", actual, expected)(_ === _),
+            Result.diffNamed("NonSystemPortNumber(value).## === nonSystemPortNumber.hashCode", actualHashCode, expected)(_ === _),
+          )
+        )
+      }
+
     def testShow: Property = for {
       nonSystemPortNumber <- networkGens.genNonSystemPortNumberInt.log("nonSystemPortNumber")
     } yield {
@@ -2393,6 +2488,7 @@ object allSpec extends Properties {
     def tests: List[Test] = List(
       property("test   Eq[UserPortNumber] === case", testEq),
       property("test   Eq[UserPortNumber] =!= case", testEqNotEqual),
+      property("test Hash[UserPortNumber]", testHash),
       property("test Show[UserPortNumber]", testShow),
     )
 
@@ -2433,6 +2529,24 @@ object allSpec extends Properties {
       Result.diffNamed("UserPortNumber(value) =!= UserPortNumber(different value)", input1, input2)(_ =!= _)
     }
 
+    def testHash: Property =
+      for {
+        userPortNumber <- networkGens.genUserPortNumberInt.log("userPortNumber")
+      } yield {
+        val input = UserPortNumber.unsafeFrom(userPortNumber)
+
+        val expected       = userPortNumber.hashCode
+        val actual         = input.hash
+        val actualHashCode = input.##
+
+        Result.all(
+          List(
+            Result.diffNamed("UserPortNumber(value).hash === userPortNumber.hashCode", actual, expected)(_ === _),
+            Result.diffNamed("UserPortNumber(value).## === userPortNumber.hashCode", actualHashCode, expected)(_ === _),
+          )
+        )
+      }
+
     def testShow: Property = for {
       userPortNumber <- networkGens.genUserPortNumberInt.log("userPortNumber")
     } yield {
@@ -2452,6 +2566,7 @@ object allSpec extends Properties {
     def tests: List[Test] = List(
       property("test   Eq[DynamicPortNumber] === case", testEq),
       property("test   Eq[DynamicPortNumber] =!= case", testEqNotEqual),
+      property("test Hash[DynamicPortNumber]", testHash),
       property("test Show[DynamicPortNumber]", testShow),
     )
 
@@ -2491,6 +2606,24 @@ object allSpec extends Properties {
       val input2 = DynamicPortNumber.unsafeFrom(dynamicPortNumber2)
       Result.diffNamed("DynamicPortNumber(value) =!= DynamicPortNumber(different value)", input1, input2)(_ =!= _)
     }
+
+    def testHash: Property =
+      for {
+        dynamicPortNumber <- networkGens.genDynamicPortNumberInt.log("dynamicPortNumber")
+      } yield {
+        val input = DynamicPortNumber.unsafeFrom(dynamicPortNumber)
+
+        val expected       = dynamicPortNumber.hashCode
+        val actual         = input.hash
+        val actualHashCode = input.##
+
+        Result.all(
+          List(
+            Result.diffNamed("DynamicPortNumber(value).hash === dynamicPortNumber.hashCode", actual, expected)(_ === _),
+            Result.diffNamed("DynamicPortNumber(value).## === dynamicPortNumber.hashCode", actualHashCode, expected)(_ === _),
+          )
+        )
+      }
 
     def testShow: Property =
       for {

--- a/modules/refined4s-core/js/src/main/scala/refined4s/types/networkCompat.scala
+++ b/modules/refined4s-core/js/src/main/scala/refined4s/types/networkCompat.scala
@@ -12,11 +12,11 @@ import scala.util.control.NonFatal
 /** @author Kevin Lee
   * @since 2024-09-04
   */
-object networkCompat extends OrphanCats, OrphanCatsKernel {
+object networkCompat {
   val validUrlSchemes = Set("http", "https", "ftp", "file")
 
   type Url = Url.Type
-  object Url extends InlinedRefined[String] {
+  object Url extends InlinedRefined[String], UrlTypeClassInstances {
 
     override def invalidReason(a: String): String =
       expectedMessage(inlinedExpectedValue)
@@ -80,16 +80,24 @@ object networkCompat extends OrphanCats, OrphanCatsKernel {
       def toURI: URI = new URI(url.value)
     }
 
+  }
+  private[types] trait UrlTypeClassInstances extends UrlTypeClassInstance1 {
     @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
     inline given derivedUrlEq[F[*]: CatsEq, G[*]: CatsEq](using eqActual: G[String]): F[Url] = {
-      internalDef.contraCoercible(eqActual.asInstanceOf[cats.Eq[String]])
+      internalDef.contraCoercible[cats.Eq, Url, String, cats.Contravariant](eqActual.asInstanceOf[cats.Eq[String]])
     }.asInstanceOf[F[Url]] // scalafix:ok DisableSyntax.asInstanceOf
-
+  }
+  private[types] trait UrlTypeClassInstance1 extends UrlTypeClassInstance2 {
+    @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
+    inline given derivedUrlHash[F[*]: CatsHash, G[*]: CatsHash](using hashActual: G[String]): F[Url] = {
+      internalDef.contraCoercible[cats.Hash, Url, String, cats.Contravariant](hashActual.asInstanceOf[cats.Hash[String]])
+    }.asInstanceOf[F[Url]] // scalafix:ok DisableSyntax.asInstanceOf
+  }
+  private[types] trait UrlTypeClassInstance2 extends OrphanCats, OrphanCatsKernel {
     @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
     inline given derivedUrlShow[F[*]: CatsShow, G[*]: CatsShow](using showActual: G[String]): F[Url] = {
-      internalDef.contraCoercible(showActual.asInstanceOf[cats.Show[String]])
+      internalDef.contraCoercible[cats.Show, Url, String, cats.Contravariant](showActual.asInstanceOf[cats.Show[String]])
     }.asInstanceOf[F[Url]] // scalafix:ok DisableSyntax.asInstanceOf
-
   }
 
   @SuppressWarnings(Array("org.wartremover.warts.JavaNetURLConstructors"))

--- a/modules/refined4s-core/jvm/src/main/scala/refined4s/types/networkCompat.scala
+++ b/modules/refined4s-core/jvm/src/main/scala/refined4s/types/networkCompat.scala
@@ -12,10 +12,10 @@ import scala.util.control.NonFatal
 /** @author Kevin Lee
   * @since 2024-09-04
   */
-object networkCompat extends OrphanCats, OrphanCatsKernel {
+object networkCompat {
 
   type Url = Url.Type
-  object Url extends InlinedRefined[String] {
+  object Url extends InlinedRefined[String], UrlTypeClassInstances {
 
     override def invalidReason(a: String): String =
       expectedMessage(inlinedExpectedValue)
@@ -44,16 +44,24 @@ object networkCompat extends OrphanCats, OrphanCatsKernel {
       def toURI: URI = toURL.toURI
     }
 
+  }
+  private[types] trait UrlTypeClassInstances extends UrlTypeClassInstance1 {
     @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
     inline given derivedUrlEq[F[*]: CatsEq, G[*]: CatsEq](using eqActual: G[String]): F[Url] = {
-      internalDef.contraCoercible(eqActual.asInstanceOf[cats.Eq[String]])
+      internalDef.contraCoercible[cats.Eq, Url, String, cats.Contravariant](eqActual.asInstanceOf[cats.Eq[String]])
     }.asInstanceOf[F[Url]] // scalafix:ok DisableSyntax.asInstanceOf
-
+  }
+  private[types] trait UrlTypeClassInstance1 extends UrlTypeClassInstance2 {
+    @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
+    inline given derivedUrlHash[F[*]: CatsHash, G[*]: CatsHash](using hashActual: G[String]): F[Url] = {
+      internalDef.contraCoercible[cats.Hash, Url, String, cats.Contravariant](hashActual.asInstanceOf[cats.Hash[String]])
+    }.asInstanceOf[F[Url]] // scalafix:ok DisableSyntax.asInstanceOf
+  }
+  private[types] trait UrlTypeClassInstance2 extends OrphanCats, OrphanCatsKernel {
     @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
     inline given derivedUrlShow[F[*]: CatsShow, G[*]: CatsShow](using showActual: G[String]): F[Url] = {
-      internalDef.contraCoercible(showActual.asInstanceOf[cats.Show[String]])
+      internalDef.contraCoercible[cats.Show, Url, String, cats.Contravariant](showActual.asInstanceOf[cats.Show[String]])
     }.asInstanceOf[F[Url]] // scalafix:ok DisableSyntax.asInstanceOf
-
   }
 
   def isValidateUrl(urlExpr: Expr[String])(using Quotes): Expr[Boolean] = {

--- a/modules/refined4s-core/native/src/main/scala/refined4s/types/networkCompat.scala
+++ b/modules/refined4s-core/native/src/main/scala/refined4s/types/networkCompat.scala
@@ -12,11 +12,11 @@ import scala.util.control.NonFatal
 /** @author Kevin Lee
   * @since 2024-09-04
   */
-object networkCompat extends OrphanCats, OrphanCatsKernel {
+object networkCompat {
   val validUrlSchemes = Set("http", "https", "ftp", "file")
 
   type Url = Url.Type
-  object Url extends InlinedRefined[String] {
+  object Url extends InlinedRefined[String], UrlTypeClassInstances {
 
     override def invalidReason(a: String): String =
       expectedMessage(inlinedExpectedValue)
@@ -80,16 +80,24 @@ object networkCompat extends OrphanCats, OrphanCatsKernel {
       def toURI: URI = new URI(url.value)
     }
 
+  }
+  private[types] trait UrlTypeClassInstances extends UrlTypeClassInstance1 {
     @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
     inline given derivedUrlEq[F[*]: CatsEq, G[*]: CatsEq](using eqActual: G[String]): F[Url] = {
-      internalDef.contraCoercible(eqActual.asInstanceOf[cats.Eq[String]])
+      internalDef.contraCoercible[cats.Eq, Url, String, cats.Contravariant](eqActual.asInstanceOf[cats.Eq[String]])
     }.asInstanceOf[F[Url]] // scalafix:ok DisableSyntax.asInstanceOf
-
+  }
+  private[types] trait UrlTypeClassInstance1 extends UrlTypeClassInstance2 {
+    @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
+    inline given derivedUrlHash[F[*]: CatsHash, G[*]: CatsHash](using hashActual: G[String]): F[Url] = {
+      internalDef.contraCoercible[cats.Hash, Url, String, cats.Contravariant](hashActual.asInstanceOf[cats.Hash[String]])
+    }.asInstanceOf[F[Url]] // scalafix:ok DisableSyntax.asInstanceOf
+  }
+  private[types] trait UrlTypeClassInstance2 extends OrphanCats, OrphanCatsKernel {
     @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
     inline given derivedUrlShow[F[*]: CatsShow, G[*]: CatsShow](using showActual: G[String]): F[Url] = {
-      internalDef.contraCoercible(showActual.asInstanceOf[cats.Show[String]])
+      internalDef.contraCoercible[cats.Show, Url, String, cats.Contravariant](showActual.asInstanceOf[cats.Show[String]])
     }.asInstanceOf[F[Url]] // scalafix:ok DisableSyntax.asInstanceOf
-
   }
 
   @SuppressWarnings(Array("org.wartremover.warts.JavaNetURLConstructors"))

--- a/modules/refined4s-core/shared/src/main/scala/refined4s/types/network.scala
+++ b/modules/refined4s-core/shared/src/main/scala/refined4s/types/network.scala
@@ -41,8 +41,7 @@ trait network {
   // scalafix:on
 
 }
-
-object network extends OrphanCats, OrphanCatsKernel {
+object network {
 
   final type Url = networkCompat.Url
   // scalafix:off DisableSyntax.noFinalVal
@@ -50,7 +49,7 @@ object network extends OrphanCats, OrphanCatsKernel {
   // scalafix:on
 
   type Uri = Uri.Type
-  object Uri extends InlinedRefined[String] {
+  object Uri extends InlinedRefined[String], UriTypeClassInstances {
 
     override def invalidReason(a: String): String =
       expectedMessage(inlinedExpectedValue)
@@ -79,20 +78,28 @@ object network extends OrphanCats, OrphanCatsKernel {
       def toURL: URL = toURI.toURL
     }
 
+  }
+  private[types] trait UriTypeClassInstances extends UriTypeClassInstance1 {
     @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
     inline given derivedUriEq[F[*]: CatsEq, G[*]: CatsEq](using eqActual: G[String]): F[Uri] = {
-      internalDef.contraCoercible(eqActual.asInstanceOf[cats.Eq[String]])
+      internalDef.contraCoercible[cats.Eq, Uri, String, cats.Contravariant](eqActual.asInstanceOf[cats.Eq[String]])
     }.asInstanceOf[F[Uri]] // scalafix:ok DisableSyntax.asInstanceOf
-
+  }
+  private[types] trait UriTypeClassInstance1 extends UriTypeClassInstance2 {
+    @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
+    inline given derivedUriHash[F[*]: CatsHash, G[*]: CatsHash](using hashActual: G[String]): F[Uri] = {
+      internalDef.contraCoercible[cats.Hash, Uri, String, cats.Contravariant](hashActual.asInstanceOf[cats.Hash[String]])
+    }.asInstanceOf[F[Uri]] // scalafix:ok DisableSyntax.asInstanceOf
+  }
+  private[types] trait UriTypeClassInstance2 extends OrphanCats, OrphanCatsKernel {
     @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
     inline given derivedUriShow[F[*]: CatsShow, G[*]: CatsShow](using showActual: G[String]): F[Uri] = {
-      internalDef.contraCoercible(showActual.asInstanceOf[cats.Show[String]])
+      internalDef.contraCoercible[cats.Show, Uri, String, cats.Contravariant](showActual.asInstanceOf[cats.Show[String]])
     }.asInstanceOf[F[Uri]] // scalafix:ok DisableSyntax.asInstanceOf
-
   }
 
   type PortNumber = PortNumber.Type
-  object PortNumber extends Refined[Int] {
+  object PortNumber extends Refined[Int], PortNumberTypeClassInstances {
 
     override inline def invalidReason(a: Int): String =
       "It has to be Int between 0 and 65535 (0 <= PortNumber <= 65535)"
@@ -100,20 +107,28 @@ object network extends OrphanCats, OrphanCatsKernel {
     override inline def predicate(a: Int): Boolean =
       0 <= a && a <= 65535
 
+  }
+  private[types] trait PortNumberTypeClassInstances extends PortNumberTypeClassInstance1 {
     @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
     inline given derivedPortNumberEq[F[*]: CatsEq, G[*]: CatsEq](using eqActual: G[Int]): F[PortNumber] = {
-      internalDef.contraCoercible(eqActual.asInstanceOf[cats.Eq[Int]])
+      internalDef.contraCoercible[cats.Eq, PortNumber, Int, cats.Contravariant](eqActual.asInstanceOf[cats.Eq[Int]])
     }.asInstanceOf[F[PortNumber]] // scalafix:ok DisableSyntax.asInstanceOf
-
+  }
+  private[types] trait PortNumberTypeClassInstance1 extends PortNumberTypeClassInstance2 {
+    @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
+    inline given derivedPortNumberHash[F[*]: CatsHash, G[*]: CatsHash](using hashActual: G[Int]): F[PortNumber] = {
+      internalDef.contraCoercible[cats.Hash, PortNumber, Int, cats.Contravariant](hashActual.asInstanceOf[cats.Hash[Int]])
+    }.asInstanceOf[F[PortNumber]] // scalafix:ok DisableSyntax.asInstanceOf
+  }
+  private[types] trait PortNumberTypeClassInstance2 extends OrphanCats, OrphanCatsKernel {
     @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
     inline given derivedPortNumberShow[F[*]: CatsShow, G[*]: CatsShow](using showActual: G[Int]): F[PortNumber] = {
-      internalDef.contraCoercible(showActual.asInstanceOf[cats.Show[Int]])
+      internalDef.contraCoercible[cats.Show, PortNumber, Int, cats.Contravariant](showActual.asInstanceOf[cats.Show[Int]])
     }.asInstanceOf[F[PortNumber]] // scalafix:ok DisableSyntax.asInstanceOf
-
   }
 
   type SystemPortNumber = SystemPortNumber.Type
-  object SystemPortNumber extends Refined[Int] {
+  object SystemPortNumber extends Refined[Int], SystemPortNumberTypeClassInstances {
 
     override inline def invalidReason(a: Int): String =
       "It has to be Int between 0 and 1023 (0 <= SystemPortNumber <= 1023)"
@@ -121,20 +136,28 @@ object network extends OrphanCats, OrphanCatsKernel {
     override inline def predicate(a: Int): Boolean =
       0 <= a && a <= 1023
 
+  }
+  private[types] trait SystemPortNumberTypeClassInstances extends SystemPortNumberTypeClassInstance1 {
     @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
     inline given derivedSystemPortNumberEq[F[*]: CatsEq, G[*]: CatsEq](using eqActual: G[Int]): F[SystemPortNumber] = {
-      internalDef.contraCoercible(eqActual.asInstanceOf[cats.Eq[Int]])
+      internalDef.contraCoercible[cats.Eq, SystemPortNumber, Int, cats.Contravariant](eqActual.asInstanceOf[cats.Eq[Int]])
     }.asInstanceOf[F[SystemPortNumber]] // scalafix:ok DisableSyntax.asInstanceOf
-
+  }
+  private[types] trait SystemPortNumberTypeClassInstance1 extends SystemPortNumberTypeClassInstance2 {
+    @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
+    inline given derivedSystemPortNumberHash[F[*]: CatsHash, G[*]: CatsHash](using hashActual: G[Int]): F[SystemPortNumber] = {
+      internalDef.contraCoercible[cats.Hash, SystemPortNumber, Int, cats.Contravariant](hashActual.asInstanceOf[cats.Hash[Int]])
+    }.asInstanceOf[F[SystemPortNumber]] // scalafix:ok DisableSyntax.asInstanceOf
+  }
+  private[types] trait SystemPortNumberTypeClassInstance2 extends OrphanCats, OrphanCatsKernel {
     @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
     inline given derivedSystemPortNumberShow[F[*]: CatsShow, G[*]: CatsShow](using showActual: G[Int]): F[SystemPortNumber] = {
-      internalDef.contraCoercible(showActual.asInstanceOf[cats.Show[Int]])
+      internalDef.contraCoercible[cats.Show, SystemPortNumber, Int, cats.Contravariant](showActual.asInstanceOf[cats.Show[Int]])
     }.asInstanceOf[F[SystemPortNumber]] // scalafix:ok DisableSyntax.asInstanceOf
-
   }
 
   type NonSystemPortNumber = NonSystemPortNumber.Type
-  object NonSystemPortNumber extends Refined[Int] {
+  object NonSystemPortNumber extends Refined[Int], NonSystemPortNumberTypeClassInstances {
 
     override inline def invalidReason(a: Int): String =
       "It has to be Int between 1024 and 65535 (1024 <= NonSystemPortNumber <= 65535)"
@@ -142,20 +165,28 @@ object network extends OrphanCats, OrphanCatsKernel {
     override inline def predicate(a: Int): Boolean =
       1024 <= a && a <= 65535
 
+  }
+  private[types] trait NonSystemPortNumberTypeClassInstances extends NonSystemPortNumberTypeClassInstance1 {
     @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
     inline given derivedNonSystemPortNumberEq[F[*]: CatsEq, G[*]: CatsEq](using eqActual: G[Int]): F[NonSystemPortNumber] = {
-      internalDef.contraCoercible(eqActual.asInstanceOf[cats.Eq[Int]])
+      internalDef.contraCoercible[cats.Eq, NonSystemPortNumber, Int, cats.Contravariant](eqActual.asInstanceOf[cats.Eq[Int]])
     }.asInstanceOf[F[NonSystemPortNumber]] // scalafix:ok DisableSyntax.asInstanceOf
-
+  }
+  private[types] trait NonSystemPortNumberTypeClassInstance1 extends NonSystemPortNumberTypeClassInstance2 {
+    @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
+    inline given derivedNonSystemPortNumberHash[F[*]: CatsHash, G[*]: CatsHash](using hashActual: G[Int]): F[NonSystemPortNumber] = {
+      internalDef.contraCoercible[cats.Hash, NonSystemPortNumber, Int, cats.Contravariant](hashActual.asInstanceOf[cats.Hash[Int]])
+    }.asInstanceOf[F[NonSystemPortNumber]] // scalafix:ok DisableSyntax.asInstanceOf
+  }
+  private[types] trait NonSystemPortNumberTypeClassInstance2 extends OrphanCats, OrphanCatsKernel {
     @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
     inline given derivedNonSystemPortNumberShow[F[*]: CatsShow, G[*]: CatsShow](using showActual: G[Int]): F[NonSystemPortNumber] = {
-      internalDef.contraCoercible(showActual.asInstanceOf[cats.Show[Int]])
+      internalDef.contraCoercible[cats.Show, NonSystemPortNumber, Int, cats.Contravariant](showActual.asInstanceOf[cats.Show[Int]])
     }.asInstanceOf[F[NonSystemPortNumber]] // scalafix:ok DisableSyntax.asInstanceOf
-
   }
 
   type UserPortNumber = UserPortNumber.Type
-  object UserPortNumber extends Refined[Int] {
+  object UserPortNumber extends Refined[Int], UserPortNumberTypeClassInstances {
 
     override inline def invalidReason(a: Int): String =
       "It has to be Int between 1024 and 49151 (1024 <= UserPortNumber <= 49151)"
@@ -163,19 +194,28 @@ object network extends OrphanCats, OrphanCatsKernel {
     override inline def predicate(a: Int): Boolean =
       1024 <= a && a <= 49151
 
+  }
+  private[types] trait UserPortNumberTypeClassInstances extends UserPortNumberTypeClassInstance1 {
     @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
     inline given derivedUserPortNumberEq[F[*]: CatsEq, G[*]: CatsEq](using eqActual: G[Int]): F[UserPortNumber] = {
-      internalDef.contraCoercible(eqActual.asInstanceOf[cats.Eq[Int]])
+      internalDef.contraCoercible[cats.Eq, UserPortNumber, Int, cats.Contravariant](eqActual.asInstanceOf[cats.Eq[Int]])
     }.asInstanceOf[F[UserPortNumber]] // scalafix:ok DisableSyntax.asInstanceOf
-
+  }
+  private[types] trait UserPortNumberTypeClassInstance1 extends UserPortNumberTypeClassInstance2 {
+    @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
+    inline given derivedUserPortNumberHash[F[*]: CatsHash, G[*]: CatsHash](using hashActual: G[Int]): F[UserPortNumber] = {
+      internalDef.contraCoercible[cats.Hash, UserPortNumber, Int, cats.Contravariant](hashActual.asInstanceOf[cats.Hash[Int]])
+    }.asInstanceOf[F[UserPortNumber]] // scalafix:ok DisableSyntax.asInstanceOf
+  }
+  private[types] trait UserPortNumberTypeClassInstance2 extends OrphanCats, OrphanCatsKernel {
     @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
     inline given derivedUserPortNumberShow[F[*]: CatsShow, G[*]: CatsShow](using showActual: G[Int]): F[UserPortNumber] = {
-      internalDef.contraCoercible(showActual.asInstanceOf[cats.Show[Int]])
+      internalDef.contraCoercible[cats.Show, UserPortNumber, Int, cats.Contravariant](showActual.asInstanceOf[cats.Show[Int]])
     }.asInstanceOf[F[UserPortNumber]] // scalafix:ok DisableSyntax.asInstanceOf
   }
 
   type DynamicPortNumber = DynamicPortNumber.Type
-  object DynamicPortNumber extends Refined[Int] {
+  object DynamicPortNumber extends Refined[Int], DynamicPortNumberTypeClassInstances {
 
     override inline def invalidReason(a: Int): String =
       "It has to be Int between 49152 and 65535 (49152 <= DynamicPortNumber <= 65535)"
@@ -183,14 +223,23 @@ object network extends OrphanCats, OrphanCatsKernel {
     override inline def predicate(a: Int): Boolean =
       49152 <= a && a <= 65535
 
+  }
+  private[types] trait DynamicPortNumberTypeClassInstances extends DynamicPortNumberTypeClassInstance1 {
     @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
     inline given derivedDynamicPortNumberEq[F[*]: CatsEq, G[*]: CatsEq](using eqActual: G[Int]): F[DynamicPortNumber] = {
-      internalDef.contraCoercible(eqActual.asInstanceOf[cats.Eq[Int]])
+      internalDef.contraCoercible[cats.Eq, DynamicPortNumber, Int, cats.Contravariant](eqActual.asInstanceOf[cats.Eq[Int]])
     }.asInstanceOf[F[DynamicPortNumber]] // scalafix:ok DisableSyntax.asInstanceOf
-
+  }
+  private[types] trait DynamicPortNumberTypeClassInstance1 extends DynamicPortNumberTypeClassInstance2 {
+    @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
+    inline given derivedDynamicPortNumberHash[F[*]: CatsHash, G[*]: CatsHash](using hashActual: G[Int]): F[DynamicPortNumber] = {
+      internalDef.contraCoercible[cats.Hash, DynamicPortNumber, Int, cats.Contravariant](hashActual.asInstanceOf[cats.Hash[Int]])
+    }.asInstanceOf[F[DynamicPortNumber]] // scalafix:ok DisableSyntax.asInstanceOf
+  }
+  private[types] trait DynamicPortNumberTypeClassInstance2 extends OrphanCats, OrphanCatsKernel {
     @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
     inline given derivedDynamicPortNumberShow[F[*]: CatsShow, G[*]: CatsShow](using showActual: G[Int]): F[DynamicPortNumber] = {
-      internalDef.contraCoercible(showActual.asInstanceOf[cats.Show[Int]])
+      internalDef.contraCoercible[cats.Show, DynamicPortNumber, Int, cats.Contravariant](showActual.asInstanceOf[cats.Show[Int]])
     }.asInstanceOf[F[DynamicPortNumber]] // scalafix:ok DisableSyntax.asInstanceOf
 
   }

--- a/modules/test-refined4s-core-without-cats/shared/src/test/scala/refined4s/types/networkWithoutCatsSpec.scala
+++ b/modules/test-refined4s-core-without-cats/shared/src/test/scala/refined4s/types/networkWithoutCatsSpec.scala
@@ -9,11 +9,12 @@ import refined4s.ExpectedErrorMessages
   */
 object networkWithoutCatsSpec extends Properties {
   override def tests: List[Test] =
-    uriSpec.tests ++ urlSpec.tests ++ portNumberSpec.tests ++ systemPortNumberSpec.tests ++ nonSystemPortNumberSpec.tests ++ userPortNumberSpec.tests
+    uriSpec.tests ++ urlSpec.tests ++ portNumberSpec.tests ++ systemPortNumberSpec.tests ++ nonSystemPortNumberSpec.tests ++ userPortNumberSpec.tests ++ dynamicPortNumberSpec.tests
 
   object uriSpec {
     def tests: List[Test] = List(
-      example("test Eq[Uri]", testEq),
+      example("test   Eq[Uri]", testEq),
+      example("test Hash[Uri]", testHash),
       example("test Show[Uri]", testShow),
     )
 
@@ -24,6 +25,23 @@ object networkWithoutCatsSpec extends Properties {
       val actual = typeCheckErrors(
         """
          val _ = refined4s.types.network.Uri.derivedUriEq
+      """
+      ).map(_.message).mkString
+
+      (actual ==== expected)
+        .log(
+          """The actual error message doesn't start with the expected one.
+            |""".stripMargin
+        )
+    }
+
+    def testHash: Result = {
+      import scala.compiletime.testing.typeCheckErrors
+      val expected = ExpectedErrorMessages.missingHash
+
+      val actual = typeCheckErrors(
+        """
+         val _ = refined4s.types.network.Uri.derivedUriHash
       """
       ).map(_.message).mkString
 
@@ -54,7 +72,8 @@ object networkWithoutCatsSpec extends Properties {
 
   object urlSpec {
     def tests: List[Test] = List(
-      example("test Eq[Url]", testEq),
+      example("test   Eq[Url]", testEq),
+      example("test Hash[Url]", testHash),
       example("test Show[Url]", testShow),
     )
 
@@ -65,6 +84,23 @@ object networkWithoutCatsSpec extends Properties {
       val actual = typeCheckErrors(
         """
          val _ = refined4s.types.network.Url.derivedUrlEq
+      """
+      ).map(_.message).mkString
+
+      (actual ==== expected)
+        .log(
+          """The actual error message doesn't start with the expected one.
+            |""".stripMargin
+        )
+    }
+
+    def testHash: Result = {
+      import scala.compiletime.testing.typeCheckErrors
+      val expected = ExpectedErrorMessages.missingHash
+
+      val actual = typeCheckErrors(
+        """
+         val _ = refined4s.types.network.Url.derivedUrlHash
       """
       ).map(_.message).mkString
 
@@ -95,7 +131,8 @@ object networkWithoutCatsSpec extends Properties {
 
   object portNumberSpec {
     def tests: List[Test] = List(
-      example("test Eq[PortNumber]", testEq),
+      example("test   Eq[PortNumber]", testEq),
+      example("test Hash[PortNumber]", testHash),
       example("test Show[PortNumber]", testShow),
     )
 
@@ -106,6 +143,23 @@ object networkWithoutCatsSpec extends Properties {
       val actual = typeCheckErrors(
         """
          val _ = refined4s.types.network.PortNumber.derivedPortNumberEq
+      """
+      ).map(_.message).mkString
+
+      (actual ==== expected)
+        .log(
+          """The actual error message doesn't start with the expected one.
+            |""".stripMargin
+        )
+    }
+
+    def testHash: Result = {
+      import scala.compiletime.testing.typeCheckErrors
+      val expected = ExpectedErrorMessages.missingHash
+
+      val actual = typeCheckErrors(
+        """
+         val _ = refined4s.types.network.PortNumber.derivedPortNumberHash
       """
       ).map(_.message).mkString
 
@@ -136,7 +190,8 @@ object networkWithoutCatsSpec extends Properties {
 
   object systemPortNumberSpec {
     def tests: List[Test] = List(
-      example("test Eq[SystemPortNumber]", testEq),
+      example("test   Eq[SystemPortNumber]", testEq),
+      example("test Hash[SystemPortNumber]", testHash),
       example("test Show[SystemPortNumber]", testShow),
     )
 
@@ -147,6 +202,23 @@ object networkWithoutCatsSpec extends Properties {
       val actual = typeCheckErrors(
         """
          val _ = refined4s.types.network.SystemPortNumber.derivedSystemPortNumberEq
+      """
+      ).map(_.message).mkString
+
+      (actual ==== expected)
+        .log(
+          """The actual error message doesn't start with the expected one.
+            |""".stripMargin
+        )
+    }
+
+    def testHash: Result = {
+      import scala.compiletime.testing.typeCheckErrors
+      val expected = ExpectedErrorMessages.missingHash
+
+      val actual = typeCheckErrors(
+        """
+         val _ = refined4s.types.network.SystemPortNumber.derivedSystemPortNumberHash
       """
       ).map(_.message).mkString
 
@@ -177,7 +249,8 @@ object networkWithoutCatsSpec extends Properties {
 
   object nonSystemPortNumberSpec {
     def tests: List[Test] = List(
-      example("test Eq[NonSystemPortNumber]", testEq),
+      example("test   Eq[NonSystemPortNumber]", testEq),
+      example("test Hash[NonSystemPortNumber]", testHash),
       example("test Show[NonSystemPortNumber]", testShow),
     )
 
@@ -188,6 +261,23 @@ object networkWithoutCatsSpec extends Properties {
       val actual = typeCheckErrors(
         """
          val _ = refined4s.types.network.NonSystemPortNumber.derivedNonSystemPortNumberEq
+      """
+      ).map(_.message).mkString
+
+      (actual ==== expected)
+        .log(
+          """The actual error message doesn't start with the expected one.
+            |""".stripMargin
+        )
+    }
+
+    def testHash: Result = {
+      import scala.compiletime.testing.typeCheckErrors
+      val expected = ExpectedErrorMessages.missingHash
+
+      val actual = typeCheckErrors(
+        """
+         val _ = refined4s.types.network.NonSystemPortNumber.derivedNonSystemPortNumberHash
       """
       ).map(_.message).mkString
 
@@ -218,7 +308,8 @@ object networkWithoutCatsSpec extends Properties {
 
   object userPortNumberSpec {
     def tests: List[Test] = List(
-      example("test Eq[UserPortNumber]", testEq),
+      example("test   Eq[UserPortNumber]", testEq),
+      example("test Hash[UserPortNumber]", testHash),
       example("test Show[UserPortNumber]", testShow),
     )
 
@@ -229,6 +320,23 @@ object networkWithoutCatsSpec extends Properties {
       val actual = typeCheckErrors(
         """
          val _ = refined4s.types.network.UserPortNumber.derivedUserPortNumberEq
+      """
+      ).map(_.message).mkString
+
+      (actual ==== expected)
+        .log(
+          """The actual error message doesn't start with the expected one.
+            |""".stripMargin
+        )
+    }
+
+    def testHash: Result = {
+      import scala.compiletime.testing.typeCheckErrors
+      val expected = ExpectedErrorMessages.missingHash
+
+      val actual = typeCheckErrors(
+        """
+         val _ = refined4s.types.network.UserPortNumber.derivedUserPortNumberHash
       """
       ).map(_.message).mkString
 
@@ -257,4 +365,62 @@ object networkWithoutCatsSpec extends Properties {
     }
   }
 
+  object dynamicPortNumberSpec {
+    def tests: List[Test] = List(
+      example("test   Eq[DynamicPortNumber]", testEq),
+      example("test Hash[DynamicPortNumber]", testHash),
+      example("test Show[DynamicPortNumber]", testShow),
+    )
+
+    def testEq: Result = {
+      import scala.compiletime.testing.typeCheckErrors
+      val expected = ExpectedErrorMessages.missingEq
+
+      val actual = typeCheckErrors(
+        """
+         val _ = refined4s.types.network.DynamicPortNumber.derivedDynamicPortNumberEq
+      """
+      ).map(_.message).mkString
+
+      (actual ==== expected)
+        .log(
+          """The actual error message doesn't start with the expected one.
+            |""".stripMargin
+        )
+    }
+
+    def testHash: Result = {
+      import scala.compiletime.testing.typeCheckErrors
+      val expected = ExpectedErrorMessages.missingHash
+
+      val actual = typeCheckErrors(
+        """
+         val _ = refined4s.types.network.DynamicPortNumber.derivedDynamicPortNumberHash
+      """
+      ).map(_.message).mkString
+
+      (actual ==== expected)
+        .log(
+          """The actual error message doesn't start with the expected one.
+            |""".stripMargin
+        )
+    }
+
+    def testShow: Result = {
+      import scala.compiletime.testing.typeCheckErrors
+      val expected = ExpectedErrorMessages.missingShow
+
+      val actual = typeCheckErrors(
+        """
+         val _ = refined4s.types.network.DynamicPortNumber.derivedDynamicPortNumberShow
+      """
+      ).map(_.message).mkString
+
+      (actual ==== expected)
+        .log(
+          """The actual error message doesn't start with the expected one.
+            |""".stripMargin
+        )
+    }
+  }
 }


### PR DESCRIPTION
## Close #490: [`refined4s-core`] Add `cats.Hash` type class instances for `refined4s.types.network` with `orphan-cats`

- Core: Add derived `cats.Hash` instances for `network` types:
  - `Uri`
  - `Url`
  - `PortNumber`
  - `SystemPortNumber`
  - `NonSystemPortNumber`
  - `UserPortNumber`
  - `DynamicPortNumber`
- Refactor cats type class instances for `network`, restructuring them into hierarchical traits to resolve ambiguous `Eq` and `Hash` instances.
- Tests with cats: Add `Hash` property tests for `Uri`, `Url`, and all port number variants. Verify `.hash` and `##` delegate to underlying value `hashCode`.
- Tests without cats: Assert `derived*Hash` is not available without `cats` for all `network` types (also add `dynamicPortNumberSpec`).