### PR TITLE
Close #492: [`refined4s-core`] Add `cats.Hash` type class instances for `refined4s.types.time` with `orphan-cats`

### DIFF
--- a/modules/refined4s-cats/shared/src/test/scala/refined4s/modules/cats/derivation/types/allSpec.scala
+++ b/modules/refined4s-cats/shared/src/test/scala/refined4s/modules/cats/derivation/types/allSpec.scala
@@ -2648,6 +2648,7 @@ object allSpec extends Properties {
       def tests: List[Test] = List(
         property("test   Eq[Month] === case", testEq),
         property("test   Eq[Month] =!= case", testEqNotEqual),
+        property("test Hash[Month]", testHash),
         property("test Show[Month]", testShow),
       )
 
@@ -2688,6 +2689,24 @@ object allSpec extends Properties {
           Result.diffNamed("Month(value) =!= Month(different value)", input1, input2)(_ =!= _)
         }
 
+      def testHash: Property =
+        for {
+          month <- Gen.int(Range.linear(1, 12)).log("month")
+        } yield {
+          val input = Month.unsafeFrom(month)
+
+          val expected       = month.hashCode
+          val actual         = input.hash
+          val actualHashCode = input.##
+
+          Result.all(
+            List(
+              Result.diffNamed("Month(value).hash === month.hashCode", actual, expected)(_ === _),
+              Result.diffNamed("Month(value).## === month.hashCode", actualHashCode, expected)(_ === _),
+            )
+          )
+        }
+
       def testShow: Property =
         for {
           month <- Gen.int(Range.linear(1, 12)).log("month")
@@ -2705,6 +2724,7 @@ object allSpec extends Properties {
       def tests: List[Test] = List(
         property("test   Eq[Day] === case", testEq),
         property("test   Eq[Day] =!= case", testEqNotEqual),
+        property("test Hash[Day]", testHash),
         property("test Show[Day]", testShow),
       )
 
@@ -2745,6 +2765,24 @@ object allSpec extends Properties {
           Result.diffNamed("Day(value) =!= Day(different value)", input1, input2)(_ =!= _)
         }
 
+      def testHash: Property =
+        for {
+          day <- Gen.int(Range.linear(1, 31)).log("day")
+        } yield {
+          val input = Day.unsafeFrom(day)
+
+          val expected       = day.hashCode
+          val actual         = input.hash
+          val actualHashCode = input.##
+
+          Result.all(
+            List(
+              Result.diffNamed("Day(value).hash === day.hashCode", actual, expected)(_ === _),
+              Result.diffNamed("Day(value).## === day.hashCode", actualHashCode, expected)(_ === _),
+            )
+          )
+        }
+
       def testShow: Property =
         for {
           day <- Gen.int(Range.linear(1, 31)).log("day")
@@ -2762,6 +2800,7 @@ object allSpec extends Properties {
       def tests: List[Test] = List(
         property("test   Eq[Hour] === case", testEq),
         property("test   Eq[Hour] =!= case", testEqNotEqual),
+        property("test Hash[Hour]", testHash),
         property("test Show[Hour]", testShow),
       )
 
@@ -2802,6 +2841,24 @@ object allSpec extends Properties {
           Result.diffNamed("Hour(value) =!= Hour(different value)", input1, input2)(_ =!= _)
         }
 
+      def testHash: Property =
+        for {
+          hour <- Gen.int(Range.linear(0, 23)).log("hour")
+        } yield {
+          val input = Hour.unsafeFrom(hour)
+
+          val expected       = hour.hashCode
+          val actual         = input.hash
+          val actualHashCode = input.##
+
+          Result.all(
+            List(
+              Result.diffNamed("Hour(value).hash === hour.hashCode", actual, expected)(_ === _),
+              Result.diffNamed("Hour(value).## === hour.hashCode", actualHashCode, expected)(_ === _),
+            )
+          )
+        }
+
       def testShow: Property =
         for {
           hour <- Gen.int(Range.linear(0, 23)).log("hour")
@@ -2819,6 +2876,7 @@ object allSpec extends Properties {
       def tests: List[Test] = List(
         property("test   Eq[Minute] === case", testEq),
         property("test   Eq[Minute] =!= case", testEqNotEqual),
+        property("test Hash[Minute]", testHash),
         property("test Show[Minute]", testShow),
       )
 
@@ -2859,6 +2917,24 @@ object allSpec extends Properties {
           Result.diffNamed("Minute(value) =!= Minute(different value)", input1, input2)(_ =!= _)
         }
 
+      def testHash: Property =
+        for {
+          minute <- Gen.int(Range.linear(0, 59)).log("minute")
+        } yield {
+          val input = Minute.unsafeFrom(minute)
+
+          val expected       = minute.hashCode
+          val actual         = input.hash
+          val actualHashCode = input.##
+
+          Result.all(
+            List(
+              Result.diffNamed("Minute(value).hash === minute.hashCode", actual, expected)(_ === _),
+              Result.diffNamed("Minute(value).## === minute.hashCode", actualHashCode, expected)(_ === _),
+            )
+          )
+        }
+
       def testShow: Property =
         for {
           minute <- Gen.int(Range.linear(0, 59)).log("minute")
@@ -2876,6 +2952,7 @@ object allSpec extends Properties {
       def tests: List[Test] = List(
         property("test   Eq[Second] === case", testEq),
         property("test   Eq[Second] =!= case", testEqNotEqual),
+        property("test Hash[Second]", testHash),
         property("test Show[Second]", testShow),
       )
 
@@ -2916,6 +2993,24 @@ object allSpec extends Properties {
           Result.diffNamed("Second(value) =!= Second(different value)", input1, input2)(_ =!= _)
         }
 
+      def testHash: Property =
+        for {
+          second <- Gen.int(Range.linear(0, 59)).log("second")
+        } yield {
+          val input = Second.unsafeFrom(second)
+
+          val expected       = second.hashCode
+          val actual         = input.hash
+          val actualHashCode = input.##
+
+          Result.all(
+            List(
+              Result.diffNamed("Second(value).hash === second.hashCode", actual, expected)(_ === _),
+              Result.diffNamed("Second(value).## === second.hashCode", actualHashCode, expected)(_ === _),
+            )
+          )
+        }
+
       def testShow: Property =
         for {
           second <- Gen.int(Range.linear(0, 59)).log("second")
@@ -2933,6 +3028,7 @@ object allSpec extends Properties {
       def tests: List[Test] = List(
         property("test   Eq[Millis] === case", testEq),
         property("test   Eq[Millis] =!= case", testEqNotEqual),
+        property("test Hash[Millis]", testHash),
         property("test Show[Millis]", testShow),
       )
 
@@ -2971,6 +3067,24 @@ object allSpec extends Properties {
           val input1 = Millis.unsafeFrom(millis1)
           val input2 = Millis.unsafeFrom(millis2)
           Result.diffNamed("Millis(value) =!= Millis(different value)", input1, input2)(_ =!= _)
+        }
+
+      def testHash: Property =
+        for {
+          millis <- Gen.int(Range.linear(0, 999)).log("millis")
+        } yield {
+          val input = Millis.unsafeFrom(millis)
+
+          val expected       = millis.hashCode
+          val actual         = input.hash
+          val actualHashCode = input.##
+
+          Result.all(
+            List(
+              Result.diffNamed("Millis(value).hash === millis.hashCode", actual, expected)(_ === _),
+              Result.diffNamed("Millis(value).## === millis.hashCode", actualHashCode, expected)(_ === _),
+            )
+          )
         }
 
       def testShow: Property =

--- a/modules/refined4s-core/shared/src/main/scala/refined4s/types/time.scala
+++ b/modules/refined4s-core/shared/src/main/scala/refined4s/types/time.scala
@@ -27,9 +27,9 @@ trait time {
   final val Millis = time.Millis // scalafix:ok DisableSyntax.noFinalVal
 
 }
-object time extends OrphanCats, OrphanCatsKernel {
+object time {
   type Month = Month.Type
-  object Month extends InlinedNumeric[Int], MinMax[Int] {
+  object Month extends InlinedNumeric[Int], MinMax[Int], MonthTypeClassInstances {
 
     override inline val inlinedExpectedValue = "in the range from 1 to 12."
 
@@ -43,20 +43,28 @@ object time extends OrphanCats, OrphanCatsKernel {
 
     override def predicate(a: Int): Boolean = a >= 1 && a <= 12
 
+  }
+  private[types] trait MonthTypeClassInstances extends MonthTypeClassInstance1 {
     @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
     inline given derivedMonthEq[F[*]: CatsEq, G[*]: CatsEq](using eqActual: G[Int]): F[Month] = {
-      internalDef.contraCoercible(eqActual.asInstanceOf[cats.Eq[Int]])
+      internalDef.contraCoercible[cats.Eq, Month, Int, cats.Contravariant](eqActual.asInstanceOf[cats.Eq[Int]])
     }.asInstanceOf[F[Month]] // scalafix:ok DisableSyntax.asInstanceOf
-
+  }
+  private[types] trait MonthTypeClassInstance1 extends MonthTypeClassInstance2 {
+    @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
+    inline given derivedMonthHash[F[*]: CatsHash, G[*]: CatsHash](using hashActual: G[Int]): F[Month] = {
+      internalDef.contraCoercible[cats.Hash, Month, Int, cats.Contravariant](hashActual.asInstanceOf[cats.Hash[Int]])
+    }.asInstanceOf[F[Month]] // scalafix:ok DisableSyntax.asInstanceOf
+  }
+  private[types] trait MonthTypeClassInstance2 extends OrphanCats, OrphanCatsKernel {
     @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
     inline given derivedMonthShow[F[*]: CatsShow, G[*]: CatsShow](using showActual: G[Int]): F[Month] = {
-      internalDef.contraCoercible(showActual.asInstanceOf[cats.Show[Int]])
+      internalDef.contraCoercible[cats.Show, Month, Int, cats.Contravariant](showActual.asInstanceOf[cats.Show[Int]])
     }.asInstanceOf[F[Month]] // scalafix:ok DisableSyntax.asInstanceOf
-
   }
 
   type Day = Day.Type
-  object Day extends InlinedNumeric[Int], MinMax[Int] {
+  object Day extends InlinedNumeric[Int], MinMax[Int], DayTypeClassInstances {
 
     override inline val inlinedExpectedValue = "in the range from 1 to 31."
 
@@ -70,20 +78,28 @@ object time extends OrphanCats, OrphanCatsKernel {
 
     override def predicate(a: Int): Boolean = a >= 1 && a <= 31
 
+  }
+  private[types] trait DayTypeClassInstances extends DayTypeClassInstance1 {
     @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
     inline given derivedDayEq[F[*]: CatsEq, G[*]: CatsEq](using eqActual: G[Int]): F[Day] = {
-      internalDef.contraCoercible(eqActual.asInstanceOf[cats.Eq[Int]])
+      internalDef.contraCoercible[cats.Eq, Day, Int, cats.Contravariant](eqActual.asInstanceOf[cats.Eq[Int]])
     }.asInstanceOf[F[Day]] // scalafix:ok DisableSyntax.asInstanceOf
-
+  }
+  private[types] trait DayTypeClassInstance1 extends DayTypeClassInstance2 {
+    @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
+    inline given derivedDayHash[F[*]: CatsHash, G[*]: CatsHash](using hashActual: G[Int]): F[Day] = {
+      internalDef.contraCoercible[cats.Hash, Day, Int, cats.Contravariant](hashActual.asInstanceOf[cats.Hash[Int]])
+    }.asInstanceOf[F[Day]] // scalafix:ok DisableSyntax.asInstanceOf
+  }
+  private[types] trait DayTypeClassInstance2 extends OrphanCats, OrphanCatsKernel {
     @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
     inline given derivedDayShow[F[*]: CatsShow, G[*]: CatsShow](using showActual: G[Int]): F[Day] = {
-      internalDef.contraCoercible(showActual.asInstanceOf[cats.Show[Int]])
+      internalDef.contraCoercible[cats.Show, Day, Int, cats.Contravariant](showActual.asInstanceOf[cats.Show[Int]])
     }.asInstanceOf[F[Day]] // scalafix:ok DisableSyntax.asInstanceOf
-
   }
 
   type Hour = Hour.Type
-  object Hour extends InlinedNumeric[Int], MinMax[Int] {
+  object Hour extends InlinedNumeric[Int], MinMax[Int], HourTypeClassInstances {
 
     override inline val inlinedExpectedValue = "in the range from 0 to 23."
 
@@ -97,20 +113,28 @@ object time extends OrphanCats, OrphanCatsKernel {
 
     override def predicate(a: Int): Boolean = a >= 0 && a <= 23
 
+  }
+  private[types] trait HourTypeClassInstances extends HourTypeClassInstance1 {
     @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
     inline given derivedHourEq[F[*]: CatsEq, G[*]: CatsEq](using eqActual: G[Int]): F[Hour] = {
-      internalDef.contraCoercible(eqActual.asInstanceOf[cats.Eq[Int]])
+      internalDef.contraCoercible[cats.Eq, Hour, Int, cats.Contravariant](eqActual.asInstanceOf[cats.Eq[Int]])
     }.asInstanceOf[F[Hour]] // scalafix:ok DisableSyntax.asInstanceOf
-
+  }
+  private[types] trait HourTypeClassInstance1 extends HourTypeClassInstance2 {
+    @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
+    inline given derivedHourHash[F[*]: CatsHash, G[*]: CatsHash](using hashActual: G[Int]): F[Hour] = {
+      internalDef.contraCoercible[cats.Hash, Hour, Int, cats.Contravariant](hashActual.asInstanceOf[cats.Hash[Int]])
+    }.asInstanceOf[F[Hour]] // scalafix:ok DisableSyntax.asInstanceOf
+  }
+  private[types] trait HourTypeClassInstance2 extends OrphanCats, OrphanCatsKernel {
     @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
     inline given derivedHourShow[F[*]: CatsShow, G[*]: CatsShow](using showActual: G[Int]): F[Hour] = {
-      internalDef.contraCoercible(showActual.asInstanceOf[cats.Show[Int]])
+      internalDef.contraCoercible[cats.Show, Hour, Int, cats.Contravariant](showActual.asInstanceOf[cats.Show[Int]])
     }.asInstanceOf[F[Hour]] // scalafix:ok DisableSyntax.asInstanceOf
-
   }
 
   type Minute = Minute.Type
-  object Minute extends InlinedNumeric[Int], MinMax[Int] {
+  object Minute extends InlinedNumeric[Int], MinMax[Int], MinuteTypeClassInstances {
 
     override inline val inlinedExpectedValue = "in the range from 0 to 59."
 
@@ -124,20 +148,28 @@ object time extends OrphanCats, OrphanCatsKernel {
 
     override def predicate(a: Int): Boolean = a >= 0 && a <= 59
 
+  }
+  private[types] trait MinuteTypeClassInstances extends MinuteTypeClassInstance1 {
     @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
     inline given derivedMinuteEq[F[*]: CatsEq, G[*]: CatsEq](using eqActual: G[Int]): F[Minute] = {
-      internalDef.contraCoercible(eqActual.asInstanceOf[cats.Eq[Int]])
+      internalDef.contraCoercible[cats.Eq, Minute, Int, cats.Contravariant](eqActual.asInstanceOf[cats.Eq[Int]])
     }.asInstanceOf[F[Minute]] // scalafix:ok DisableSyntax.asInstanceOf
-
+  }
+  private[types] trait MinuteTypeClassInstance1 extends MinuteTypeClassInstance2 {
+    @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
+    inline given derivedMinuteHash[F[*]: CatsHash, G[*]: CatsHash](using hashActual: G[Int]): F[Minute] = {
+      internalDef.contraCoercible[cats.Hash, Minute, Int, cats.Contravariant](hashActual.asInstanceOf[cats.Hash[Int]])
+    }.asInstanceOf[F[Minute]] // scalafix:ok DisableSyntax.asInstanceOf
+  }
+  private[types] trait MinuteTypeClassInstance2 extends OrphanCats, OrphanCatsKernel {
     @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
     inline given derivedMinuteShow[F[*]: CatsShow, G[*]: CatsShow](using showActual: G[Int]): F[Minute] = {
-      internalDef.contraCoercible(showActual.asInstanceOf[cats.Show[Int]])
+      internalDef.contraCoercible[cats.Show, Minute, Int, cats.Contravariant](showActual.asInstanceOf[cats.Show[Int]])
     }.asInstanceOf[F[Minute]] // scalafix:ok DisableSyntax.asInstanceOf
-
   }
 
   type Second = Second.Type
-  object Second extends InlinedNumeric[Int], MinMax[Int] {
+  object Second extends InlinedNumeric[Int], MinMax[Int], SecondTypeClassInstances {
 
     override inline val inlinedExpectedValue = "in the range from 0 to 59."
 
@@ -151,20 +183,28 @@ object time extends OrphanCats, OrphanCatsKernel {
 
     override def predicate(a: Int): Boolean = a >= 0 && a <= 59
 
+  }
+  private[types] trait SecondTypeClassInstances extends SecondTypeClassInstance1 {
     @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
     inline given derivedSecondEq[F[*]: CatsEq, G[*]: CatsEq](using eqActual: G[Int]): F[Second] = {
-      internalDef.contraCoercible(eqActual.asInstanceOf[cats.Eq[Int]])
+      internalDef.contraCoercible[cats.Eq, Second, Int, cats.Contravariant](eqActual.asInstanceOf[cats.Eq[Int]])
     }.asInstanceOf[F[Second]] // scalafix:ok DisableSyntax.asInstanceOf
-
+  }
+  private[types] trait SecondTypeClassInstance1 extends SecondTypeClassInstance2 {
+    @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
+    inline given derivedSecondHash[F[*]: CatsHash, G[*]: CatsHash](using hashActual: G[Int]): F[Second] = {
+      internalDef.contraCoercible[cats.Hash, Second, Int, cats.Contravariant](hashActual.asInstanceOf[cats.Hash[Int]])
+    }.asInstanceOf[F[Second]] // scalafix:ok DisableSyntax.asInstanceOf
+  }
+  private[types] trait SecondTypeClassInstance2 extends OrphanCats, OrphanCatsKernel {
     @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
     inline given derivedSecondShow[F[*]: CatsShow, G[*]: CatsShow](using showActual: G[Int]): F[Second] = {
-      internalDef.contraCoercible(showActual.asInstanceOf[cats.Show[Int]])
+      internalDef.contraCoercible[cats.Show, Second, Int, cats.Contravariant](showActual.asInstanceOf[cats.Show[Int]])
     }.asInstanceOf[F[Second]] // scalafix:ok DisableSyntax.asInstanceOf
-
   }
 
   type Millis = Millis.Type
-  object Millis extends InlinedNumeric[Int], MinMax[Int] {
+  object Millis extends InlinedNumeric[Int], MinMax[Int], MillisTypeClassInstances {
 
     override inline val inlinedExpectedValue = "in the range from 0 to 999."
 
@@ -178,16 +218,24 @@ object time extends OrphanCats, OrphanCatsKernel {
 
     override def predicate(a: Int): Boolean = a >= 0 && a <= 999
 
+  }
+  private[types] trait MillisTypeClassInstances extends MillisTypeClassInstance1 {
     @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
     inline given derivedMillisEq[F[*]: CatsEq, G[*]: CatsEq](using eqActual: G[Int]): F[Millis] = {
-      internalDef.contraCoercible(eqActual.asInstanceOf[cats.Eq[Int]])
+      internalDef.contraCoercible[cats.Eq, Millis, Int, cats.Contravariant](eqActual.asInstanceOf[cats.Eq[Int]])
     }.asInstanceOf[F[Millis]] // scalafix:ok DisableSyntax.asInstanceOf
-
+  }
+  private[types] trait MillisTypeClassInstance1 extends MillisTypeClassInstance2 {
+    @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
+    inline given derivedMillisHash[F[*]: CatsHash, G[*]: CatsHash](using hashActual: G[Int]): F[Millis] = {
+      internalDef.contraCoercible[cats.Hash, Millis, Int, cats.Contravariant](hashActual.asInstanceOf[cats.Hash[Int]])
+    }.asInstanceOf[F[Millis]] // scalafix:ok DisableSyntax.asInstanceOf
+  }
+  private[types] trait MillisTypeClassInstance2 extends OrphanCats, OrphanCatsKernel {
     @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
     inline given derivedMillisShow[F[*]: CatsShow, G[*]: CatsShow](using showActual: G[Int]): F[Millis] = {
-      internalDef.contraCoercible(showActual.asInstanceOf[cats.Show[Int]])
+      internalDef.contraCoercible[cats.Show, Millis, Int, cats.Contravariant](showActual.asInstanceOf[cats.Show[Int]])
     }.asInstanceOf[F[Millis]] // scalafix:ok DisableSyntax.asInstanceOf
-
   }
 
 }

--- a/modules/test-refined4s-core-without-cats/shared/src/test/scala/refined4s/types/timeWithoutCatsSpec.scala
+++ b/modules/test-refined4s-core-without-cats/shared/src/test/scala/refined4s/types/timeWithoutCatsSpec.scala
@@ -13,7 +13,8 @@ object timeWithoutCatsSpec extends Properties {
 
   object monthSpec {
     def tests: List[Test] = List(
-      example("test Eq[Month]", testEq),
+      example("test   Eq[Month]", testEq),
+      example("test Hash[Month]", testHash),
       example("test Show[Month]", testShow),
     )
 
@@ -24,6 +25,23 @@ object timeWithoutCatsSpec extends Properties {
       val actual = typeCheckErrors(
         """
          val _ = refined4s.types.time.Month.derivedMonthEq
+      """
+      ).map(_.message).mkString
+
+      (actual ==== expected)
+        .log(
+          """The actual error message doesn't start with the expected one.
+            |""".stripMargin
+        )
+    }
+
+    def testHash: Result = {
+      import scala.compiletime.testing.typeCheckErrors
+      val expected = ExpectedErrorMessages.missingHash
+
+      val actual = typeCheckErrors(
+        """
+         val _ = refined4s.types.time.Month.derivedMonthHash
       """
       ).map(_.message).mkString
 
@@ -54,7 +72,8 @@ object timeWithoutCatsSpec extends Properties {
 
   object daySpec {
     def tests: List[Test] = List(
-      example("test Eq[Day]", testEq),
+      example("test   Eq[Day]", testEq),
+      example("test Hash[Day]", testHash),
       example("test Show[Day]", testShow),
     )
 
@@ -65,6 +84,23 @@ object timeWithoutCatsSpec extends Properties {
       val actual = typeCheckErrors(
         """
          val _ = refined4s.types.time.Day.derivedDayEq
+      """
+      ).map(_.message).mkString
+
+      (actual ==== expected)
+        .log(
+          """The actual error message doesn't start with the expected one.
+            |""".stripMargin
+        )
+    }
+
+    def testHash: Result = {
+      import scala.compiletime.testing.typeCheckErrors
+      val expected = ExpectedErrorMessages.missingHash
+
+      val actual = typeCheckErrors(
+        """
+         val _ = refined4s.types.time.Day.derivedDayHash
       """
       ).map(_.message).mkString
 
@@ -95,7 +131,8 @@ object timeWithoutCatsSpec extends Properties {
 
   object hourSpec {
     def tests: List[Test] = List(
-      example("test Eq[Hour]", testEq),
+      example("test   Eq[Hour]", testEq),
+      example("test Hash[Hour]", testHash),
       example("test Show[Hour]", testShow),
     )
 
@@ -106,6 +143,23 @@ object timeWithoutCatsSpec extends Properties {
       val actual = typeCheckErrors(
         """
          val _ = refined4s.types.time.Hour.derivedHourEq
+      """
+      ).map(_.message).mkString
+
+      (actual ==== expected)
+        .log(
+          """The actual error message doesn't start with the expected one.
+            |""".stripMargin
+        )
+    }
+
+    def testHash: Result = {
+      import scala.compiletime.testing.typeCheckErrors
+      val expected = ExpectedErrorMessages.missingHash
+
+      val actual = typeCheckErrors(
+        """
+         val _ = refined4s.types.time.Hour.derivedHourHash
       """
       ).map(_.message).mkString
 
@@ -136,7 +190,8 @@ object timeWithoutCatsSpec extends Properties {
 
   object minuteSpec {
     def tests: List[Test] = List(
-      example("test Eq[Minute]", testEq),
+      example("test   Eq[Minute]", testEq),
+      example("test Hash[Minute]", testHash),
       example("test Show[Minute]", testShow),
     )
 
@@ -147,6 +202,23 @@ object timeWithoutCatsSpec extends Properties {
       val actual = typeCheckErrors(
         """
          val _ = refined4s.types.time.Minute.derivedMinuteEq
+      """
+      ).map(_.message).mkString
+
+      (actual ==== expected)
+        .log(
+          """The actual error message doesn't start with the expected one.
+            |""".stripMargin
+        )
+    }
+
+    def testHash: Result = {
+      import scala.compiletime.testing.typeCheckErrors
+      val expected = ExpectedErrorMessages.missingHash
+
+      val actual = typeCheckErrors(
+        """
+         val _ = refined4s.types.time.Minute.derivedMinuteHash
       """
       ).map(_.message).mkString
 
@@ -177,7 +249,8 @@ object timeWithoutCatsSpec extends Properties {
 
   object secondSpec {
     def tests: List[Test] = List(
-      example("test Eq[Second]", testEq),
+      example("test   Eq[Second]", testEq),
+      example("test Hash[Second]", testHash),
       example("test Show[Second]", testShow),
     )
 
@@ -188,6 +261,23 @@ object timeWithoutCatsSpec extends Properties {
       val actual = typeCheckErrors(
         """
          val _ = refined4s.types.time.Second.derivedSecondEq
+      """
+      ).map(_.message).mkString
+
+      (actual ==== expected)
+        .log(
+          """The actual error message doesn't start with the expected one.
+            |""".stripMargin
+        )
+    }
+
+    def testHash: Result = {
+      import scala.compiletime.testing.typeCheckErrors
+      val expected = ExpectedErrorMessages.missingHash
+
+      val actual = typeCheckErrors(
+        """
+         val _ = refined4s.types.time.Second.derivedSecondHash
       """
       ).map(_.message).mkString
 
@@ -218,7 +308,8 @@ object timeWithoutCatsSpec extends Properties {
 
   object millisSpec {
     def tests: List[Test] = List(
-      example("test Eq[Millis]", testEq),
+      example("test   Eq[Millis]", testEq),
+      example("test Hash[Millis]", testHash),
       example("test Show[Millis]", testShow),
     )
 
@@ -229,6 +320,23 @@ object timeWithoutCatsSpec extends Properties {
       val actual = typeCheckErrors(
         """
          val _ = refined4s.types.time.Millis.derivedMillisEq
+      """
+      ).map(_.message).mkString
+
+      (actual ==== expected)
+        .log(
+          """The actual error message doesn't start with the expected one.
+            |""".stripMargin
+        )
+    }
+
+    def testHash: Result = {
+      import scala.compiletime.testing.typeCheckErrors
+      val expected = ExpectedErrorMessages.missingHash
+
+      val actual = typeCheckErrors(
+        """
+         val _ = refined4s.types.time.Millis.derivedMillisHash
       """
       ).map(_.message).mkString
 


### PR DESCRIPTION
## Close #492: [`refined4s-core`] Add `cats.Hash` type class instances for `refined4s.types.time` with `orphan-cats`

- Add `Hash` type class instances for `Month`, `Day`, `Hour`, `Minute`, `Second` and `Millis` types.
- Add comprehensive `Hash` tests for all `time` types