### PR TITLE
Bump sbt plugins

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,12 +1,12 @@
-addSbtPlugin("com.github.sbt" % "sbt-ci-release" % "1.11.1")
+addSbtPlugin("com.github.sbt" % "sbt-ci-release" % "1.11.2")
 
 addSbtPlugin("org.wartremover" % "sbt-wartremover" % "3.4.0")
 
-addSbtPlugin("ch.epfl.scala" % "sbt-scalafix"  % "0.12.1")
-addSbtPlugin("org.scalameta" % "sbt-scalafmt"  % "2.5.2")
+addSbtPlugin("ch.epfl.scala" % "sbt-scalafix"  % "0.14.3")
+addSbtPlugin("org.scalameta" % "sbt-scalafmt"  % "2.5.5")
 addSbtPlugin("org.scoverage" % "sbt-scoverage" % "2.2.2")
-addSbtPlugin("org.scalameta" % "sbt-mdoc"      % "2.5.4")
-addSbtPlugin("io.kevinlee"   % "sbt-docusaur"  % "0.16.0")
+addSbtPlugin("org.scalameta" % "sbt-mdoc"      % "2.7.2")
+addSbtPlugin("io.kevinlee"   % "sbt-docusaur"  % "0.17.0")
 
 addSbtPlugin("org.scala-js"       % "sbt-scalajs"              % "1.18.2")
 addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject" % "1.3.2")


### PR DESCRIPTION
Bump sbt plugins

- `sbt-ci-release`: `1.11.1` -> `1.11.2`
- `sbt-scalafix`: `0.12.1` -> `0.14.3`
- `sbt-scalafmt`: `2.5.2` -> `2.5.5`
- `sbt-mdoc`: `2.5.4` -> `2.7.2`
- `sbt-docusaur`: `0.16.0` -> `0.17.0`