### PR TITLE
Close #491: [`refined4s-core`] Add `cats.Hash` type class instances for `refined4s.types.numeric` with `orphan-cats`

### DIFF
--- a/modules/refined4s-cats/shared/src/test/scala/refined4s/modules/cats/derivation/types/allSpec.scala
+++ b/modules/refined4s-cats/shared/src/test/scala/refined4s/modules/cats/derivation/types/allSpec.scala
@@ -39,6 +39,7 @@ object allSpec extends Properties {
     def tests: List[Test] = List(
       property("test   Eq[NegInt] === case", testEq),
       property("test   Eq[NegInt] =!= case", testEqNotEqual),
+      property("test Hash[NegInt]", testHash),
       property("test Show[NegInt]", testShow),
     )
 
@@ -76,6 +77,24 @@ object allSpec extends Properties {
         Result.diffNamed("NegInt(value) =!= NegInt(value)", input1, input2)(_ =!= _)
       }
 
+    def testHash: Property =
+      for {
+        n <- Gen.int(Range.linear(-1, Int.MinValue)).log("n")
+      } yield {
+        val input = NegInt.unsafeFrom(n)
+
+        val expected       = n.hashCode
+        val actual         = input.hash
+        val actualHashCode = input.##
+
+        Result.all(
+          List(
+            Result.diffNamed("NegInt(n).hash === n.hashCode", actual, expected)(_ === _),
+            Result.diffNamed("NegInt(n).## === n.hashCode", actualHashCode, expected)(_ === _),
+          )
+        )
+      }
+
     def testShow: Property =
       for {
         n <- Gen.int(Range.linear(-1, Int.MinValue)).log("n")
@@ -94,6 +113,7 @@ object allSpec extends Properties {
     def tests: List[Test] = List(
       property("test   Eq[NonNegInt] === case", testEq),
       property("test   Eq[NonNegInt] =!= case", testEqNotEqual),
+      property("test Hash[NonNegInt]", testHash),
       property("test Show[NonNegInt]", testShow),
     )
 
@@ -131,6 +151,24 @@ object allSpec extends Properties {
         Result.diffNamed("NonNegInt(value) =!= NonNegInt(value)", input1, input2)(_ =!= _)
       }
 
+    def testHash: Property =
+      for {
+        n <- Gen.int(Range.linear(0, Int.MaxValue)).log("n")
+      } yield {
+        val input = NonNegInt.unsafeFrom(n)
+
+        val expected       = n.hashCode
+        val actual         = input.hash
+        val actualHashCode = input.##
+
+        Result.all(
+          List(
+            Result.diffNamed("NonNegInt(n).hash === n.hashCode", actual, expected)(_ === _),
+            Result.diffNamed("NonNegInt(n).## === n.hashCode", actualHashCode, expected)(_ === _),
+          )
+        )
+      }
+
     def testShow: Property =
       for {
         n <- Gen.int(Range.linear(0, Int.MaxValue)).log("n")
@@ -149,6 +187,7 @@ object allSpec extends Properties {
     def tests: List[Test] = List(
       property("test   Eq[PosInt] === case", testEq),
       property("test   Eq[PosInt] =!= case", testEqNotEqual),
+      property("test Hash[PosInt]", testHash),
       property("test Show[PosInt]", testShow),
     )
 
@@ -186,6 +225,24 @@ object allSpec extends Properties {
         Result.diffNamed("PosInt(value) =!= PosInt(value)", input1, input2)(_ =!= _)
       }
 
+    def testHash: Property =
+      for {
+        n <- Gen.int(Range.linear(1, Int.MaxValue)).log("n")
+      } yield {
+        val input = PosInt.unsafeFrom(n)
+
+        val expected       = n.hashCode
+        val actual         = input.hash
+        val actualHashCode = input.##
+
+        Result.all(
+          List(
+            Result.diffNamed("PosInt(n).hash === n.hashCode", actual, expected)(_ === _),
+            Result.diffNamed("PosInt(n).## === n.hashCode", actualHashCode, expected)(_ === _),
+          )
+        )
+      }
+
     def testShow: Property =
       for {
         n <- Gen.int(Range.linear(1, Int.MaxValue)).log("n")
@@ -203,6 +260,7 @@ object allSpec extends Properties {
     def tests: List[Test] = List(
       property("test   Eq[NonPosInt] === case", testEq),
       property("test   Eq[NonPosInt] =!= case", testEqNotEqual),
+      property("test Hash[NonPosInt]", testHash),
       property("test Show[NonPosInt]", testShow),
     )
 
@@ -240,6 +298,24 @@ object allSpec extends Properties {
         Result.diffNamed("NonPosInt(value) =!= NonPosInt(value)", input1, input2)(_ =!= _)
       }
 
+    def testHash: Property =
+      for {
+        n <- Gen.int(Range.linear(0, Int.MinValue)).log("n")
+      } yield {
+        val input = NonPosInt.unsafeFrom(n)
+
+        val expected       = n.hashCode
+        val actual         = input.hash
+        val actualHashCode = input.##
+
+        Result.all(
+          List(
+            Result.diffNamed("NonPosInt(n).hash === n.hashCode", actual, expected)(_ === _),
+            Result.diffNamed("NonPosInt(n).## === n.hashCode", actualHashCode, expected)(_ === _),
+          )
+        )
+      }
+
     def testShow: Property =
       for {
         n <- Gen.int(Range.linear(0, Int.MinValue)).log("n")
@@ -258,6 +334,7 @@ object allSpec extends Properties {
     def tests: List[Test] = List(
       property("test   Eq[NegLong] === case", testEq),
       property("test   Eq[NegLong] =!= case", testEqNotEqual),
+      property("test Hash[NegLong]", testHash),
       property("test Show[NegLong]", testShow),
     )
 
@@ -295,6 +372,24 @@ object allSpec extends Properties {
         Result.diffNamed("NegLong(value) =!= NegLong(value)", input1, input2)(_ =!= _)
       }
 
+    def testHash: Property =
+      for {
+        n <- Gen.long(Range.linear(-1L, Long.MinValue)).log("n")
+      } yield {
+        val input = NegLong.unsafeFrom(n)
+
+        val expected       = n.hashCode
+        val actual         = input.hash
+        val actualHashCode = input.##
+
+        Result.all(
+          List(
+            Result.diffNamed("NegLong(n).hash === n.hashCode", actual, expected)(_ === _),
+            Result.diffNamed("NegLong(n).## === n.hashCode", actualHashCode, expected)(_ === _),
+          )
+        )
+      }
+
     def testShow: Property =
       for {
         n <- Gen.long(Range.linear(-1L, Long.MinValue)).log("n")
@@ -314,6 +409,7 @@ object allSpec extends Properties {
     def tests: List[Test] = List(
       property("test   Eq[NonNegLong] === case", testEq),
       property("test   Eq[NonNegLong] =!= case", testEqNotEqual),
+      property("test Hash[NonNegLong]", testHash),
       property("test Show[NonNegLong]", testShow),
     )
 
@@ -351,6 +447,24 @@ object allSpec extends Properties {
         Result.diffNamed("NonNegLong(value) =!= NonNegLong(value)", input1, input2)(_ =!= _)
       }
 
+    def testHash: Property =
+      for {
+        n <- Gen.long(Range.linear(0L, Long.MaxValue)).log("n")
+      } yield {
+        val input = NonNegLong.unsafeFrom(n)
+
+        val expected       = n.hashCode
+        val actual         = input.hash
+        val actualHashCode = input.##
+
+        Result.all(
+          List(
+            Result.diffNamed("NonNegLong(n).hash === n.hashCode", actual, expected)(_ === _),
+            Result.diffNamed("NonNegLong(n).## === n.hashCode", actualHashCode, expected)(_ === _),
+          )
+        )
+      }
+
     def testShow: Property =
       for {
         n <- Gen.long(Range.linear(0L, Long.MaxValue)).log("n")
@@ -369,6 +483,7 @@ object allSpec extends Properties {
     def tests: List[Test] = List(
       property("test   Eq[PosLong] === case", testEq),
       property("test   Eq[PosLong] =!= case", testEqNotEqual),
+      property("test Hash[PosLong]", testHash),
       property("test Show[PosLong]", testShow),
     )
 
@@ -406,6 +521,24 @@ object allSpec extends Properties {
         Result.diffNamed("PosLong(value) =!= PosLong(value)", input1, input2)(_ =!= _)
       }
 
+    def testHash: Property =
+      for {
+        n <- Gen.long(Range.linear(1L, Long.MaxValue)).log("n")
+      } yield {
+        val input = PosLong.unsafeFrom(n)
+
+        val expected       = n.hashCode
+        val actual         = input.hash
+        val actualHashCode = input.##
+
+        Result.all(
+          List(
+            Result.diffNamed("PosLong(n).hash === n.hashCode", actual, expected)(_ === _),
+            Result.diffNamed("PosLong(n).## === n.hashCode", actualHashCode, expected)(_ === _),
+          )
+        )
+      }
+
     def testShow: Property =
       for {
         n <- Gen.long(Range.linear(1L, Long.MaxValue)).log("n")
@@ -425,6 +558,7 @@ object allSpec extends Properties {
     def tests: List[Test] = List(
       property("test   Eq[NonPosLong] === case", testEq),
       property("test   Eq[NonPosLong] =!= case", testEqNotEqual),
+      property("test Hash[NonPosLong]", testHash),
       property("test Show[NonPosLong]", testShow),
     )
 
@@ -462,6 +596,24 @@ object allSpec extends Properties {
         Result.diffNamed("NonPosLong(value) =!= NonPosLong(value)", input1, input2)(_ =!= _)
       }
 
+    def testHash: Property =
+      for {
+        n <- Gen.long(Range.linear(0, Long.MinValue)).log("n")
+      } yield {
+        val input = NonPosLong.unsafeFrom(n)
+
+        val expected       = n.hashCode
+        val actual         = input.hash
+        val actualHashCode = input.##
+
+        Result.all(
+          List(
+            Result.diffNamed("NonPosLong(n).hash === n.hashCode", actual, expected)(_ === _),
+            Result.diffNamed("NonPosLong(n).## === n.hashCode", actualHashCode, expected)(_ === _),
+          )
+        )
+      }
+
     def testShow: Property =
       for {
         n <- Gen.long(Range.linear(0, Long.MinValue)).log("n")
@@ -481,6 +633,7 @@ object allSpec extends Properties {
     def tests: List[Test] = List(
       property("test   Eq[NegShort] === case", testEq),
       property("test   Eq[NegShort] =!= case", testEqNotEqual),
+      property("test Hash[NegShort]", testHash),
       property("test Show[NegShort]", testShow),
     )
 
@@ -520,6 +673,24 @@ object allSpec extends Properties {
         Result.diffNamed("NegShort(value) =!= NegShort(value)", input1, input2)(_ =!= _)
       }
 
+    def testHash: Property =
+      for {
+        n <- Gen.short(Range.linear(-1, Short.MinValue)).log("n")
+      } yield {
+        val input = NegShort.unsafeFrom(n)
+
+        val expected       = n.hashCode
+        val actual         = input.hash
+        val actualHashCode = input.##
+
+        Result.all(
+          List(
+            Result.diffNamed("NegShort(n).hash === n.hashCode", actual, expected)(_ === _),
+            Result.diffNamed("NegShort(n).## === n.hashCode", actualHashCode, expected)(_ === _),
+          )
+        )
+      }
+
     def testShow: Property =
       for {
         n <- Gen.short(Range.linear(-1, Short.MinValue)).log("n")
@@ -539,6 +710,7 @@ object allSpec extends Properties {
     def tests: List[Test] = List(
       property("test   Eq[NonNegShort] === case", testEq),
       property("test   Eq[NonNegShort] =!= case", testEqNotEqual),
+      property("test Hash[NonNegShort]", testHash),
       property("test Show[NonNegShort]", testShow),
     )
 
@@ -578,6 +750,24 @@ object allSpec extends Properties {
         Result.diffNamed("NonNegShort(value) =!= NonNegShort(value)", input1, input2)(_ =!= _)
       }
 
+    def testHash: Property =
+      for {
+        n <- Gen.short(Range.linear(0, Short.MaxValue)).log("n")
+      } yield {
+        val input = NonNegShort.unsafeFrom(n)
+
+        val expected       = n.hashCode
+        val actual         = input.hash
+        val actualHashCode = input.##
+
+        Result.all(
+          List(
+            Result.diffNamed("NonNegShort(n).hash === n.hashCode", actual, expected)(_ === _),
+            Result.diffNamed("NonNegShort(n).## === n.hashCode", actualHashCode, expected)(_ === _),
+          )
+        )
+      }
+
     def testShow: Property =
       for {
         n <- Gen.short(Range.linear(0, Short.MaxValue)).log("n")
@@ -597,6 +787,7 @@ object allSpec extends Properties {
     def tests: List[Test] = List(
       property("test   Eq[PosShort] === case", testEq),
       property("test   Eq[PosShort] =!= case", testEqNotEqual),
+      property("test Hash[PosShort]", testHash),
       property("test Show[PosShort]", testShow),
     )
 
@@ -636,6 +827,24 @@ object allSpec extends Properties {
         Result.diffNamed("PosShort(value) =!= PosShort(value)", input1, input2)(_ =!= _)
       }
 
+    def testHash: Property =
+      for {
+        n <- Gen.short(Range.linear(1, Short.MaxValue)).log("n")
+      } yield {
+        val input = PosShort.unsafeFrom(n)
+
+        val expected       = n.hashCode
+        val actual         = input.hash
+        val actualHashCode = input.##
+
+        Result.all(
+          List(
+            Result.diffNamed("PosShort(n).hash === n.hashCode", actual, expected)(_ === _),
+            Result.diffNamed("PosShort(n).## === n.hashCode", actualHashCode, expected)(_ === _),
+          )
+        )
+      }
+
     def testShow: Property =
       for {
         n <- Gen.short(Range.linear(1, Short.MaxValue)).log("n")
@@ -654,6 +863,7 @@ object allSpec extends Properties {
     def tests: List[Test] = List(
       property("test   Eq[NonPosShort] === case", testEq),
       property("test   Eq[NonPosShort] =!= case", testEqNotEqual),
+      property("test Hash[NonPosShort]", testHash),
       property("test Show[NonPosShort]", testShow),
     )
 
@@ -693,6 +903,24 @@ object allSpec extends Properties {
         Result.diffNamed("NonPosShort(value) =!= NonPosShort(value)", input1, input2)(_ =!= _)
       }
 
+    def testHash: Property =
+      for {
+        n <- Gen.short(Range.linear(0, Short.MinValue)).log("n")
+      } yield {
+        val input = NonPosShort.unsafeFrom(n)
+
+        val expected       = n.hashCode
+        val actual         = input.hash
+        val actualHashCode = input.##
+
+        Result.all(
+          List(
+            Result.diffNamed("NonPosShort(n).hash === n.hashCode", actual, expected)(_ === _),
+            Result.diffNamed("NonPosShort(n).## === n.hashCode", actualHashCode, expected)(_ === _),
+          )
+        )
+      }
+
     def testShow: Property =
       for {
         n <- Gen.short(Range.linear(0, Short.MinValue)).log("n")
@@ -712,6 +940,7 @@ object allSpec extends Properties {
     def tests: List[Test] = List(
       property("test   Eq[NegByte] === case", testEq),
       property("test   Eq[NegByte] =!= case", testEqNotEqual),
+      property("test Hash[NegByte]", testHash),
       property("test Show[NegByte]", testShow),
     )
 
@@ -750,6 +979,24 @@ object allSpec extends Properties {
         Result.diffNamed("NegByte(value) =!= NegByte(value)", input1, input2)(_ =!= _)
       }
 
+    def testHash: Property =
+      for {
+        n <- Gen.byte(Range.linear(-1, Byte.MinValue)).log("n")
+      } yield {
+        val input = NegByte.unsafeFrom(n)
+
+        val expected       = n.hashCode
+        val actual         = input.hash
+        val actualHashCode = input.##
+
+        Result.all(
+          List(
+            Result.diffNamed("NegByte(n).hash === n.hashCode", actual, expected)(_ === _),
+            Result.diffNamed("NegByte(n).## === n.hashCode", actualHashCode, expected)(_ === _),
+          )
+        )
+      }
+
     def testShow: Property =
       for {
         n <- Gen.byte(Range.linear(-1, Byte.MinValue)).log("n")
@@ -769,6 +1016,7 @@ object allSpec extends Properties {
     def tests: List[Test] = List(
       property("test   Eq[NonNegByte] === case", testEq),
       property("test   Eq[NonNegByte] =!= case", testEqNotEqual),
+      property("test Hash[NonNegByte]", testHash),
       property("test Show[NonNegByte]", testShow),
     )
 
@@ -808,6 +1056,24 @@ object allSpec extends Properties {
         Result.diffNamed("NonNegByte(value) =!= NonNegByte(value)", input1, input2)(_ =!= _)
       }
 
+    def testHash: Property =
+      for {
+        n <- Gen.byte(Range.linear(0, Byte.MaxValue)).log("n")
+      } yield {
+        val input = NonNegByte.unsafeFrom(n)
+
+        val expected       = n.hashCode
+        val actual         = input.hash
+        val actualHashCode = input.##
+
+        Result.all(
+          List(
+            Result.diffNamed("NonNegByte(n).hash === n.hashCode", actual, expected)(_ === _),
+            Result.diffNamed("NonNegByte(n).## === n.hashCode", actualHashCode, expected)(_ === _),
+          )
+        )
+      }
+
     def testShow: Property =
       for {
         n <- Gen.byte(Range.linear(0, Byte.MaxValue)).log("n")
@@ -827,6 +1093,7 @@ object allSpec extends Properties {
     def tests: List[Test] = List(
       property("test   Eq[PosByte] === case", testEq),
       property("test   Eq[PosByte] =!= case", testEqNotEqual),
+      property("test Hash[PosByte]", testHash),
       property("test Show[PosByte]", testShow),
     )
 
@@ -866,6 +1133,24 @@ object allSpec extends Properties {
         Result.diffNamed("PosByte(value) =!= PosByte(value)", input1, input2)(_ =!= _)
       }
 
+    def testHash: Property =
+      for {
+        n <- Gen.byte(Range.linear(1, Byte.MaxValue)).log("n")
+      } yield {
+        val input = PosByte.unsafeFrom(n)
+
+        val expected       = n.hashCode
+        val actual         = input.hash
+        val actualHashCode = input.##
+
+        Result.all(
+          List(
+            Result.diffNamed("PosByte(n).hash === n.hashCode", actual, expected)(_ === _),
+            Result.diffNamed("PosByte(n).## === n.hashCode", actualHashCode, expected)(_ === _),
+          )
+        )
+      }
+
     def testShow: Property =
       for {
         n <- Gen.byte(Range.linear(1, Byte.MaxValue)).log("n")
@@ -885,6 +1170,7 @@ object allSpec extends Properties {
     def tests: List[Test] = List(
       property("test   Eq[NonPosByte] === case", testEq),
       property("test   Eq[NonPosByte] =!= case", testEqNotEqual),
+      property("test Hash[NonPosByte]", testHash),
       property("test Show[NonPosByte]", testShow),
     )
 
@@ -924,6 +1210,24 @@ object allSpec extends Properties {
         Result.diffNamed("NonPosByte(value) =!= NonPosByte(value)", input1, input2)(_ =!= _)
       }
 
+    def testHash: Property =
+      for {
+        n <- Gen.byte(Range.linear(0, Byte.MinValue)).log("n")
+      } yield {
+        val input = NonPosByte.unsafeFrom(n)
+
+        val expected       = n.hashCode
+        val actual         = input.hash
+        val actualHashCode = input.##
+
+        Result.all(
+          List(
+            Result.diffNamed("NonPosByte(n).hash === n.hashCode", actual, expected)(_ === _),
+            Result.diffNamed("NonPosByte(n).## === n.hashCode", actualHashCode, expected)(_ === _),
+          )
+        )
+      }
+
     def testShow: Property =
       for {
         n <- Gen.byte(Range.linear(0, Byte.MinValue)).log("n")
@@ -943,6 +1247,7 @@ object allSpec extends Properties {
     def tests: List[Test] = List(
       property("test   Eq[NegFloat] === case", testEq),
       property("test   Eq[NegFloat] =!= case", testEqNotEqual),
+      property("test Hash[NegFloat]", testHash),
       property("test Show[NegFloat]", testShow),
     )
 
@@ -983,6 +1288,24 @@ object allSpec extends Properties {
         Result.diffNamed("NegFloat(value) =!= NegFloat(value)", input1, input2)(_ =!= _)
       }
 
+    def testHash: Property =
+      for {
+        n <- Gen.double(Range.linearFrac(-0.00001d, Float.MinValue)).map(_.toFloat).log("n")
+      } yield {
+        val input = NegFloat.unsafeFrom(n)
+
+        val expected       = n.hashCode
+        val actual         = input.hash
+        val actualHashCode = input.##
+
+        Result.all(
+          List(
+            Result.diffNamed("NegFloat(n).hash === n.hashCode", actual, expected)(_ === _),
+            Result.diffNamed("NegFloat(n).## === n.hashCode", actualHashCode, expected)(_ === _),
+          )
+        )
+      }
+
     def testShow: Property =
       for {
         n <- Gen.double(Range.linearFrac(-0.00001d, Float.MinValue)).map(_.toFloat).log("n")
@@ -1002,6 +1325,7 @@ object allSpec extends Properties {
     def tests: List[Test] = List(
       property("test   Eq[NonNegFloat] === case", testEq),
       property("test   Eq[NonNegFloat] =!= case", testEqNotEqual),
+      property("test Hash[NonNegFloat]", testHash),
       property("test Show[NonNegFloat]", testShow),
     )
 
@@ -1042,6 +1366,24 @@ object allSpec extends Properties {
         Result.diffNamed("NonNegFloat(value) =!= NonNegFloat(value)", input1, input2)(_ =!= _)
       }
 
+    def testHash: Property =
+      for {
+        n <- Gen.double(Range.linearFrac(0d, Float.MaxValue)).map(_.toFloat).log("n")
+      } yield {
+        val input = NonNegFloat.unsafeFrom(n)
+
+        val expected       = n.hashCode
+        val actual         = input.hash
+        val actualHashCode = input.##
+
+        Result.all(
+          List(
+            Result.diffNamed("NonNegFloat(n).hash === n.hashCode", actual, expected)(_ === _),
+            Result.diffNamed("NonNegFloat(n).## === n.hashCode", actualHashCode, expected)(_ === _),
+          )
+        )
+      }
+
     def testShow: Property =
       for {
         n <- Gen.double(Range.linearFrac(0d, Float.MaxValue)).map(_.toFloat).log("n")
@@ -1061,6 +1403,7 @@ object allSpec extends Properties {
     def tests: List[Test] = List(
       property("test   Eq[PosFloat] === case", testEq),
       property("test   Eq[PosFloat] =!= case", testEqNotEqual),
+      property("test Hash[PosFloat]", testHash),
       property("test Show[PosFloat]", testShow),
     )
 
@@ -1101,6 +1444,24 @@ object allSpec extends Properties {
         Result.diffNamed("PosFloat(value) =!= PosFloat(value)", input1, input2)(_ =!= _)
       }
 
+    def testHash: Property =
+      for {
+        n <- Gen.double(Range.linearFrac(0.0001d, Float.MaxValue)).map(_.toFloat).log("n")
+      } yield {
+        val input = PosFloat.unsafeFrom(n)
+
+        val expected       = n.hashCode
+        val actual         = input.hash
+        val actualHashCode = input.##
+
+        Result.all(
+          List(
+            Result.diffNamed("PosFloat(n).hash === n.hashCode", actual, expected)(_ === _),
+            Result.diffNamed("PosFloat(n).## === n.hashCode", actualHashCode, expected)(_ === _),
+          )
+        )
+      }
+
     def testShow: Property =
       for {
         n <- Gen.double(Range.linearFrac(0.0001d, Float.MaxValue)).map(_.toFloat).log("n")
@@ -1120,6 +1481,7 @@ object allSpec extends Properties {
     def tests: List[Test] = List(
       property("test   Eq[NonPosFloat] === case", testEq),
       property("test   Eq[NonPosFloat] =!= case", testEqNotEqual),
+      property("test Hash[NonPosFloat]", testHash),
       property("test Show[NonPosFloat]", testShow),
     )
 
@@ -1160,6 +1522,24 @@ object allSpec extends Properties {
         Result.diffNamed("NonPosFloat(value) =!= NonPosFloat(value)", input1, input2)(_ =!= _)
       }
 
+    def testHash: Property =
+      for {
+        n <- Gen.double(Range.linearFrac(0d, Float.MinValue)).map(_.toFloat).log("n")
+      } yield {
+        val input = NonPosFloat.unsafeFrom(n)
+
+        val expected       = n.hashCode
+        val actual         = input.hash
+        val actualHashCode = input.##
+
+        Result.all(
+          List(
+            Result.diffNamed("NonPosFloat(n).hash === n.hashCode", actual, expected)(_ === _),
+            Result.diffNamed("NonPosFloat(n).## === n.hashCode", actualHashCode, expected)(_ === _),
+          )
+        )
+      }
+
     def testShow: Property =
       for {
         n <- Gen.double(Range.linearFrac(0d, Float.MinValue)).map(_.toFloat).log("n")
@@ -1179,6 +1559,7 @@ object allSpec extends Properties {
     def tests: List[Test] = List(
       property("test   Eq[NegDouble] === case", testEq),
       property("test   Eq[NegDouble] =!= case", testEqNotEqual),
+      property("test Hash[NegDouble]", testHash),
       property("test Show[NegDouble]", testShow),
     )
 
@@ -1218,6 +1599,24 @@ object allSpec extends Properties {
         Result.diffNamed("NegDouble(value) =!= NegDouble(value)", input1, input2)(_ =!= _)
       }
 
+    def testHash: Property =
+      for {
+        n <- Gen.double(Range.linearFrac(-0.000001d, Double.MinValue)).log("n")
+      } yield {
+        val input = NegDouble.unsafeFrom(n)
+
+        val expected       = n.hashCode
+        val actual         = input.hash
+        val actualHashCode = input.##
+
+        Result.all(
+          List(
+            Result.diffNamed("NegDouble(n).hash === n.hashCode", actual, expected)(_ === _),
+            Result.diffNamed("NegDouble(n).## === n.hashCode", actualHashCode, expected)(_ === _),
+          )
+        )
+      }
+
     def testShow: Property =
       for {
         n <- Gen.double(Range.linearFrac(-0.000001d, Double.MinValue)).log("n")
@@ -1237,6 +1636,7 @@ object allSpec extends Properties {
     def tests: List[Test] = List(
       property("test   Eq[NonNegDouble] === case", testEq),
       property("test   Eq[NonNegDouble] =!= case", testEqNotEqual),
+      property("test Hash[NonNegDouble]", testHash),
       property("test Show[NonNegDouble]", testShow),
     )
 
@@ -1276,6 +1676,24 @@ object allSpec extends Properties {
         Result.diffNamed("NonNegDouble(value) =!= NonNegDouble(value)", input1, input2)(_ =!= _)
       }
 
+    def testHash: Property =
+      for {
+        n <- Gen.double(Range.linearFrac(0d, Double.MaxValue)).log("n")
+      } yield {
+        val input = NonNegDouble.unsafeFrom(n)
+
+        val expected       = n.hashCode
+        val actual         = input.hash
+        val actualHashCode = input.##
+
+        Result.all(
+          List(
+            Result.diffNamed("NonNegDouble(n).hash === n.hashCode", actual, expected)(_ === _),
+            Result.diffNamed("NonNegDouble(n).## === n.hashCode", actualHashCode, expected)(_ === _),
+          )
+        )
+      }
+
     def testShow: Property =
       for {
         n <- Gen.double(Range.linearFrac(0d, Double.MaxValue)).log("n")
@@ -1295,6 +1713,7 @@ object allSpec extends Properties {
     def tests: List[Test] = List(
       property("test   Eq[PosDouble] === case", testEq),
       property("test   Eq[PosDouble] =!= case", testEqNotEqual),
+      property("test Hash[PosDouble]", testHash),
       property("test Show[PosDouble]", testShow),
     )
 
@@ -1334,6 +1753,24 @@ object allSpec extends Properties {
         Result.diffNamed("PosDouble(value) =!= PosDouble(value)", input1, input2)(_ =!= _)
       }
 
+    def testHash: Property =
+      for {
+        n <- Gen.double(Range.linearFrac(0.000001d, Double.MaxValue)).log("n")
+      } yield {
+        val input = PosDouble.unsafeFrom(n)
+
+        val expected       = n.hashCode
+        val actual         = input.hash
+        val actualHashCode = input.##
+
+        Result.all(
+          List(
+            Result.diffNamed("PosDouble(n).hash === n.hashCode", actual, expected)(_ === _),
+            Result.diffNamed("PosDouble(n).## === n.hashCode", actualHashCode, expected)(_ === _),
+          )
+        )
+      }
+
     def testShow: Property =
       for {
         n <- Gen.double(Range.linearFrac(0.000001d, Double.MaxValue)).log("n")
@@ -1353,6 +1790,7 @@ object allSpec extends Properties {
     def tests: List[Test] = List(
       property("test   Eq[NonPosDouble] === case", testEq),
       property("test   Eq[NonPosDouble] =!= case", testEqNotEqual),
+      property("test Hash[NonPosDouble]", testHash),
       property("test Show[NonPosDouble]", testShow),
     )
 
@@ -1391,6 +1829,24 @@ object allSpec extends Properties {
         Result.diffNamed("NonPosDouble(value) =!= NonPosDouble(value)", input1, input2)(_ =!= _)
       }
 
+    def testHash: Property =
+      for {
+        n <- Gen.double(Range.linearFrac(0d, Double.MinValue)).log("n")
+      } yield {
+        val input = NonPosDouble.unsafeFrom(n)
+
+        val expected       = n.hashCode
+        val actual         = input.hash
+        val actualHashCode = input.##
+
+        Result.all(
+          List(
+            Result.diffNamed("NonPosDouble(n).hash === n.hashCode", actual, expected)(_ === _),
+            Result.diffNamed("NonPosDouble(n).## === n.hashCode", actualHashCode, expected)(_ === _),
+          )
+        )
+      }
+
     def testShow: Property =
       for {
         n <- Gen.double(Range.linearFrac(0d, Double.MinValue)).log("n")
@@ -1410,6 +1866,7 @@ object allSpec extends Properties {
     def tests: List[Test] = List(
       property("test   Eq[NegBigInt] === case", testEq),
       property("test   Eq[NegBigInt] =!= case", testEqNotEqual),
+      property("test Hash[NegBigInt]", testHash),
       property("test Show[NegBigInt]", testShow),
     )
 
@@ -1450,6 +1907,24 @@ object allSpec extends Properties {
         Result.diffNamed("NegBigInt(value) =!= NegBigInt(value)", input1, input2)(_ =!= _)
       }
 
+    def testHash: Property =
+      for {
+        n <- Gen.long(Range.linear(-1L, Long.MinValue)).map(BigInt(_)).log("n")
+      } yield {
+        val input = NegBigInt.unsafeFrom(n)
+
+        val expected       = n.hashCode
+        val actual         = input.hash
+        val actualHashCode = input.##
+
+        Result.all(
+          List(
+            Result.diffNamed("NegBigInt(n).hash === n.hashCode", actual, expected)(_ === _),
+            Result.diffNamed("NegBigInt(n).## === n.hashCode", actualHashCode, expected)(_ === _),
+          )
+        )
+      }
+
     def testShow: Property =
       for {
         n <- Gen.long(Range.linear(-1L, Long.MinValue)).map(BigInt(_)).log("n")
@@ -1468,6 +1943,7 @@ object allSpec extends Properties {
     def tests: List[Test] = List(
       property("test   Eq[NonNegBigInt] === case", testEq),
       property("test   Eq[NonNegBigInt] =!= case", testEqNotEqual),
+      property("test Hash[NonNegBigInt]", testHash),
       property("test Show[NonNegBigInt]", testShow),
     )
 
@@ -1507,6 +1983,24 @@ object allSpec extends Properties {
         Result.diffNamed("NonNegBigInt(value) =!= NonNegBigInt(value)", input1, input2)(_ =!= _)
       }
 
+    def testHash: Property =
+      for {
+        n <- Gen.long(Range.linear(0L, Long.MaxValue)).map(BigInt(_)).log("n")
+      } yield {
+        val input = NonNegBigInt.unsafeFrom(n)
+
+        val expected       = n.hashCode
+        val actual         = input.hash
+        val actualHashCode = input.##
+
+        Result.all(
+          List(
+            Result.diffNamed("NonNegBigInt(n).hash === n.hashCode", actual, expected)(_ === _),
+            Result.diffNamed("NonNegBigInt(n).## === n.hashCode", actualHashCode, expected)(_ === _),
+          )
+        )
+      }
+
     def testShow: Property =
       for {
         n <- Gen.long(Range.linear(0L, Long.MaxValue)).map(BigInt(_)).log("n")
@@ -1526,6 +2020,7 @@ object allSpec extends Properties {
     def tests: List[Test] = List(
       property("test   Eq[PosBigInt] === case", testEq),
       property("test   Eq[PosBigInt] =!= case", testEqNotEqual),
+      property("test Hash[PosBigInt]", testHash),
       property("test Show[PosBigInt]", testShow),
     )
 
@@ -1566,6 +2061,24 @@ object allSpec extends Properties {
         Result.diffNamed("PosBigInt(value) =!= PosBigInt(value)", input1, input2)(_ =!= _)
       }
 
+    def testHash: Property =
+      for {
+        n <- Gen.long(Range.linear(1L, Long.MaxValue)).map(BigInt(_)).log("n")
+      } yield {
+        val input = PosBigInt.unsafeFrom(n)
+
+        val expected       = n.hashCode
+        val actual         = input.hash
+        val actualHashCode = input.##
+
+        Result.all(
+          List(
+            Result.diffNamed("PosBigInt(n).hash === n.hashCode", actual, expected)(_ === _),
+            Result.diffNamed("PosBigInt(n).## === n.hashCode", actualHashCode, expected)(_ === _),
+          )
+        )
+      }
+
     def testShow: Property =
       for {
         n <- Gen.long(Range.linear(1L, Long.MaxValue)).map(BigInt(_)).log("n")
@@ -1585,6 +2098,7 @@ object allSpec extends Properties {
     def tests: List[Test] = List(
       property("test   Eq[NonPosBigInt] === case", testEq),
       property("test   Eq[NonPosBigInt] =!= case", testEqNotEqual),
+      property("test Hash[NonPosBigInt]", testHash),
       property("test Show[NonPosBigInt]", testShow),
     )
 
@@ -1625,6 +2139,24 @@ object allSpec extends Properties {
         Result.diffNamed("NonPosBigInt(value) =!= NonPosBigInt(value)", input1, input2)(_ =!= _)
       }
 
+    def testHash: Property =
+      for {
+        n <- Gen.long(Range.linear(0L, Long.MinValue)).map(BigInt(_)).log("n")
+      } yield {
+        val input = NonPosBigInt.unsafeFrom(n)
+
+        val expected       = n.hashCode
+        val actual         = input.hash
+        val actualHashCode = input.##
+
+        Result.all(
+          List(
+            Result.diffNamed("NonPosBigInt(n).hash === n.hashCode", actual, expected)(_ === _),
+            Result.diffNamed("NonPosBigInt(n).## === n.hashCode", actualHashCode, expected)(_ === _),
+          )
+        )
+      }
+
     def testShow: Property =
       for {
         n <- Gen.long(Range.linear(0L, Long.MinValue)).map(BigInt(_)).log("n")
@@ -1651,6 +2183,7 @@ object allSpec extends Properties {
     def tests: List[Test] = List(
       property("test   Eq[NegBigDecimal] === case", testEq),
       property("test   Eq[NegBigDecimal] =!= case", testEqNotEqual),
+      property("test Hash[NegBigDecimal]", testHash),
       property("test Show[NegBigDecimal]", testShow),
     )
 
@@ -1690,6 +2223,24 @@ object allSpec extends Properties {
         Result.diffNamed("NegBigDecimal(value) =!= NegBigDecimal(value)", input1, input2)(_ =!= _)
       }
 
+    def testHash: Property =
+      for {
+        n <- Gen.double(Range.linearFrac(-0.0000001d, Double.MinValue)).map(BigDecimal(_)).log("n")
+      } yield {
+        val input = NegBigDecimal.unsafeFrom(n)
+
+        val expected       = n.hashCode
+        val actual         = input.hash
+        val actualHashCode = input.##
+
+        Result.all(
+          List(
+            Result.diffNamed("NegBigDecimal(n).hash === n.hashCode", actual, expected)(_ === _),
+            Result.diffNamed("NegBigDecimal(n).## === n.hashCode", actualHashCode, expected)(_ === _),
+          )
+        )
+      }
+
     def testShow: Property =
       for {
         n <- Gen.double(Range.linearFrac(-0.0000001d, Double.MinValue)).map(BigDecimal(_)).log("n")
@@ -1708,6 +2259,7 @@ object allSpec extends Properties {
     def tests: List[Test] = List(
       property("test   Eq[NonNegBigDecimal] === case", testEq),
       property("test   Eq[NonNegBigDecimal] =!= case", testEqNotEqual),
+      property("test Hash[NonNegBigDecimal]", testHash),
       property("test Show[NonNegBigDecimal]", testShow),
     )
 
@@ -1748,6 +2300,24 @@ object allSpec extends Properties {
         Result.diffNamed("NonNegBigDecimal(value) =!= NonNegBigDecimal(value)", input1, input2)(_ =!= _)
       }
 
+    def testHash: Property =
+      for {
+        n <- Gen.double(Range.linearFrac(0d, Double.MaxValue)).map(BigDecimal(_)).log("n")
+      } yield {
+        val input = NonNegBigDecimal.unsafeFrom(n)
+
+        val expected       = n.hashCode
+        val actual         = input.hash
+        val actualHashCode = input.##
+
+        Result.all(
+          List(
+            Result.diffNamed("NonNegBigDecimal(n).hash === n.hashCode", actual, expected)(_ === _),
+            Result.diffNamed("NonNegBigDecimal(n).## === n.hashCode", actualHashCode, expected)(_ === _),
+          )
+        )
+      }
+
     def testShow: Property =
       for {
         n <- Gen.double(Range.linearFrac(0d, Double.MaxValue)).map(BigDecimal(_)).log("n")
@@ -1767,6 +2337,7 @@ object allSpec extends Properties {
     def tests: List[Test] = List(
       property("test   Eq[PosBigDecimal] === case", testEq),
       property("test   Eq[PosBigDecimal] =!= case", testEqNotEqual),
+      property("test Hash[PosBigDecimal]", testHash),
       property("test Show[PosBigDecimal]", testShow),
     )
 
@@ -1807,6 +2378,24 @@ object allSpec extends Properties {
         Result.diffNamed("PosBigDecimal(value) =!= PosBigDecimal(value)", input1, input2)(_ =!= _)
       }
 
+    def testHash: Property =
+      for {
+        n <- Gen.double(Range.linearFrac(0.0000001d, Double.MaxValue)).map(BigDecimal(_)).log("n")
+      } yield {
+        val input = PosBigDecimal.unsafeFrom(n)
+
+        val expected       = n.hashCode
+        val actual         = input.hash
+        val actualHashCode = input.##
+
+        Result.all(
+          List(
+            Result.diffNamed("PosBigDecimal(n).hash === n.hashCode", actual, expected)(_ === _),
+            Result.diffNamed("PosBigDecimal(n).## === n.hashCode", actualHashCode, expected)(_ === _),
+          )
+        )
+      }
+
     def testShow: Property =
       for {
         n <- Gen.double(Range.linearFrac(0.0000001d, Double.MaxValue)).map(BigDecimal(_)).log("n")
@@ -1826,6 +2415,7 @@ object allSpec extends Properties {
     def tests: List[Test] = List(
       property("test   Eq[NonPosBigDecimal] === case", testEq),
       property("test   Eq[NonPosBigDecimal] =!= case", testEqNotEqual),
+      property("test Hash[NonPosBigDecimal]", testHash),
       property("test Show[NonPosBigDecimal]", testShow),
     )
 
@@ -1864,6 +2454,24 @@ object allSpec extends Properties {
         val input2 = NonPosBigDecimal.unsafeFrom(n2)
 
         Result.diffNamed("NonPosBigDecimal(value) =!= NonPosBigDecimal(value)", input1, input2)(_ =!= _)
+      }
+
+    def testHash: Property =
+      for {
+        n <- Gen.double(Range.linearFrac(0d, Double.MinValue)).map(BigDecimal(_)).log("n")
+      } yield {
+        val input = NonPosBigDecimal.unsafeFrom(n)
+
+        val expected       = n.hashCode
+        val actual         = input.hash
+        val actualHashCode = input.##
+
+        Result.all(
+          List(
+            Result.diffNamed("NonPosBigDecimal(n).hash === n.hashCode", actual, expected)(_ === _),
+            Result.diffNamed("NonPosBigDecimal(n).## === n.hashCode", actualHashCode, expected)(_ === _),
+          )
+        )
       }
 
     def testShow: Property =

--- a/modules/refined4s-core/shared/src/main/scala/refined4s/types/numeric.scala
+++ b/modules/refined4s-core/shared/src/main/scala/refined4s/types/numeric.scala
@@ -109,7 +109,7 @@ trait numeric {
 
   // scalafix:on
 }
-object numeric extends OrphanCats, OrphanCatsKernel {
+object numeric {
 
   trait Numeric[@specialized(Int, Long, Short, Byte, Float, Double) A: math.Ordering] extends Refined[A], CanBeOrdered[A]
 
@@ -134,7 +134,7 @@ object numeric extends OrphanCats, OrphanCatsKernel {
   }
 
   type NegInt = NegInt.Type
-  object NegInt extends Numeric[Int], MinMax[Int] {
+  object NegInt extends Numeric[Int], MinMax[Int], NegIntTypeClassInstances {
     override def min: Type = apply(Int.MinValue)
     override def max: Type = apply(-1)
 
@@ -142,20 +142,28 @@ object numeric extends OrphanCats, OrphanCatsKernel {
 
     override inline def predicate(a: Int): Boolean = a < 0
 
+  }
+  private[types] trait NegIntTypeClassInstances extends NegIntTypeClassInstance1 {
     @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
     inline given derivedNegIntEq[F[*]: CatsEq, G[*]: CatsEq](using eqActual: G[Int]): F[NegInt] = {
-      internalDef.contraCoercible(eqActual.asInstanceOf[cats.Eq[Int]])
+      internalDef.contraCoercible[cats.Eq, NegInt, Int, cats.Contravariant](eqActual.asInstanceOf[cats.Eq[Int]])
     }.asInstanceOf[F[NegInt]] // scalafix:ok DisableSyntax.asInstanceOf
-
+  }
+  private[types] trait NegIntTypeClassInstance1 extends NegIntTypeClassInstance2 {
+    @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
+    inline given derivedNegIntHash[F[*]: CatsHash, G[*]: CatsHash](using hashActual: G[Int]): F[NegInt] = {
+      internalDef.contraCoercible[cats.Hash, NegInt, Int, cats.Contravariant](hashActual.asInstanceOf[cats.Hash[Int]])
+    }.asInstanceOf[F[NegInt]] // scalafix:ok DisableSyntax.asInstanceOf
+  }
+  private[types] trait NegIntTypeClassInstance2 extends OrphanCats, OrphanCatsKernel {
     @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
     inline given derivedNegIntShow[F[*]: CatsShow, G[*]: CatsShow](using showActual: G[Int]): F[NegInt] = {
-      internalDef.contraCoercible(showActual.asInstanceOf[cats.Show[Int]])
+      internalDef.contraCoercible[cats.Show, NegInt, Int, cats.Contravariant](showActual.asInstanceOf[cats.Show[Int]])
     }.asInstanceOf[F[NegInt]] // scalafix:ok DisableSyntax.asInstanceOf
-
   }
 
   type NonNegInt = NonNegInt.Type
-  object NonNegInt extends Numeric[Int], MinMax[Int] {
+  object NonNegInt extends Numeric[Int], MinMax[Int], NonNegIntTypeClassInstances {
     override def min: Type = apply(0)
     override def max: Type = apply(Int.MaxValue)
 
@@ -163,20 +171,28 @@ object numeric extends OrphanCats, OrphanCatsKernel {
 
     override inline def predicate(a: Int): Boolean = a >= 0
 
+  }
+  private[types] trait NonNegIntTypeClassInstances extends NonNegIntTypeClassInstance1 {
     @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
     inline given derivedNonNegIntEq[F[*]: CatsEq, G[*]: CatsEq](using eqActual: G[Int]): F[NonNegInt] = {
-      internalDef.contraCoercible(eqActual.asInstanceOf[cats.Eq[Int]])
+      internalDef.contraCoercible[cats.Eq, NonNegInt, Int, cats.Contravariant](eqActual.asInstanceOf[cats.Eq[Int]])
     }.asInstanceOf[F[NonNegInt]] // scalafix:ok DisableSyntax.asInstanceOf
-
+  }
+  private[types] trait NonNegIntTypeClassInstance1 extends NonNegIntTypeClassInstance2 {
+    @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
+    inline given derivedNonNegIntHash[F[*]: CatsHash, G[*]: CatsHash](using hashActual: G[Int]): F[NonNegInt] = {
+      internalDef.contraCoercible[cats.Hash, NonNegInt, Int, cats.Contravariant](hashActual.asInstanceOf[cats.Hash[Int]])
+    }.asInstanceOf[F[NonNegInt]] // scalafix:ok DisableSyntax.asInstanceOf
+  }
+  private[types] trait NonNegIntTypeClassInstance2 extends OrphanCats, OrphanCatsKernel {
     @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
     inline given derivedNonNegIntShow[F[*]: CatsShow, G[*]: CatsShow](using showActual: G[Int]): F[NonNegInt] = {
-      internalDef.contraCoercible(showActual.asInstanceOf[cats.Show[Int]])
+      internalDef.contraCoercible[cats.Show, NonNegInt, Int, cats.Contravariant](showActual.asInstanceOf[cats.Show[Int]])
     }.asInstanceOf[F[NonNegInt]] // scalafix:ok DisableSyntax.asInstanceOf
-
   }
 
   type PosInt = PosInt.Type
-  object PosInt extends Numeric[Int], MinMax[Int] {
+  object PosInt extends Numeric[Int], MinMax[Int], PosIntTypeClassInstances {
     override def min: Type = apply(1)
     override def max: Type = apply(Int.MaxValue)
 
@@ -184,20 +200,28 @@ object numeric extends OrphanCats, OrphanCatsKernel {
 
     override inline def predicate(a: Int): Boolean = a > 0
 
+  }
+  private[types] trait PosIntTypeClassInstances extends PosIntTypeClassInstance1 {
     @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
     inline given derivedPosIntEq[F[*]: CatsEq, G[*]: CatsEq](using eqActual: G[Int]): F[PosInt] = {
-      internalDef.contraCoercible(eqActual.asInstanceOf[cats.Eq[Int]])
+      internalDef.contraCoercible[cats.Eq, PosInt, Int, cats.Contravariant](eqActual.asInstanceOf[cats.Eq[Int]])
     }.asInstanceOf[F[PosInt]] // scalafix:ok DisableSyntax.asInstanceOf
-
+  }
+  private[types] trait PosIntTypeClassInstance1 extends PosIntTypeClassInstance2 {
+    @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
+    inline given derivedPosIntHash[F[*]: CatsHash, G[*]: CatsHash](using hashActual: G[Int]): F[PosInt] = {
+      internalDef.contraCoercible[cats.Hash, PosInt, Int, cats.Contravariant](hashActual.asInstanceOf[cats.Hash[Int]])
+    }.asInstanceOf[F[PosInt]] // scalafix:ok DisableSyntax.asInstanceOf
+  }
+  private[types] trait PosIntTypeClassInstance2 extends OrphanCats, OrphanCatsKernel {
     @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
     inline given derivedPosIntShow[F[*]: CatsShow, G[*]: CatsShow](using showActual: G[Int]): F[PosInt] = {
-      internalDef.contraCoercible(showActual.asInstanceOf[cats.Show[Int]])
+      internalDef.contraCoercible[cats.Show, PosInt, Int, cats.Contravariant](showActual.asInstanceOf[cats.Show[Int]])
     }.asInstanceOf[F[PosInt]] // scalafix:ok DisableSyntax.asInstanceOf
-
   }
 
   type NonPosInt = NonPosInt.Type
-  object NonPosInt extends Numeric[Int], MinMax[Int] {
+  object NonPosInt extends Numeric[Int], MinMax[Int], NonPosIntTypeClassInstances {
     override def min: Type = apply(Int.MinValue)
     override def max: Type = apply(0)
 
@@ -205,20 +229,28 @@ object numeric extends OrphanCats, OrphanCatsKernel {
 
     override inline def predicate(a: Int): Boolean = a <= 0
 
+  }
+  private[types] trait NonPosIntTypeClassInstances extends NonPosIntTypeClassInstance1 {
     @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
     inline given derivedNonPosIntEq[F[*]: CatsEq, G[*]: CatsEq](using eqActual: G[Int]): F[NonPosInt] = {
-      internalDef.contraCoercible(eqActual.asInstanceOf[cats.Eq[Int]])
+      internalDef.contraCoercible[cats.Eq, NonPosInt, Int, cats.Contravariant](eqActual.asInstanceOf[cats.Eq[Int]])
     }.asInstanceOf[F[NonPosInt]] // scalafix:ok DisableSyntax.asInstanceOf
-
+  }
+  private[types] trait NonPosIntTypeClassInstance1 extends NonPosIntTypeClassInstance2 {
+    @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
+    inline given derivedNonPosIntHash[F[*]: CatsHash, G[*]: CatsHash](using hashActual: G[Int]): F[NonPosInt] = {
+      internalDef.contraCoercible[cats.Hash, NonPosInt, Int, cats.Contravariant](hashActual.asInstanceOf[cats.Hash[Int]])
+    }.asInstanceOf[F[NonPosInt]] // scalafix:ok DisableSyntax.asInstanceOf
+  }
+  private[types] trait NonPosIntTypeClassInstance2 extends OrphanCats, OrphanCatsKernel {
     @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
     inline given derivedNonPosIntShow[F[*]: CatsShow, G[*]: CatsShow](using showActual: G[Int]): F[NonPosInt] = {
-      internalDef.contraCoercible(showActual.asInstanceOf[cats.Show[Int]])
+      internalDef.contraCoercible[cats.Show, NonPosInt, Int, cats.Contravariant](showActual.asInstanceOf[cats.Show[Int]])
     }.asInstanceOf[F[NonPosInt]] // scalafix:ok DisableSyntax.asInstanceOf
-
   }
 
   type NegLong = NegLong.Type
-  object NegLong extends Numeric[Long], MinMax[Long] {
+  object NegLong extends Numeric[Long], MinMax[Long], NegLongTypeClassInstances {
     override def min: Type = apply(Long.MinValue)
     override def max: Type = apply(-1L)
 
@@ -226,20 +258,28 @@ object numeric extends OrphanCats, OrphanCatsKernel {
 
     override inline def predicate(a: Long): Boolean = a < 0L
 
+  }
+  private[types] trait NegLongTypeClassInstances extends NegLongTypeClassInstance1 {
     @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
     inline given derivedNegLongEq[F[*]: CatsEq, G[*]: CatsEq](using eqActual: G[Long]): F[NegLong] = {
-      internalDef.contraCoercible(eqActual.asInstanceOf[cats.Eq[Long]])
+      internalDef.contraCoercible[cats.Eq, NegLong, Long, cats.Contravariant](eqActual.asInstanceOf[cats.Eq[Long]])
     }.asInstanceOf[F[NegLong]] // scalafix:ok DisableSyntax.asInstanceOf
-
+  }
+  private[types] trait NegLongTypeClassInstance1 extends NegLongTypeClassInstance2 {
+    @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
+    inline given derivedNegLongHash[F[*]: CatsHash, G[*]: CatsHash](using hashActual: G[Long]): F[NegLong] = {
+      internalDef.contraCoercible[cats.Hash, NegLong, Long, cats.Contravariant](hashActual.asInstanceOf[cats.Hash[Long]])
+    }.asInstanceOf[F[NegLong]] // scalafix:ok DisableSyntax.asInstanceOf
+  }
+  private[types] trait NegLongTypeClassInstance2 extends OrphanCats, OrphanCatsKernel {
     @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
     inline given derivedNegLongShow[F[*]: CatsShow, G[*]: CatsShow](using showActual: G[Long]): F[NegLong] = {
-      internalDef.contraCoercible(showActual.asInstanceOf[cats.Show[Long]])
+      internalDef.contraCoercible[cats.Show, NegLong, Long, cats.Contravariant](showActual.asInstanceOf[cats.Show[Long]])
     }.asInstanceOf[F[NegLong]] // scalafix:ok DisableSyntax.asInstanceOf
-
   }
 
   type NonNegLong = NonNegLong.Type
-  object NonNegLong extends Numeric[Long], MinMax[Long] {
+  object NonNegLong extends Numeric[Long], MinMax[Long], NonNegLongTypeClassInstances {
     override def min: Type = apply(0L)
     override def max: Type = apply(Long.MaxValue)
 
@@ -247,20 +287,28 @@ object numeric extends OrphanCats, OrphanCatsKernel {
 
     override inline def predicate(a: Long): Boolean = a >= 0L
 
+  }
+  private[types] trait NonNegLongTypeClassInstances extends NonNegLongTypeClassInstance1 {
     @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
     inline given derivedNonNegLongEq[F[*]: CatsEq, G[*]: CatsEq](using eqActual: G[Long]): F[NonNegLong] = {
-      internalDef.contraCoercible(eqActual.asInstanceOf[cats.Eq[Long]])
+      internalDef.contraCoercible[cats.Eq, NonNegLong, Long, cats.Contravariant](eqActual.asInstanceOf[cats.Eq[Long]])
     }.asInstanceOf[F[NonNegLong]] // scalafix:ok DisableSyntax.asInstanceOf
-
+  }
+  private[types] trait NonNegLongTypeClassInstance1 extends NonNegLongTypeClassInstance2 {
+    @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
+    inline given derivedNonNegLongHash[F[*]: CatsHash, G[*]: CatsHash](using hashActual: G[Long]): F[NonNegLong] = {
+      internalDef.contraCoercible[cats.Hash, NonNegLong, Long, cats.Contravariant](hashActual.asInstanceOf[cats.Hash[Long]])
+    }.asInstanceOf[F[NonNegLong]] // scalafix:ok DisableSyntax.asInstanceOf
+  }
+  private[types] trait NonNegLongTypeClassInstance2 extends OrphanCats, OrphanCatsKernel {
     @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
     inline given derivedNonNegLongShow[F[*]: CatsShow, G[*]: CatsShow](using showActual: G[Long]): F[NonNegLong] = {
-      internalDef.contraCoercible(showActual.asInstanceOf[cats.Show[Long]])
+      internalDef.contraCoercible[cats.Show, NonNegLong, Long, cats.Contravariant](showActual.asInstanceOf[cats.Show[Long]])
     }.asInstanceOf[F[NonNegLong]] // scalafix:ok DisableSyntax.asInstanceOf
-
   }
 
   type PosLong = PosLong.Type
-  object PosLong extends Numeric[Long], MinMax[Long] {
+  object PosLong extends Numeric[Long], MinMax[Long], PosLongTypeClassInstances {
     override def min: Type = apply(1L)
     override def max: Type = apply(Long.MaxValue)
 
@@ -268,20 +316,28 @@ object numeric extends OrphanCats, OrphanCatsKernel {
 
     override inline def predicate(a: Long): Boolean = a > 0L
 
+  }
+  private[types] trait PosLongTypeClassInstances extends PosLongTypeClassInstance1 {
     @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
     inline given derivedPosLongEq[F[*]: CatsEq, G[*]: CatsEq](using eqActual: G[Long]): F[PosLong] = {
-      internalDef.contraCoercible(eqActual.asInstanceOf[cats.Eq[Long]])
+      internalDef.contraCoercible[cats.Eq, PosLong, Long, cats.Contravariant](eqActual.asInstanceOf[cats.Eq[Long]])
     }.asInstanceOf[F[PosLong]] // scalafix:ok DisableSyntax.asInstanceOf
-
+  }
+  private[types] trait PosLongTypeClassInstance1 extends PosLongTypeClassInstance2 {
+    @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
+    inline given derivedPosLongHash[F[*]: CatsHash, G[*]: CatsHash](using hashActual: G[Long]): F[PosLong] = {
+      internalDef.contraCoercible[cats.Hash, PosLong, Long, cats.Contravariant](hashActual.asInstanceOf[cats.Hash[Long]])
+    }.asInstanceOf[F[PosLong]] // scalafix:ok DisableSyntax.asInstanceOf
+  }
+  private[types] trait PosLongTypeClassInstance2 extends OrphanCats, OrphanCatsKernel {
     @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
     inline given derivedPosLongShow[F[*]: CatsShow, G[*]: CatsShow](using showActual: G[Long]): F[PosLong] = {
-      internalDef.contraCoercible(showActual.asInstanceOf[cats.Show[Long]])
+      internalDef.contraCoercible[cats.Show, PosLong, Long, cats.Contravariant](showActual.asInstanceOf[cats.Show[Long]])
     }.asInstanceOf[F[PosLong]] // scalafix:ok DisableSyntax.asInstanceOf
-
   }
 
   type NonPosLong = NonPosLong.Type
-  object NonPosLong extends Numeric[Long], MinMax[Long] {
+  object NonPosLong extends Numeric[Long], MinMax[Long], NonPosLongTypeClassInstances {
     override def min: Type = apply(Long.MinValue)
     override def max: Type = apply(0L)
 
@@ -289,20 +345,28 @@ object numeric extends OrphanCats, OrphanCatsKernel {
 
     override inline def predicate(a: Long): Boolean = a <= 0L
 
+  }
+  private[types] trait NonPosLongTypeClassInstances extends NonPosLongTypeClassInstance1 {
     @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
     inline given derivedNonPosLongEq[F[*]: CatsEq, G[*]: CatsEq](using eqActual: G[Long]): F[NonPosLong] = {
-      internalDef.contraCoercible(eqActual.asInstanceOf[cats.Eq[Long]])
+      internalDef.contraCoercible[cats.Eq, NonPosLong, Long, cats.Contravariant](eqActual.asInstanceOf[cats.Eq[Long]])
     }.asInstanceOf[F[NonPosLong]] // scalafix:ok DisableSyntax.asInstanceOf
-
+  }
+  private[types] trait NonPosLongTypeClassInstance1 extends NonPosLongTypeClassInstance2 {
+    @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
+    inline given derivedNonPosLongHash[F[*]: CatsHash, G[*]: CatsHash](using hashActual: G[Long]): F[NonPosLong] = {
+      internalDef.contraCoercible[cats.Hash, NonPosLong, Long, cats.Contravariant](hashActual.asInstanceOf[cats.Hash[Long]])
+    }.asInstanceOf[F[NonPosLong]] // scalafix:ok DisableSyntax.asInstanceOf
+  }
+  private[types] trait NonPosLongTypeClassInstance2 extends OrphanCats, OrphanCatsKernel {
     @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
     inline given derivedNonPosLongShow[F[*]: CatsShow, G[*]: CatsShow](using showActual: G[Long]): F[NonPosLong] = {
-      internalDef.contraCoercible(showActual.asInstanceOf[cats.Show[Long]])
+      internalDef.contraCoercible[cats.Show, NonPosLong, Long, cats.Contravariant](showActual.asInstanceOf[cats.Show[Long]])
     }.asInstanceOf[F[NonPosLong]] // scalafix:ok DisableSyntax.asInstanceOf
-
   }
 
   type NegShort = NegShort.Type
-  object NegShort extends Numeric[Short], MinMax[Short] {
+  object NegShort extends Numeric[Short], MinMax[Short], NegShortTypeClassInstances {
     override def min: Type = apply(Short.MinValue)
     override def max: Type = apply(-1)
 
@@ -310,20 +374,28 @@ object numeric extends OrphanCats, OrphanCatsKernel {
 
     override inline def predicate(a: Short): Boolean = a < 0
 
+  }
+  private[types] trait NegShortTypeClassInstances extends NegShortTypeClassInstance1 {
     @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
     inline given derivedNegShortEq[F[*]: CatsEq, G[*]: CatsEq](using eqActual: G[Short]): F[NegShort] = {
-      internalDef.contraCoercible(eqActual.asInstanceOf[cats.Eq[Short]])
+      internalDef.contraCoercible[cats.Eq, NegShort, Short, cats.Contravariant](eqActual.asInstanceOf[cats.Eq[Short]])
     }.asInstanceOf[F[NegShort]] // scalafix:ok DisableSyntax.asInstanceOf
-
+  }
+  private[types] trait NegShortTypeClassInstance1 extends NegShortTypeClassInstance2 {
+    @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
+    inline given derivedNegShortHash[F[*]: CatsHash, G[*]: CatsHash](using hashActual: G[Short]): F[NegShort] = {
+      internalDef.contraCoercible[cats.Hash, NegShort, Short, cats.Contravariant](hashActual.asInstanceOf[cats.Hash[Short]])
+    }.asInstanceOf[F[NegShort]] // scalafix:ok DisableSyntax.asInstanceOf
+  }
+  private[types] trait NegShortTypeClassInstance2 extends OrphanCats, OrphanCatsKernel {
     @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
     inline given derivedNegShortShow[F[*]: CatsShow, G[*]: CatsShow](using showActual: G[Short]): F[NegShort] = {
-      internalDef.contraCoercible(showActual.asInstanceOf[cats.Show[Short]])
+      internalDef.contraCoercible[cats.Show, NegShort, Short, cats.Contravariant](showActual.asInstanceOf[cats.Show[Short]])
     }.asInstanceOf[F[NegShort]] // scalafix:ok DisableSyntax.asInstanceOf
-
   }
 
   type NonNegShort = NonNegShort.Type
-  object NonNegShort extends Numeric[Short], MinMax[Short] {
+  object NonNegShort extends Numeric[Short], MinMax[Short], NonNegShortTypeClassInstances {
     override def min: Type = apply(0)
     override def max: Type = apply(Short.MaxValue)
 
@@ -331,20 +403,28 @@ object numeric extends OrphanCats, OrphanCatsKernel {
 
     override inline def predicate(a: Short): Boolean = a >= 0
 
+  }
+  private[types] trait NonNegShortTypeClassInstances extends NonNegShortTypeClassInstance1 {
     @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
     inline given derivedNonNegShortEq[F[*]: CatsEq, G[*]: CatsEq](using eqActual: G[Short]): F[NonNegShort] = {
-      internalDef.contraCoercible(eqActual.asInstanceOf[cats.Eq[Short]])
+      internalDef.contraCoercible[cats.Eq, NonNegShort, Short, cats.Contravariant](eqActual.asInstanceOf[cats.Eq[Short]])
     }.asInstanceOf[F[NonNegShort]] // scalafix:ok DisableSyntax.asInstanceOf
-
+  }
+  private[types] trait NonNegShortTypeClassInstance1 extends NonNegShortTypeClassInstance2 {
+    @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
+    inline given derivedNonNegShortHash[F[*]: CatsHash, G[*]: CatsHash](using hashActual: G[Short]): F[NonNegShort] = {
+      internalDef.contraCoercible[cats.Hash, NonNegShort, Short, cats.Contravariant](hashActual.asInstanceOf[cats.Hash[Short]])
+    }.asInstanceOf[F[NonNegShort]] // scalafix:ok DisableSyntax.asInstanceOf
+  }
+  private[types] trait NonNegShortTypeClassInstance2 extends OrphanCats, OrphanCatsKernel {
     @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
     inline given derivedNonNegShortShow[F[*]: CatsShow, G[*]: CatsShow](using showActual: G[Short]): F[NonNegShort] = {
-      internalDef.contraCoercible(showActual.asInstanceOf[cats.Show[Short]])
+      internalDef.contraCoercible[cats.Show, NonNegShort, Short, cats.Contravariant](showActual.asInstanceOf[cats.Show[Short]])
     }.asInstanceOf[F[NonNegShort]] // scalafix:ok DisableSyntax.asInstanceOf
-
   }
 
   type PosShort = PosShort.Type
-  object PosShort extends Numeric[Short], MinMax[Short] {
+  object PosShort extends Numeric[Short], MinMax[Short], PosShortTypeClassInstances {
     override def min: Type = apply(1)
     override def max: Type = apply(Short.MaxValue)
 
@@ -352,20 +432,28 @@ object numeric extends OrphanCats, OrphanCatsKernel {
 
     override inline def predicate(a: Short): Boolean = a > 0
 
+  }
+  private[types] trait PosShortTypeClassInstances extends PosShortTypeClassInstance1 {
     @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
     inline given derivedPosShortEq[F[*]: CatsEq, G[*]: CatsEq](using eqActual: G[Short]): F[PosShort] = {
-      internalDef.contraCoercible(eqActual.asInstanceOf[cats.Eq[Short]])
+      internalDef.contraCoercible[cats.Eq, PosShort, Short, cats.Contravariant](eqActual.asInstanceOf[cats.Eq[Short]])
     }.asInstanceOf[F[PosShort]] // scalafix:ok DisableSyntax.asInstanceOf
-
+  }
+  private[types] trait PosShortTypeClassInstance1 extends PosShortTypeClassInstance2 {
+    @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
+    inline given derivedPosShortHash[F[*]: CatsHash, G[*]: CatsHash](using hashActual: G[Short]): F[PosShort] = {
+      internalDef.contraCoercible[cats.Hash, PosShort, Short, cats.Contravariant](hashActual.asInstanceOf[cats.Hash[Short]])
+    }.asInstanceOf[F[PosShort]] // scalafix:ok DisableSyntax.asInstanceOf
+  }
+  private[types] trait PosShortTypeClassInstance2 extends OrphanCats, OrphanCatsKernel {
     @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
     inline given derivedPosShortShow[F[*]: CatsShow, G[*]: CatsShow](using showActual: G[Short]): F[PosShort] = {
-      internalDef.contraCoercible(showActual.asInstanceOf[cats.Show[Short]])
+      internalDef.contraCoercible[cats.Show, PosShort, Short, cats.Contravariant](showActual.asInstanceOf[cats.Show[Short]])
     }.asInstanceOf[F[PosShort]] // scalafix:ok DisableSyntax.asInstanceOf
-
   }
 
   type NonPosShort = NonPosShort.Type
-  object NonPosShort extends Numeric[Short], MinMax[Short] {
+  object NonPosShort extends Numeric[Short], MinMax[Short], NonPosShortTypeClassInstances {
     override def min: Type = apply(Short.MinValue)
     override def max: Type = apply(0)
 
@@ -373,20 +461,28 @@ object numeric extends OrphanCats, OrphanCatsKernel {
 
     override inline def predicate(a: Short): Boolean = a <= 0
 
+  }
+  private[types] trait NonPosShortTypeClassInstances extends NonPosShortTypeClassInstance1 {
     @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
     inline given derivedNonPosShortEq[F[*]: CatsEq, G[*]: CatsEq](using eqActual: G[Short]): F[NonPosShort] = {
-      internalDef.contraCoercible(eqActual.asInstanceOf[cats.Eq[Short]])
+      internalDef.contraCoercible[cats.Eq, NonPosShort, Short, cats.Contravariant](eqActual.asInstanceOf[cats.Eq[Short]])
     }.asInstanceOf[F[NonPosShort]] // scalafix:ok DisableSyntax.asInstanceOf
-
+  }
+  private[types] trait NonPosShortTypeClassInstance1 extends NonPosShortTypeClassInstance2 {
+    @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
+    inline given derivedNonPosShortHash[F[*]: CatsHash, G[*]: CatsHash](using hashActual: G[Short]): F[NonPosShort] = {
+      internalDef.contraCoercible[cats.Hash, NonPosShort, Short, cats.Contravariant](hashActual.asInstanceOf[cats.Hash[Short]])
+    }.asInstanceOf[F[NonPosShort]] // scalafix:ok DisableSyntax.asInstanceOf
+  }
+  private[types] trait NonPosShortTypeClassInstance2 extends OrphanCats, OrphanCatsKernel {
     @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
     inline given derivedNonPosShortShow[F[*]: CatsShow, G[*]: CatsShow](using showActual: G[Short]): F[NonPosShort] = {
-      internalDef.contraCoercible(showActual.asInstanceOf[cats.Show[Short]])
+      internalDef.contraCoercible[cats.Show, NonPosShort, Short, cats.Contravariant](showActual.asInstanceOf[cats.Show[Short]])
     }.asInstanceOf[F[NonPosShort]] // scalafix:ok DisableSyntax.asInstanceOf
-
   }
 
   type NegByte = NegByte.Type
-  object NegByte extends Numeric[Byte], MinMax[Byte] {
+  object NegByte extends Numeric[Byte], MinMax[Byte], NegByteTypeClassInstances {
     override def min: Type = apply(Byte.MinValue)
     override def max: Type = apply(-1)
 
@@ -394,20 +490,28 @@ object numeric extends OrphanCats, OrphanCatsKernel {
 
     override inline def predicate(a: Byte): Boolean = a < 0
 
+  }
+  private[types] trait NegByteTypeClassInstances extends NegByteTypeClassInstance1 {
     @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
     inline given derivedNegByteEq[F[*]: CatsEq, G[*]: CatsEq](using eqActual: G[Byte]): F[NegByte] = {
-      internalDef.contraCoercible(eqActual.asInstanceOf[cats.Eq[Byte]])
+      internalDef.contraCoercible[cats.Eq, NegByte, Byte, cats.Contravariant](eqActual.asInstanceOf[cats.Eq[Byte]])
     }.asInstanceOf[F[NegByte]] // scalafix:ok DisableSyntax.asInstanceOf
-
+  }
+  private[types] trait NegByteTypeClassInstance1 extends NegByteTypeClassInstance2 {
+    @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
+    inline given derivedNegByteHash[F[*]: CatsHash, G[*]: CatsHash](using hashActual: G[Byte]): F[NegByte] = {
+      internalDef.contraCoercible[cats.Hash, NegByte, Byte, cats.Contravariant](hashActual.asInstanceOf[cats.Hash[Byte]])
+    }.asInstanceOf[F[NegByte]] // scalafix:ok DisableSyntax.asInstanceOf
+  }
+  private[types] trait NegByteTypeClassInstance2 extends OrphanCats, OrphanCatsKernel {
     @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
     inline given derivedNegByteShow[F[*]: CatsShow, G[*]: CatsShow](using showActual: G[Byte]): F[NegByte] = {
-      internalDef.contraCoercible(showActual.asInstanceOf[cats.Show[Byte]])
+      internalDef.contraCoercible[cats.Show, NegByte, Byte, cats.Contravariant](showActual.asInstanceOf[cats.Show[Byte]])
     }.asInstanceOf[F[NegByte]] // scalafix:ok DisableSyntax.asInstanceOf
-
   }
 
   type NonNegByte = NonNegByte.Type
-  object NonNegByte extends Numeric[Byte], MinMax[Byte] {
+  object NonNegByte extends Numeric[Byte], MinMax[Byte], NonNegByteTypeClassInstances {
     override def min: Type = apply(0)
     override def max: Type = apply(Byte.MaxValue)
 
@@ -415,20 +519,28 @@ object numeric extends OrphanCats, OrphanCatsKernel {
 
     override inline def predicate(a: Byte): Boolean = a >= 0
 
+  }
+  private[types] trait NonNegByteTypeClassInstances extends NonNegByteTypeClassInstance1 {
     @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
     inline given derivedNonNegByteEq[F[*]: CatsEq, G[*]: CatsEq](using eqActual: G[Byte]): F[NonNegByte] = {
-      internalDef.contraCoercible(eqActual.asInstanceOf[cats.Eq[Byte]])
+      internalDef.contraCoercible[cats.Eq, NonNegByte, Byte, cats.Contravariant](eqActual.asInstanceOf[cats.Eq[Byte]])
     }.asInstanceOf[F[NonNegByte]] // scalafix:ok DisableSyntax.asInstanceOf
-
+  }
+  private[types] trait NonNegByteTypeClassInstance1 extends NonNegByteTypeClassInstance2 {
+    @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
+    inline given derivedNonNegByteHash[F[*]: CatsHash, G[*]: CatsHash](using hashActual: G[Byte]): F[NonNegByte] = {
+      internalDef.contraCoercible[cats.Hash, NonNegByte, Byte, cats.Contravariant](hashActual.asInstanceOf[cats.Hash[Byte]])
+    }.asInstanceOf[F[NonNegByte]] // scalafix:ok DisableSyntax.asInstanceOf
+  }
+  private[types] trait NonNegByteTypeClassInstance2 extends OrphanCats, OrphanCatsKernel {
     @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
     inline given derivedNonNegByteShow[F[*]: CatsShow, G[*]: CatsShow](using showActual: G[Byte]): F[NonNegByte] = {
-      internalDef.contraCoercible(showActual.asInstanceOf[cats.Show[Byte]])
+      internalDef.contraCoercible[cats.Show, NonNegByte, Byte, cats.Contravariant](showActual.asInstanceOf[cats.Show[Byte]])
     }.asInstanceOf[F[NonNegByte]] // scalafix:ok DisableSyntax.asInstanceOf
-
   }
 
   type PosByte = PosByte.Type
-  object PosByte extends Numeric[Byte], MinMax[Byte] {
+  object PosByte extends Numeric[Byte], MinMax[Byte], PosByteTypeClassInstances {
     override def min: Type = apply(1)
     override def max: Type = apply(Byte.MaxValue)
 
@@ -436,20 +548,28 @@ object numeric extends OrphanCats, OrphanCatsKernel {
 
     override inline def predicate(a: Byte): Boolean = a > 0
 
+  }
+  private[types] trait PosByteTypeClassInstances extends PosByteTypeClassInstance1 {
     @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
     inline given derivedPosByteEq[F[*]: CatsEq, G[*]: CatsEq](using eqActual: G[Byte]): F[PosByte] = {
-      internalDef.contraCoercible(eqActual.asInstanceOf[cats.Eq[Byte]])
+      internalDef.contraCoercible[cats.Eq, PosByte, Byte, cats.Contravariant](eqActual.asInstanceOf[cats.Eq[Byte]])
     }.asInstanceOf[F[PosByte]] // scalafix:ok DisableSyntax.asInstanceOf
-
+  }
+  private[types] trait PosByteTypeClassInstance1 extends PosByteTypeClassInstance2 {
+    @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
+    inline given derivedPosByteHash[F[*]: CatsHash, G[*]: CatsHash](using hashActual: G[Byte]): F[PosByte] = {
+      internalDef.contraCoercible[cats.Hash, PosByte, Byte, cats.Contravariant](hashActual.asInstanceOf[cats.Hash[Byte]])
+    }.asInstanceOf[F[PosByte]] // scalafix:ok DisableSyntax.asInstanceOf
+  }
+  private[types] trait PosByteTypeClassInstance2 extends OrphanCats, OrphanCatsKernel {
     @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
     inline given derivedPosByteShow[F[*]: CatsShow, G[*]: CatsShow](using showActual: G[Byte]): F[PosByte] = {
-      internalDef.contraCoercible(showActual.asInstanceOf[cats.Show[Byte]])
+      internalDef.contraCoercible[cats.Show, PosByte, Byte, cats.Contravariant](showActual.asInstanceOf[cats.Show[Byte]])
     }.asInstanceOf[F[PosByte]] // scalafix:ok DisableSyntax.asInstanceOf
-
   }
 
   type NonPosByte = NonPosByte.Type
-  object NonPosByte extends Numeric[Byte], MinMax[Byte] {
+  object NonPosByte extends Numeric[Byte], MinMax[Byte], NonPosByteTypeClassInstances {
     override def min: Type = apply(Byte.MinValue)
     override def max: Type = apply(0)
 
@@ -457,20 +577,28 @@ object numeric extends OrphanCats, OrphanCatsKernel {
 
     override inline def predicate(a: Byte): Boolean = a <= 0
 
+  }
+  private[types] trait NonPosByteTypeClassInstances extends NonPosByteTypeClassInstance1 {
     @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
     inline given derivedNonPosByteEq[F[*]: CatsEq, G[*]: CatsEq](using eqActual: G[Byte]): F[NonPosByte] = {
-      internalDef.contraCoercible(eqActual.asInstanceOf[cats.Eq[Byte]])
+      internalDef.contraCoercible[cats.Eq, NonPosByte, Byte, cats.Contravariant](eqActual.asInstanceOf[cats.Eq[Byte]])
     }.asInstanceOf[F[NonPosByte]] // scalafix:ok DisableSyntax.asInstanceOf
-
+  }
+  private[types] trait NonPosByteTypeClassInstance1 extends NonPosByteTypeClassInstance2 {
+    @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
+    inline given derivedNonPosByteHash[F[*]: CatsHash, G[*]: CatsHash](using hashActual: G[Byte]): F[NonPosByte] = {
+      internalDef.contraCoercible[cats.Hash, NonPosByte, Byte, cats.Contravariant](hashActual.asInstanceOf[cats.Hash[Byte]])
+    }.asInstanceOf[F[NonPosByte]] // scalafix:ok DisableSyntax.asInstanceOf
+  }
+  private[types] trait NonPosByteTypeClassInstance2 extends OrphanCats, OrphanCatsKernel {
     @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
     inline given derivedNonPosByteShow[F[*]: CatsShow, G[*]: CatsShow](using showActual: G[Byte]): F[NonPosByte] = {
-      internalDef.contraCoercible(showActual.asInstanceOf[cats.Show[Byte]])
+      internalDef.contraCoercible[cats.Show, NonPosByte, Byte, cats.Contravariant](showActual.asInstanceOf[cats.Show[Byte]])
     }.asInstanceOf[F[NonPosByte]] // scalafix:ok DisableSyntax.asInstanceOf
-
   }
 
   type NegFloat = NegFloat.Type
-  object NegFloat extends Numeric[Float], MinMax[Float] {
+  object NegFloat extends Numeric[Float], MinMax[Float], NegFloatTypeClassInstances {
     override def min: Type = apply(-java.lang.Float.MAX_VALUE) // Float.MinValue
     override def max: Type = apply(-1.4e-45f) // math.nextDown(0f)
 
@@ -478,20 +606,28 @@ object numeric extends OrphanCats, OrphanCatsKernel {
 
     override inline def predicate(a: Float): Boolean = a < 0f
 
+  }
+  private[types] trait NegFloatTypeClassInstances extends NegFloatTypeClassInstance1 {
     @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
     inline given derivedNegFloatEq[F[*]: CatsEq, G[*]: CatsEq](using eqActual: G[Float]): F[NegFloat] = {
-      internalDef.contraCoercible(eqActual.asInstanceOf[cats.Eq[Float]])
+      internalDef.contraCoercible[cats.Eq, NegFloat, Float, cats.Contravariant](eqActual.asInstanceOf[cats.Eq[Float]])
     }.asInstanceOf[F[NegFloat]] // scalafix:ok DisableSyntax.asInstanceOf
-
+  }
+  private[types] trait NegFloatTypeClassInstance1 extends NegFloatTypeClassInstance2 {
+    @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
+    inline given derivedNegFloatHash[F[*]: CatsHash, G[*]: CatsHash](using hashActual: G[Float]): F[NegFloat] = {
+      internalDef.contraCoercible[cats.Hash, NegFloat, Float, cats.Contravariant](hashActual.asInstanceOf[cats.Hash[Float]])
+    }.asInstanceOf[F[NegFloat]] // scalafix:ok DisableSyntax.asInstanceOf
+  }
+  private[types] trait NegFloatTypeClassInstance2 extends OrphanCats, OrphanCatsKernel {
     @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
     inline given derivedNegFloatShow[F[*]: CatsShow, G[*]: CatsShow](using showActual: G[Float]): F[NegFloat] = {
-      internalDef.contraCoercible(showActual.asInstanceOf[cats.Show[Float]])
+      internalDef.contraCoercible[cats.Show, NegFloat, Float, cats.Contravariant](showActual.asInstanceOf[cats.Show[Float]])
     }.asInstanceOf[F[NegFloat]] // scalafix:ok DisableSyntax.asInstanceOf
-
   }
 
   type NonNegFloat = NonNegFloat.Type
-  object NonNegFloat extends Numeric[Float], MinMax[Float] {
+  object NonNegFloat extends Numeric[Float], MinMax[Float], NonNegFloatTypeClassInstances {
     override def min: Type = apply(0f)
     override def max: Type = apply(Float.MaxValue)
 
@@ -499,20 +635,28 @@ object numeric extends OrphanCats, OrphanCatsKernel {
 
     override inline def predicate(a: Float): Boolean = a >= 0f
 
+  }
+  private[types] trait NonNegFloatTypeClassInstances extends NonNegFloatTypeClassInstance1 {
     @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
     inline given derivedNonNegFloatEq[F[*]: CatsEq, G[*]: CatsEq](using eqActual: G[Float]): F[NonNegFloat] = {
-      internalDef.contraCoercible(eqActual.asInstanceOf[cats.Eq[Float]])
+      internalDef.contraCoercible[cats.Eq, NonNegFloat, Float, cats.Contravariant](eqActual.asInstanceOf[cats.Eq[Float]])
     }.asInstanceOf[F[NonNegFloat]] // scalafix:ok DisableSyntax.asInstanceOf
-
+  }
+  private[types] trait NonNegFloatTypeClassInstance1 extends NonNegFloatTypeClassInstance2 {
+    @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
+    inline given derivedNonNegFloatHash[F[*]: CatsHash, G[*]: CatsHash](using hashActual: G[Float]): F[NonNegFloat] = {
+      internalDef.contraCoercible[cats.Hash, NonNegFloat, Float, cats.Contravariant](hashActual.asInstanceOf[cats.Hash[Float]])
+    }.asInstanceOf[F[NonNegFloat]] // scalafix:ok DisableSyntax.asInstanceOf
+  }
+  private[types] trait NonNegFloatTypeClassInstance2 extends OrphanCats, OrphanCatsKernel {
     @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
     inline given derivedNonNegFloatShow[F[*]: CatsShow, G[*]: CatsShow](using showActual: G[Float]): F[NonNegFloat] = {
-      internalDef.contraCoercible(showActual.asInstanceOf[cats.Show[Float]])
+      internalDef.contraCoercible[cats.Show, NonNegFloat, Float, cats.Contravariant](showActual.asInstanceOf[cats.Show[Float]])
     }.asInstanceOf[F[NonNegFloat]] // scalafix:ok DisableSyntax.asInstanceOf
-
   }
 
   type PosFloat = PosFloat.Type
-  object PosFloat extends Numeric[Float], MinMax[Float] {
+  object PosFloat extends Numeric[Float], MinMax[Float], PosFloatTypeClassInstances {
     override def min: Type = apply(1.4e-45f) // math.nextUp(0f)
     override def max: Type = apply(Float.MaxValue)
 
@@ -520,20 +664,28 @@ object numeric extends OrphanCats, OrphanCatsKernel {
 
     override inline def predicate(a: Float): Boolean = a > 0f
 
+  }
+  private[types] trait PosFloatTypeClassInstances extends PosFloatTypeClassInstance1 {
     @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
     inline given derivedPosFloatEq[F[*]: CatsEq, G[*]: CatsEq](using eqActual: G[Float]): F[PosFloat] = {
-      internalDef.contraCoercible(eqActual.asInstanceOf[cats.Eq[Float]])
+      internalDef.contraCoercible[cats.Eq, PosFloat, Float, cats.Contravariant](eqActual.asInstanceOf[cats.Eq[Float]])
     }.asInstanceOf[F[PosFloat]] // scalafix:ok DisableSyntax.asInstanceOf
-
+  }
+  private[types] trait PosFloatTypeClassInstance1 extends PosFloatTypeClassInstance2 {
+    @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
+    inline given derivedPosFloatHash[F[*]: CatsHash, G[*]: CatsHash](using hashActual: G[Float]): F[PosFloat] = {
+      internalDef.contraCoercible[cats.Hash, PosFloat, Float, cats.Contravariant](hashActual.asInstanceOf[cats.Hash[Float]])
+    }.asInstanceOf[F[PosFloat]] // scalafix:ok DisableSyntax.asInstanceOf
+  }
+  private[types] trait PosFloatTypeClassInstance2 extends OrphanCats, OrphanCatsKernel {
     @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
     inline given derivedPosFloatShow[F[*]: CatsShow, G[*]: CatsShow](using showActual: G[Float]): F[PosFloat] = {
-      internalDef.contraCoercible(showActual.asInstanceOf[cats.Show[Float]])
+      internalDef.contraCoercible[cats.Show, PosFloat, Float, cats.Contravariant](showActual.asInstanceOf[cats.Show[Float]])
     }.asInstanceOf[F[PosFloat]] // scalafix:ok DisableSyntax.asInstanceOf
-
   }
 
   type NonPosFloat = NonPosFloat.Type
-  object NonPosFloat extends Numeric[Float], MinMax[Float] {
+  object NonPosFloat extends Numeric[Float], MinMax[Float], NonPosFloatTypeClassInstances {
     override def min: Type = apply(-java.lang.Float.MAX_VALUE)
     override def max: Type = apply(0f)
 
@@ -541,20 +693,28 @@ object numeric extends OrphanCats, OrphanCatsKernel {
 
     override inline def predicate(a: Float): Boolean = a <= 0f
 
+  }
+  private[types] trait NonPosFloatTypeClassInstances extends NonPosFloatTypeClassInstance1 {
     @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
     inline given derivedNonPosFloatEq[F[*]: CatsEq, G[*]: CatsEq](using eqActual: G[Float]): F[NonPosFloat] = {
-      internalDef.contraCoercible(eqActual.asInstanceOf[cats.Eq[Float]])
+      internalDef.contraCoercible[cats.Eq, NonPosFloat, Float, cats.Contravariant](eqActual.asInstanceOf[cats.Eq[Float]])
     }.asInstanceOf[F[NonPosFloat]] // scalafix:ok DisableSyntax.asInstanceOf
-
+  }
+  private[types] trait NonPosFloatTypeClassInstance1 extends NonPosFloatTypeClassInstance2 {
+    @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
+    inline given derivedNonPosFloatHash[F[*]: CatsHash, G[*]: CatsHash](using hashActual: G[Float]): F[NonPosFloat] = {
+      internalDef.contraCoercible[cats.Hash, NonPosFloat, Float, cats.Contravariant](hashActual.asInstanceOf[cats.Hash[Float]])
+    }.asInstanceOf[F[NonPosFloat]] // scalafix:ok DisableSyntax.asInstanceOf
+  }
+  private[types] trait NonPosFloatTypeClassInstance2 extends OrphanCats, OrphanCatsKernel {
     @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
     inline given derivedNonPosFloatShow[F[*]: CatsShow, G[*]: CatsShow](using showActual: G[Float]): F[NonPosFloat] = {
-      internalDef.contraCoercible(showActual.asInstanceOf[cats.Show[Float]])
+      internalDef.contraCoercible[cats.Show, NonPosFloat, Float, cats.Contravariant](showActual.asInstanceOf[cats.Show[Float]])
     }.asInstanceOf[F[NonPosFloat]] // scalafix:ok DisableSyntax.asInstanceOf
-
   }
 
   type NegDouble = NegDouble.Type
-  object NegDouble extends Numeric[Double], MinMax[Double] {
+  object NegDouble extends Numeric[Double], MinMax[Double], NegDoubleTypeClassInstances {
     override def min: Type = apply(-java.lang.Double.MAX_VALUE) // Double.MinValue
     override def max: Type = apply(-4.9e-324d) // math.nextDown(0d)
 
@@ -562,20 +722,28 @@ object numeric extends OrphanCats, OrphanCatsKernel {
 
     override inline def predicate(a: Double): Boolean = a < 0d
 
+  }
+  private[types] trait NegDoubleTypeClassInstances extends NegDoubleTypeClassInstance1 {
     @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
     inline given derivedNegDoubleEq[F[*]: CatsEq, G[*]: CatsEq](using eqActual: G[Double]): F[NegDouble] = {
-      internalDef.contraCoercible(eqActual.asInstanceOf[cats.Eq[Double]])
+      internalDef.contraCoercible[cats.Eq, NegDouble, Double, cats.Contravariant](eqActual.asInstanceOf[cats.Eq[Double]])
     }.asInstanceOf[F[NegDouble]] // scalafix:ok DisableSyntax.asInstanceOf
-
+  }
+  private[types] trait NegDoubleTypeClassInstance1 extends NegDoubleTypeClassInstance2 {
+    @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
+    inline given derivedNegDoubleHash[F[*]: CatsHash, G[*]: CatsHash](using hashActual: G[Double]): F[NegDouble] = {
+      internalDef.contraCoercible[cats.Hash, NegDouble, Double, cats.Contravariant](hashActual.asInstanceOf[cats.Hash[Double]])
+    }.asInstanceOf[F[NegDouble]] // scalafix:ok DisableSyntax.asInstanceOf
+  }
+  private[types] trait NegDoubleTypeClassInstance2 extends OrphanCats, OrphanCatsKernel {
     @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
     inline given derivedNegDoubleShow[F[*]: CatsShow, G[*]: CatsShow](using showActual: G[Double]): F[NegDouble] = {
-      internalDef.contraCoercible(showActual.asInstanceOf[cats.Show[Double]])
+      internalDef.contraCoercible[cats.Show, NegDouble, Double, cats.Contravariant](showActual.asInstanceOf[cats.Show[Double]])
     }.asInstanceOf[F[NegDouble]] // scalafix:ok DisableSyntax.asInstanceOf
-
   }
 
   type NonNegDouble = NonNegDouble.Type
-  object NonNegDouble extends Numeric[Double], MinMax[Double] {
+  object NonNegDouble extends Numeric[Double], MinMax[Double], NonNegDoubleTypeClassInstances {
     override def min: Type = apply(0d)
     override def max: Type = apply(Double.MaxValue)
 
@@ -583,20 +751,28 @@ object numeric extends OrphanCats, OrphanCatsKernel {
 
     override inline def predicate(a: Double): Boolean = a >= 0d
 
+  }
+  private[types] trait NonNegDoubleTypeClassInstances extends NonNegDoubleTypeClassInstance1 {
     @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
     inline given derivedNonNegDoubleEq[F[*]: CatsEq, G[*]: CatsEq](using eqActual: G[Double]): F[NonNegDouble] = {
-      internalDef.contraCoercible(eqActual.asInstanceOf[cats.Eq[Double]])
+      internalDef.contraCoercible[cats.Eq, NonNegDouble, Double, cats.Contravariant](eqActual.asInstanceOf[cats.Eq[Double]])
     }.asInstanceOf[F[NonNegDouble]] // scalafix:ok DisableSyntax.asInstanceOf
-
+  }
+  private[types] trait NonNegDoubleTypeClassInstance1 extends NonNegDoubleTypeClassInstance2 {
+    @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
+    inline given derivedNonNegDoubleHash[F[*]: CatsHash, G[*]: CatsHash](using hashActual: G[Double]): F[NonNegDouble] = {
+      internalDef.contraCoercible[cats.Hash, NonNegDouble, Double, cats.Contravariant](hashActual.asInstanceOf[cats.Hash[Double]])
+    }.asInstanceOf[F[NonNegDouble]] // scalafix:ok DisableSyntax.asInstanceOf
+  }
+  private[types] trait NonNegDoubleTypeClassInstance2 extends OrphanCats, OrphanCatsKernel {
     @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
     inline given derivedNonNegDoubleShow[F[*]: CatsShow, G[*]: CatsShow](using showActual: G[Double]): F[NonNegDouble] = {
-      internalDef.contraCoercible(showActual.asInstanceOf[cats.Show[Double]])
+      internalDef.contraCoercible[cats.Show, NonNegDouble, Double, cats.Contravariant](showActual.asInstanceOf[cats.Show[Double]])
     }.asInstanceOf[F[NonNegDouble]] // scalafix:ok DisableSyntax.asInstanceOf
-
   }
 
   type PosDouble = PosDouble.Type
-  object PosDouble extends Numeric[Double], MinMax[Double] {
+  object PosDouble extends Numeric[Double], MinMax[Double], PosDoubleTypeClassInstances {
     override def min: Type = apply(4.9e-324d) // math.nextUp(0d)
     override def max: Type = apply(Double.MaxValue)
 
@@ -604,20 +780,28 @@ object numeric extends OrphanCats, OrphanCatsKernel {
 
     override inline def predicate(a: Double): Boolean = a > 0d
 
+  }
+  private[types] trait PosDoubleTypeClassInstances extends PosDoubleTypeClassInstance1 {
     @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
     inline given derivedPosDoubleEq[F[*]: CatsEq, G[*]: CatsEq](using eqActual: G[Double]): F[PosDouble] = {
-      internalDef.contraCoercible(eqActual.asInstanceOf[cats.Eq[Double]])
+      internalDef.contraCoercible[cats.Eq, PosDouble, Double, cats.Contravariant](eqActual.asInstanceOf[cats.Eq[Double]])
     }.asInstanceOf[F[PosDouble]] // scalafix:ok DisableSyntax.asInstanceOf
-
+  }
+  private[types] trait PosDoubleTypeClassInstance1 extends PosDoubleTypeClassInstance2 {
+    @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
+    inline given derivedPosDoubleHash[F[*]: CatsHash, G[*]: CatsHash](using hashActual: G[Double]): F[PosDouble] = {
+      internalDef.contraCoercible[cats.Hash, PosDouble, Double, cats.Contravariant](hashActual.asInstanceOf[cats.Hash[Double]])
+    }.asInstanceOf[F[PosDouble]] // scalafix:ok DisableSyntax.asInstanceOf
+  }
+  private[types] trait PosDoubleTypeClassInstance2 extends OrphanCats, OrphanCatsKernel {
     @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
     inline given derivedPosDoubleShow[F[*]: CatsShow, G[*]: CatsShow](using showActual: G[Double]): F[PosDouble] = {
-      internalDef.contraCoercible(showActual.asInstanceOf[cats.Show[Double]])
+      internalDef.contraCoercible[cats.Show, PosDouble, Double, cats.Contravariant](showActual.asInstanceOf[cats.Show[Double]])
     }.asInstanceOf[F[PosDouble]] // scalafix:ok DisableSyntax.asInstanceOf
-
   }
 
   type NonPosDouble = NonPosDouble.Type
-  object NonPosDouble extends Numeric[Double], MinMax[Double] {
+  object NonPosDouble extends Numeric[Double], MinMax[Double], NonPosDoubleTypeClassInstances {
     override def min: Type = apply(-java.lang.Double.MAX_VALUE) // Double.MinValue
     override def max: Type = apply(0d)
 
@@ -625,16 +809,24 @@ object numeric extends OrphanCats, OrphanCatsKernel {
 
     override inline def predicate(a: Double): Boolean = a <= 0d
 
+  }
+  private[types] trait NonPosDoubleTypeClassInstances extends NonPosDoubleTypeClassInstance1 {
     @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
     inline given derivedNonPosDoubleEq[F[*]: CatsEq, G[*]: CatsEq](using eqActual: G[Double]): F[NonPosDouble] = {
-      internalDef.contraCoercible(eqActual.asInstanceOf[cats.Eq[Double]])
+      internalDef.contraCoercible[cats.Eq, NonPosDouble, Double, cats.Contravariant](eqActual.asInstanceOf[cats.Eq[Double]])
     }.asInstanceOf[F[NonPosDouble]] // scalafix:ok DisableSyntax.asInstanceOf
-
+  }
+  private[types] trait NonPosDoubleTypeClassInstance1 extends NonPosDoubleTypeClassInstance2 {
+    @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
+    inline given derivedNonPosDoubleHash[F[*]: CatsHash, G[*]: CatsHash](using hashActual: G[Double]): F[NonPosDouble] = {
+      internalDef.contraCoercible[cats.Hash, NonPosDouble, Double, cats.Contravariant](hashActual.asInstanceOf[cats.Hash[Double]])
+    }.asInstanceOf[F[NonPosDouble]] // scalafix:ok DisableSyntax.asInstanceOf
+  }
+  private[types] trait NonPosDoubleTypeClassInstance2 extends OrphanCats, OrphanCatsKernel {
     @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
     inline given derivedNonPosDoubleShow[F[*]: CatsShow, G[*]: CatsShow](using showActual: G[Double]): F[NonPosDouble] = {
-      internalDef.contraCoercible(showActual.asInstanceOf[cats.Show[Double]])
+      internalDef.contraCoercible[cats.Show, NonPosDouble, Double, cats.Contravariant](showActual.asInstanceOf[cats.Show[Double]])
     }.asInstanceOf[F[NonPosDouble]] // scalafix:ok DisableSyntax.asInstanceOf
-
   }
 
   val BigInt0: BigInt = numericTools.BigInt0
@@ -643,7 +835,7 @@ object numeric extends OrphanCats, OrphanCatsKernel {
 
   type NegBigInt = NegBigInt.Type
   @SuppressWarnings(Array("org.wartremover.warts.Overloading"))
-  object NegBigInt extends InlinedNumeric[BigInt] {
+  object NegBigInt extends InlinedNumeric[BigInt], NegBigIntTypeClassInstances {
     override inline def invalidReason(a: BigInt): String = expectedMessage("a negative BigInt")
 
     override def predicate(a: BigInt): Boolean = a < BigInt0
@@ -660,21 +852,29 @@ object numeric extends OrphanCats, OrphanCatsKernel {
 
     inline def apply(inline a: String): Type = apply(BigInt(a))
 
+  }
+  private[types] trait NegBigIntTypeClassInstances extends NegBigIntTypeClassInstance1 {
     @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
     inline given derivedNegBigIntEq[F[*]: CatsEq, G[*]: CatsEq](using eqActual: G[BigInt]): F[NegBigInt] = {
-      internalDef.contraCoercible(eqActual.asInstanceOf[cats.Eq[BigInt]])
+      internalDef.contraCoercible[cats.Eq, NegBigInt, BigInt, cats.Contravariant](eqActual.asInstanceOf[cats.Eq[BigInt]])
     }.asInstanceOf[F[NegBigInt]] // scalafix:ok DisableSyntax.asInstanceOf
-
+  }
+  private[types] trait NegBigIntTypeClassInstance1 extends NegBigIntTypeClassInstance2 {
+    @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
+    inline given derivedNegBigIntHash[F[*]: CatsHash, G[*]: CatsHash](using hashActual: G[BigInt]): F[NegBigInt] = {
+      internalDef.contraCoercible[cats.Hash, NegBigInt, BigInt, cats.Contravariant](hashActual.asInstanceOf[cats.Hash[BigInt]])
+    }.asInstanceOf[F[NegBigInt]] // scalafix:ok DisableSyntax.asInstanceOf
+  }
+  private[types] trait NegBigIntTypeClassInstance2 extends OrphanCats, OrphanCatsKernel {
     @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
     inline given derivedNegBigIntShow[F[*]: CatsShow, G[*]: CatsShow](using showActual: G[BigInt]): F[NegBigInt] = {
-      internalDef.contraCoercible(showActual.asInstanceOf[cats.Show[BigInt]])
+      internalDef.contraCoercible[cats.Show, NegBigInt, BigInt, cats.Contravariant](showActual.asInstanceOf[cats.Show[BigInt]])
     }.asInstanceOf[F[NegBigInt]] // scalafix:ok DisableSyntax.asInstanceOf
-
   }
 
   type NonNegBigInt = NonNegBigInt.Type
   @SuppressWarnings(Array("org.wartremover.warts.Overloading"))
-  object NonNegBigInt extends InlinedNumeric[BigInt] {
+  object NonNegBigInt extends InlinedNumeric[BigInt], NonNegBigIntTypeClassInstances {
     override inline def invalidReason(a: BigInt): String = expectedMessage("a non-negative BigInt")
 
     override def predicate(a: BigInt): Boolean = a >= BigInt0
@@ -689,21 +889,29 @@ object numeric extends OrphanCats, OrphanCatsKernel {
 
     inline def apply(inline a: String): Type = apply(BigInt(a))
 
+  }
+  private[types] trait NonNegBigIntTypeClassInstances extends NonNegBigIntTypeClassInstance1 {
     @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
     inline given derivedNonNegBigIntEq[F[*]: CatsEq, G[*]: CatsEq](using eqActual: G[BigInt]): F[NonNegBigInt] = {
-      internalDef.contraCoercible(eqActual.asInstanceOf[cats.Eq[BigInt]])
+      internalDef.contraCoercible[cats.Eq, NonNegBigInt, BigInt, cats.Contravariant](eqActual.asInstanceOf[cats.Eq[BigInt]])
     }.asInstanceOf[F[NonNegBigInt]] // scalafix:ok DisableSyntax.asInstanceOf
-
+  }
+  private[types] trait NonNegBigIntTypeClassInstance1 extends NonNegBigIntTypeClassInstance2 {
+    @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
+    inline given derivedNonNegBigIntHash[F[*]: CatsHash, G[*]: CatsHash](using hashActual: G[BigInt]): F[NonNegBigInt] = {
+      internalDef.contraCoercible[cats.Hash, NonNegBigInt, BigInt, cats.Contravariant](hashActual.asInstanceOf[cats.Hash[BigInt]])
+    }.asInstanceOf[F[NonNegBigInt]] // scalafix:ok DisableSyntax.asInstanceOf
+  }
+  private[types] trait NonNegBigIntTypeClassInstance2 extends OrphanCats, OrphanCatsKernel {
     @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
     inline given derivedNonNegBigIntShow[F[*]: CatsShow, G[*]: CatsShow](using showActual: G[BigInt]): F[NonNegBigInt] = {
-      internalDef.contraCoercible(showActual.asInstanceOf[cats.Show[BigInt]])
+      internalDef.contraCoercible[cats.Show, NonNegBigInt, BigInt, cats.Contravariant](showActual.asInstanceOf[cats.Show[BigInt]])
     }.asInstanceOf[F[NonNegBigInt]] // scalafix:ok DisableSyntax.asInstanceOf
-
   }
 
   type PosBigInt = PosBigInt.Type
   @SuppressWarnings(Array("org.wartremover.warts.Overloading"))
-  object PosBigInt extends InlinedNumeric[BigInt] {
+  object PosBigInt extends InlinedNumeric[BigInt], PosBigIntTypeClassInstances {
     override inline def invalidReason(a: BigInt): String = expectedMessage("a positive BigInt")
 
     override def predicate(a: BigInt): Boolean = a > BigInt0
@@ -718,21 +926,29 @@ object numeric extends OrphanCats, OrphanCatsKernel {
 
     inline def apply(inline a: String): Type = apply(BigInt(a))
 
+  }
+  private[types] trait PosBigIntTypeClassInstances extends PosBigIntTypeClassInstance1 {
     @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
     inline given derivedPosBigIntEq[F[*]: CatsEq, G[*]: CatsEq](using eqActual: G[BigInt]): F[PosBigInt] = {
-      internalDef.contraCoercible(eqActual.asInstanceOf[cats.Eq[BigInt]])
+      internalDef.contraCoercible[cats.Eq, PosBigInt, BigInt, cats.Contravariant](eqActual.asInstanceOf[cats.Eq[BigInt]])
     }.asInstanceOf[F[PosBigInt]] // scalafix:ok DisableSyntax.asInstanceOf
-
+  }
+  private[types] trait PosBigIntTypeClassInstance1 extends PosBigIntTypeClassInstance2 {
+    @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
+    inline given derivedPosBigIntHash[F[*]: CatsHash, G[*]: CatsHash](using hashActual: G[BigInt]): F[PosBigInt] = {
+      internalDef.contraCoercible[cats.Hash, PosBigInt, BigInt, cats.Contravariant](hashActual.asInstanceOf[cats.Hash[BigInt]])
+    }.asInstanceOf[F[PosBigInt]] // scalafix:ok DisableSyntax.asInstanceOf
+  }
+  private[types] trait PosBigIntTypeClassInstance2 extends OrphanCats, OrphanCatsKernel {
     @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
     inline given derivedPosBigIntShow[F[*]: CatsShow, G[*]: CatsShow](using showActual: G[BigInt]): F[PosBigInt] = {
-      internalDef.contraCoercible(showActual.asInstanceOf[cats.Show[BigInt]])
+      internalDef.contraCoercible[cats.Show, PosBigInt, BigInt, cats.Contravariant](showActual.asInstanceOf[cats.Show[BigInt]])
     }.asInstanceOf[F[PosBigInt]] // scalafix:ok DisableSyntax.asInstanceOf
-
   }
 
   type NonPosBigInt = NonPosBigInt.Type
   @SuppressWarnings(Array("org.wartremover.warts.Overloading"))
-  object NonPosBigInt extends InlinedNumeric[BigInt] {
+  object NonPosBigInt extends InlinedNumeric[BigInt], NonPosBigIntTypeClassInstances {
     override inline def invalidReason(a: BigInt): String = expectedMessage("a non-positive BigInt")
 
     override def predicate(a: BigInt): Boolean = a <= BigInt0
@@ -747,21 +963,29 @@ object numeric extends OrphanCats, OrphanCatsKernel {
 
     inline def apply(inline a: String): Type = apply(BigInt(a))
 
+  }
+  private[types] trait NonPosBigIntTypeClassInstances extends NonPosBigIntTypeClassInstance1 {
     @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
     inline given derivedNonPosBigIntEq[F[*]: CatsEq, G[*]: CatsEq](using eqActual: G[BigInt]): F[NonPosBigInt] = {
-      internalDef.contraCoercible(eqActual.asInstanceOf[cats.Eq[BigInt]])
+      internalDef.contraCoercible[cats.Eq, NonPosBigInt, BigInt, cats.Contravariant](eqActual.asInstanceOf[cats.Eq[BigInt]])
     }.asInstanceOf[F[NonPosBigInt]] // scalafix:ok DisableSyntax.asInstanceOf
-
+  }
+  private[types] trait NonPosBigIntTypeClassInstance1 extends NonPosBigIntTypeClassInstance2 {
+    @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
+    inline given derivedNonPosBigIntHash[F[*]: CatsHash, G[*]: CatsHash](using hashActual: G[BigInt]): F[NonPosBigInt] = {
+      internalDef.contraCoercible[cats.Hash, NonPosBigInt, BigInt, cats.Contravariant](hashActual.asInstanceOf[cats.Hash[BigInt]])
+    }.asInstanceOf[F[NonPosBigInt]] // scalafix:ok DisableSyntax.asInstanceOf
+  }
+  private[types] trait NonPosBigIntTypeClassInstance2 extends OrphanCats, OrphanCatsKernel {
     @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
     inline given derivedNonPosBigIntShow[F[*]: CatsShow, G[*]: CatsShow](using showActual: G[BigInt]): F[NonPosBigInt] = {
-      internalDef.contraCoercible(showActual.asInstanceOf[cats.Show[BigInt]])
+      internalDef.contraCoercible[cats.Show, NonPosBigInt, BigInt, cats.Contravariant](showActual.asInstanceOf[cats.Show[BigInt]])
     }.asInstanceOf[F[NonPosBigInt]] // scalafix:ok DisableSyntax.asInstanceOf
-
   }
 
   type NegBigDecimal = NegBigDecimal.Type
   @SuppressWarnings(Array("org.wartremover.warts.Overloading"))
-  object NegBigDecimal extends InlinedNumeric[BigDecimal] {
+  object NegBigDecimal extends InlinedNumeric[BigDecimal], NegBigDecimalTypeClassInstances {
     override inline def invalidReason(a: BigDecimal): String = expectedMessage("a negative BigDecimal")
 
     override def predicate(a: BigDecimal): Boolean = a < BigDecimal0
@@ -780,21 +1004,29 @@ object numeric extends OrphanCats, OrphanCatsKernel {
 
     inline def apply(inline a: String): Type = apply(BigDecimal(a))
 
+  }
+  private[types] trait NegBigDecimalTypeClassInstances extends NegBigDecimalTypeClassInstance1 {
     @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
     inline given derivedNegBigDecimalEq[F[*]: CatsEq, G[*]: CatsEq](using eqActual: G[BigDecimal]): F[NegBigDecimal] = {
-      internalDef.contraCoercible(eqActual.asInstanceOf[cats.Eq[BigDecimal]])
+      internalDef.contraCoercible[cats.Eq, NegBigDecimal, BigDecimal, cats.Contravariant](eqActual.asInstanceOf[cats.Eq[BigDecimal]])
     }.asInstanceOf[F[NegBigDecimal]] // scalafix:ok DisableSyntax.asInstanceOf
-
+  }
+  private[types] trait NegBigDecimalTypeClassInstance1 extends NegBigDecimalTypeClassInstance2 {
+    @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
+    inline given derivedNegBigDecimalHash[F[*]: CatsHash, G[*]: CatsHash](using hashActual: G[BigDecimal]): F[NegBigDecimal] = {
+      internalDef.contraCoercible[cats.Hash, NegBigDecimal, BigDecimal, cats.Contravariant](hashActual.asInstanceOf[cats.Hash[BigDecimal]])
+    }.asInstanceOf[F[NegBigDecimal]] // scalafix:ok DisableSyntax.asInstanceOf
+  }
+  private[types] trait NegBigDecimalTypeClassInstance2 extends OrphanCats, OrphanCatsKernel {
     @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
     inline given derivedNegBigDecimalShow[F[*]: CatsShow, G[*]: CatsShow](using showActual: G[BigDecimal]): F[NegBigDecimal] = {
-      internalDef.contraCoercible(showActual.asInstanceOf[cats.Show[BigDecimal]])
+      internalDef.contraCoercible[cats.Show, NegBigDecimal, BigDecimal, cats.Contravariant](showActual.asInstanceOf[cats.Show[BigDecimal]])
     }.asInstanceOf[F[NegBigDecimal]] // scalafix:ok DisableSyntax.asInstanceOf
-
   }
 
   type NonNegBigDecimal = NonNegBigDecimal.Type
   @SuppressWarnings(Array("org.wartremover.warts.Overloading"))
-  object NonNegBigDecimal extends InlinedNumeric[BigDecimal] {
+  object NonNegBigDecimal extends InlinedNumeric[BigDecimal], NonNegBigDecimalTypeClassInstances {
     override inline def invalidReason(a: BigDecimal): String = expectedMessage("a non-negative BigDecimal")
 
     override def predicate(a: BigDecimal): Boolean = a >= BigDecimal0
@@ -813,21 +1045,33 @@ object numeric extends OrphanCats, OrphanCatsKernel {
 
     inline def apply(inline a: String): Type = apply(BigDecimal(a))
 
+  }
+  private[types] trait NonNegBigDecimalTypeClassInstances extends NonNegBigDecimalTypeClassInstance1 {
     @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
     inline given derivedNonNegBigDecimalEq[F[*]: CatsEq, G[*]: CatsEq](using eqActual: G[BigDecimal]): F[NonNegBigDecimal] = {
-      internalDef.contraCoercible(eqActual.asInstanceOf[cats.Eq[BigDecimal]])
+      internalDef.contraCoercible[cats.Eq, NonNegBigDecimal, BigDecimal, cats.Contravariant](eqActual.asInstanceOf[cats.Eq[BigDecimal]])
     }.asInstanceOf[F[NonNegBigDecimal]] // scalafix:ok DisableSyntax.asInstanceOf
-
+  }
+  private[types] trait NonNegBigDecimalTypeClassInstance1 extends NonNegBigDecimalTypeClassInstance2 {
+    @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
+    inline given derivedNonNegBigDecimalHash[F[*]: CatsHash, G[*]: CatsHash](using hashActual: G[BigDecimal]): F[NonNegBigDecimal] = {
+      internalDef.contraCoercible[cats.Hash, NonNegBigDecimal, BigDecimal, cats.Contravariant](
+        hashActual.asInstanceOf[cats.Hash[BigDecimal]]
+      )
+    }.asInstanceOf[F[NonNegBigDecimal]] // scalafix:ok DisableSyntax.asInstanceOf
+  }
+  private[types] trait NonNegBigDecimalTypeClassInstance2 extends OrphanCats, OrphanCatsKernel {
     @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
     inline given derivedNonNegBigDecimalShow[F[*]: CatsShow, G[*]: CatsShow](using showActual: G[BigDecimal]): F[NonNegBigDecimal] = {
-      internalDef.contraCoercible(showActual.asInstanceOf[cats.Show[BigDecimal]])
+      internalDef.contraCoercible[cats.Show, NonNegBigDecimal, BigDecimal, cats.Contravariant](
+        showActual.asInstanceOf[cats.Show[BigDecimal]]
+      )
     }.asInstanceOf[F[NonNegBigDecimal]] // scalafix:ok DisableSyntax.asInstanceOf
-
   }
 
   type PosBigDecimal = PosBigDecimal.Type
   @SuppressWarnings(Array("org.wartremover.warts.Overloading"))
-  object PosBigDecimal extends InlinedNumeric[BigDecimal] {
+  object PosBigDecimal extends InlinedNumeric[BigDecimal], PosBigDecimalTypeClassInstances {
     override inline def invalidReason(a: BigDecimal): String = expectedMessage("a positive BigDecimal")
 
     override def predicate(a: BigDecimal): Boolean = a > BigDecimal0
@@ -846,21 +1090,29 @@ object numeric extends OrphanCats, OrphanCatsKernel {
 
     inline def apply(inline a: String): Type = apply(BigDecimal(a))
 
+  }
+  private[types] trait PosBigDecimalTypeClassInstances extends PosBigDecimalTypeClassInstance1 {
     @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
     inline given derivedPosBigDecimalEq[F[*]: CatsEq, G[*]: CatsEq](using eqActual: G[BigDecimal]): F[PosBigDecimal] = {
-      internalDef.contraCoercible(eqActual.asInstanceOf[cats.Eq[BigDecimal]])
+      internalDef.contraCoercible[cats.Eq, PosBigDecimal, BigDecimal, cats.Contravariant](eqActual.asInstanceOf[cats.Eq[BigDecimal]])
     }.asInstanceOf[F[PosBigDecimal]] // scalafix:ok DisableSyntax.asInstanceOf
-
+  }
+  private[types] trait PosBigDecimalTypeClassInstance1 extends PosBigDecimalTypeClassInstance2 {
+    @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
+    inline given derivedPosBigDecimalHash[F[*]: CatsHash, G[*]: CatsHash](using hashActual: G[BigDecimal]): F[PosBigDecimal] = {
+      internalDef.contraCoercible[cats.Hash, PosBigDecimal, BigDecimal, cats.Contravariant](hashActual.asInstanceOf[cats.Hash[BigDecimal]])
+    }.asInstanceOf[F[PosBigDecimal]] // scalafix:ok DisableSyntax.asInstanceOf
+  }
+  private[types] trait PosBigDecimalTypeClassInstance2 extends OrphanCats, OrphanCatsKernel {
     @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
     inline given derivedPosBigDecimalShow[F[*]: CatsShow, G[*]: CatsShow](using showActual: G[BigDecimal]): F[PosBigDecimal] = {
-      internalDef.contraCoercible(showActual.asInstanceOf[cats.Show[BigDecimal]])
+      internalDef.contraCoercible[cats.Show, PosBigDecimal, BigDecimal, cats.Contravariant](showActual.asInstanceOf[cats.Show[BigDecimal]])
     }.asInstanceOf[F[PosBigDecimal]] // scalafix:ok DisableSyntax.asInstanceOf
-
   }
 
   type NonPosBigDecimal = NonPosBigDecimal.Type
   @SuppressWarnings(Array("org.wartremover.warts.Overloading"))
-  object NonPosBigDecimal extends InlinedNumeric[BigDecimal] {
+  object NonPosBigDecimal extends InlinedNumeric[BigDecimal], NonPosBigDecimalTypeClassInstances {
     override inline def invalidReason(a: BigDecimal): String = expectedMessage("a non-positive BigDecimal")
 
     override def predicate(a: BigDecimal): Boolean = a <= BigDecimal0
@@ -879,16 +1131,28 @@ object numeric extends OrphanCats, OrphanCatsKernel {
 
     inline def apply(inline a: String): Type = apply(BigDecimal(a))
 
+  }
+  private[types] trait NonPosBigDecimalTypeClassInstances extends NonPosBigDecimalTypeClassInstance1 {
     @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
     inline given derivedNonPosBigDecimalEq[F[*]: CatsEq, G[*]: CatsEq](using eqActual: G[BigDecimal]): F[NonPosBigDecimal] = {
-      internalDef.contraCoercible(eqActual.asInstanceOf[cats.Eq[BigDecimal]])
+      internalDef.contraCoercible[cats.Eq, NonPosBigDecimal, BigDecimal, cats.Contravariant](eqActual.asInstanceOf[cats.Eq[BigDecimal]])
     }.asInstanceOf[F[NonPosBigDecimal]] // scalafix:ok DisableSyntax.asInstanceOf
-
+  }
+  private[types] trait NonPosBigDecimalTypeClassInstance1 extends NonPosBigDecimalTypeClassInstance2 {
+    @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
+    inline given derivedNonPosBigDecimalHash[F[*]: CatsHash, G[*]: CatsHash](using hashActual: G[BigDecimal]): F[NonPosBigDecimal] = {
+      internalDef.contraCoercible[cats.Hash, NonPosBigDecimal, BigDecimal, cats.Contravariant](
+        hashActual.asInstanceOf[cats.Hash[BigDecimal]]
+      )
+    }.asInstanceOf[F[NonPosBigDecimal]] // scalafix:ok DisableSyntax.asInstanceOf
+  }
+  private[types] trait NonPosBigDecimalTypeClassInstance2 extends OrphanCats, OrphanCatsKernel {
     @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
     inline given derivedNonPosBigDecimalShow[F[*]: CatsShow, G[*]: CatsShow](using showActual: G[BigDecimal]): F[NonPosBigDecimal] = {
-      internalDef.contraCoercible(showActual.asInstanceOf[cats.Show[BigDecimal]])
+      internalDef.contraCoercible[cats.Show, NonPosBigDecimal, BigDecimal, cats.Contravariant](
+        showActual.asInstanceOf[cats.Show[BigDecimal]]
+      )
     }.asInstanceOf[F[NonPosBigDecimal]] // scalafix:ok DisableSyntax.asInstanceOf
-
   }
 
 }

--- a/modules/test-refined4s-core-without-cats/shared/src/test/scala/refined4s/types/numericWithoutCatsSpec.scala
+++ b/modules/test-refined4s-core-without-cats/shared/src/test/scala/refined4s/types/numericWithoutCatsSpec.scala
@@ -20,7 +20,8 @@ object numericWithoutCatsSpec extends Properties {
 
   object negIntSpec {
     def tests: List[Test] = List(
-      example("test Eq[NegInt]", testEq),
+      example("test   Eq[NegInt]", testEq),
+      example("test Hash[NegInt]", testHash),
       example("test Show[NegInt]", testShow),
     )
 
@@ -30,8 +31,25 @@ object numericWithoutCatsSpec extends Properties {
 
       val actual = typeCheckErrors(
         """
-         val _ = refined4s.types.numeric.NegInt.derivedNegIntEq
-      """
+        val _ = refined4s.types.numeric.NegInt.derivedNegIntEq
+        """
+      ).map(_.message).mkString
+
+      (actual ==== expected)
+        .log(
+          """The actual error message doesn't start with the expected one.
+            |""".stripMargin
+        )
+    }
+
+    def testHash: Result = {
+      import scala.compiletime.testing.typeCheckErrors
+      val expected = ExpectedErrorMessages.missingHash
+
+      val actual = typeCheckErrors(
+        """
+        val _ = refined4s.types.numeric.NegInt.derivedNegIntHash
+        """
       ).map(_.message).mkString
 
       (actual ==== expected)
@@ -47,8 +65,8 @@ object numericWithoutCatsSpec extends Properties {
 
       val actual = typeCheckErrors(
         """
-         val _ = refined4s.types.numeric.NegInt.derivedNegIntShow
-      """
+        val _ = refined4s.types.numeric.NegInt.derivedNegIntShow
+        """
       ).map(_.message).mkString
 
       (actual ==== expected)
@@ -61,7 +79,8 @@ object numericWithoutCatsSpec extends Properties {
 
   object nonNegIntSpec {
     def tests: List[Test] = List(
-      example("test Eq[NonNegInt]", testEq),
+      example("test   Eq[NonNegInt]", testEq),
+      example("test Hash[NonNegInt]", testHash),
       example("test Show[NonNegInt]", testShow),
     )
 
@@ -71,8 +90,25 @@ object numericWithoutCatsSpec extends Properties {
 
       val actual = typeCheckErrors(
         """
-         val _ = refined4s.types.numeric.NonNegInt.derivedNonNegIntEq
-      """
+        val _ = refined4s.types.numeric.NonNegInt.derivedNonNegIntEq
+        """
+      ).map(_.message).mkString
+
+      (actual ==== expected)
+        .log(
+          """The actual error message doesn't start with the expected one.
+            |""".stripMargin
+        )
+    }
+
+    def testHash: Result = {
+      import scala.compiletime.testing.typeCheckErrors
+      val expected = ExpectedErrorMessages.missingHash
+
+      val actual = typeCheckErrors(
+        """
+        val _ = refined4s.types.numeric.NonNegInt.derivedNonNegIntHash
+        """
       ).map(_.message).mkString
 
       (actual ==== expected)
@@ -88,8 +124,8 @@ object numericWithoutCatsSpec extends Properties {
 
       val actual = typeCheckErrors(
         """
-         val _ = refined4s.types.numeric.NonNegInt.derivedNonNegIntShow
-      """
+        val _ = refined4s.types.numeric.NonNegInt.derivedNonNegIntShow
+        """
       ).map(_.message).mkString
 
       (actual ==== expected)
@@ -102,7 +138,8 @@ object numericWithoutCatsSpec extends Properties {
 
   object posIntSpec {
     def tests: List[Test] = List(
-      example("test Eq[PosInt]", testEq),
+      example("test   Eq[PosInt]", testEq),
+      example("test Hash[PosInt]", testHash),
       example("test Show[PosInt]", testShow),
     )
 
@@ -112,8 +149,25 @@ object numericWithoutCatsSpec extends Properties {
 
       val actual = typeCheckErrors(
         """
-         val _ = refined4s.types.numeric.PosInt.derivedPosIntEq
-      """
+        val _ = refined4s.types.numeric.PosInt.derivedPosIntEq
+        """
+      ).map(_.message).mkString
+
+      (actual ==== expected)
+        .log(
+          """The actual error message doesn't start with the expected one.
+            |""".stripMargin
+        )
+    }
+
+    def testHash: Result = {
+      import scala.compiletime.testing.typeCheckErrors
+      val expected = ExpectedErrorMessages.missingHash
+
+      val actual = typeCheckErrors(
+        """
+        val _ = refined4s.types.numeric.PosInt.derivedPosIntHash
+        """
       ).map(_.message).mkString
 
       (actual ==== expected)
@@ -129,8 +183,8 @@ object numericWithoutCatsSpec extends Properties {
 
       val actual = typeCheckErrors(
         """
-         val _ = refined4s.types.numeric.PosInt.derivedPosIntShow
-      """
+        val _ = refined4s.types.numeric.PosInt.derivedPosIntShow
+        """
       ).map(_.message).mkString
 
       (actual ==== expected)
@@ -143,7 +197,8 @@ object numericWithoutCatsSpec extends Properties {
 
   object nonPosIntSpec {
     def tests: List[Test] = List(
-      example("test Eq[NonPosInt]", testEq),
+      example("test   Eq[NonPosInt]", testEq),
+      example("test Hash[NonPosInt]", testHash),
       example("test Show[NonPosInt]", testShow),
     )
 
@@ -153,8 +208,25 @@ object numericWithoutCatsSpec extends Properties {
 
       val actual = typeCheckErrors(
         """
-         val _ = refined4s.types.numeric.NonPosInt.derivedNonPosIntEq
-      """
+        val _ = refined4s.types.numeric.NonPosInt.derivedNonPosIntEq
+        """
+      ).map(_.message).mkString
+
+      (actual ==== expected)
+        .log(
+          """The actual error message doesn't start with the expected one.
+            |""".stripMargin
+        )
+    }
+
+    def testHash: Result = {
+      import scala.compiletime.testing.typeCheckErrors
+      val expected = ExpectedErrorMessages.missingHash
+
+      val actual = typeCheckErrors(
+        """
+        val _ = refined4s.types.numeric.NonPosInt.derivedNonPosIntHash
+        """
       ).map(_.message).mkString
 
       (actual ==== expected)
@@ -170,8 +242,8 @@ object numericWithoutCatsSpec extends Properties {
 
       val actual = typeCheckErrors(
         """
-         val _ = refined4s.types.numeric.NonPosInt.derivedNonPosIntShow
-      """
+        val _ = refined4s.types.numeric.NonPosInt.derivedNonPosIntShow
+        """
       ).map(_.message).mkString
 
       (actual ==== expected)
@@ -184,7 +256,8 @@ object numericWithoutCatsSpec extends Properties {
 
   object negLongSpec {
     def tests: List[Test] = List(
-      example("test Eq[NegLong]", testEq),
+      example("test   Eq[NegLong]", testEq),
+      example("test Hash[NegLong]", testHash),
       example("test Show[NegLong]", testShow),
     )
 
@@ -194,8 +267,25 @@ object numericWithoutCatsSpec extends Properties {
 
       val actual = typeCheckErrors(
         """
-         val _ = refined4s.types.numeric.NegLong.derivedNegLongEq
-      """
+        val _ = refined4s.types.numeric.NegLong.derivedNegLongEq
+        """
+      ).map(_.message).mkString
+
+      (actual ==== expected)
+        .log(
+          """The actual error message doesn't start with the expected one.
+            |""".stripMargin
+        )
+    }
+
+    def testHash: Result = {
+      import scala.compiletime.testing.typeCheckErrors
+      val expected = ExpectedErrorMessages.missingHash
+
+      val actual = typeCheckErrors(
+        """
+        val _ = refined4s.types.numeric.NegLong.derivedNegLongHash
+        """
       ).map(_.message).mkString
 
       (actual ==== expected)
@@ -211,8 +301,8 @@ object numericWithoutCatsSpec extends Properties {
 
       val actual = typeCheckErrors(
         """
-         val _ = refined4s.types.numeric.NegLong.derivedNegLongShow
-      """
+        val _ = refined4s.types.numeric.NegLong.derivedNegLongShow
+        """
       ).map(_.message).mkString
 
       (actual ==== expected)
@@ -225,7 +315,8 @@ object numericWithoutCatsSpec extends Properties {
 
   object nonNegLongSpec {
     def tests: List[Test] = List(
-      example("test Eq[NonNegLong]", testEq),
+      example("test   Eq[NonNegLong]", testEq),
+      example("test Hash[NonNegLong]", testHash),
       example("test Show[NonNegLong]", testShow),
     )
 
@@ -235,8 +326,25 @@ object numericWithoutCatsSpec extends Properties {
 
       val actual = typeCheckErrors(
         """
-         val _ = refined4s.types.numeric.NonNegLong.derivedNonNegLongEq
-      """
+        val _ = refined4s.types.numeric.NonNegLong.derivedNonNegLongEq
+        """
+      ).map(_.message).mkString
+
+      (actual ==== expected)
+        .log(
+          """The actual error message doesn't start with the expected one.
+            |""".stripMargin
+        )
+    }
+
+    def testHash: Result = {
+      import scala.compiletime.testing.typeCheckErrors
+      val expected = ExpectedErrorMessages.missingHash
+
+      val actual = typeCheckErrors(
+        """
+        val _ = refined4s.types.numeric.NonNegLong.derivedNonNegLongHash
+        """
       ).map(_.message).mkString
 
       (actual ==== expected)
@@ -252,8 +360,8 @@ object numericWithoutCatsSpec extends Properties {
 
       val actual = typeCheckErrors(
         """
-         val _ = refined4s.types.numeric.NonNegLong.derivedNonNegLongShow
-      """
+        val _ = refined4s.types.numeric.NonNegLong.derivedNonNegLongShow
+        """
       ).map(_.message).mkString
 
       (actual ==== expected)
@@ -266,7 +374,8 @@ object numericWithoutCatsSpec extends Properties {
 
   object posLongSpec {
     def tests: List[Test] = List(
-      example("test Eq[PosLong]", testEq),
+      example("test   Eq[PosLong]", testEq),
+      example("test Hash[PosLong]", testHash),
       example("test Show[PosLong]", testShow),
     )
 
@@ -276,8 +385,25 @@ object numericWithoutCatsSpec extends Properties {
 
       val actual = typeCheckErrors(
         """
-         val _ = refined4s.types.numeric.PosLong.derivedPosLongEq
-      """
+        val _ = refined4s.types.numeric.PosLong.derivedPosLongEq
+        """
+      ).map(_.message).mkString
+
+      (actual ==== expected)
+        .log(
+          """The actual error message doesn't start with the expected one.
+            |""".stripMargin
+        )
+    }
+
+    def testHash: Result = {
+      import scala.compiletime.testing.typeCheckErrors
+      val expected = ExpectedErrorMessages.missingHash
+
+      val actual = typeCheckErrors(
+        """
+        val _ = refined4s.types.numeric.PosLong.derivedPosLongHash
+        """
       ).map(_.message).mkString
 
       (actual ==== expected)
@@ -293,8 +419,8 @@ object numericWithoutCatsSpec extends Properties {
 
       val actual = typeCheckErrors(
         """
-         val _ = refined4s.types.numeric.PosLong.derivedPosLongShow
-      """
+        val _ = refined4s.types.numeric.PosLong.derivedPosLongShow
+        """
       ).map(_.message).mkString
 
       (actual ==== expected)
@@ -307,7 +433,8 @@ object numericWithoutCatsSpec extends Properties {
 
   object nonPosLongSpec {
     def tests: List[Test] = List(
-      example("test Eq[NonPosLong]", testEq),
+      example("test   Eq[NonPosLong]", testEq),
+      example("test Hash[NonPosLong]", testHash),
       example("test Show[NonPosLong]", testShow),
     )
 
@@ -317,8 +444,25 @@ object numericWithoutCatsSpec extends Properties {
 
       val actual = typeCheckErrors(
         """
-         val _ = refined4s.types.numeric.NonPosLong.derivedNonPosLongEq
-      """
+        val _ = refined4s.types.numeric.NonPosLong.derivedNonPosLongEq
+        """
+      ).map(_.message).mkString
+
+      (actual ==== expected)
+        .log(
+          """The actual error message doesn't start with the expected one.
+            |""".stripMargin
+        )
+    }
+
+    def testHash: Result = {
+      import scala.compiletime.testing.typeCheckErrors
+      val expected = ExpectedErrorMessages.missingHash
+
+      val actual = typeCheckErrors(
+        """
+        val _ = refined4s.types.numeric.NonPosLong.derivedNonPosLongHash
+        """
       ).map(_.message).mkString
 
       (actual ==== expected)
@@ -334,8 +478,8 @@ object numericWithoutCatsSpec extends Properties {
 
       val actual = typeCheckErrors(
         """
-         val _ = refined4s.types.numeric.NonPosLong.derivedNonPosLongShow
-      """
+        val _ = refined4s.types.numeric.NonPosLong.derivedNonPosLongShow
+        """
       ).map(_.message).mkString
 
       (actual ==== expected)
@@ -348,7 +492,8 @@ object numericWithoutCatsSpec extends Properties {
 
   object negShortSpec {
     def tests: List[Test] = List(
-      example("test Eq[NegShort]", testEq),
+      example("test   Eq[NegShort]", testEq),
+      example("test Hash[NegShort]", testHash),
       example("test Show[NegShort]", testShow),
     )
 
@@ -358,8 +503,25 @@ object numericWithoutCatsSpec extends Properties {
 
       val actual = typeCheckErrors(
         """
-         val _ = refined4s.types.numeric.NegShort.derivedNegShortEq
-      """
+        val _ = refined4s.types.numeric.NegShort.derivedNegShortEq
+        """
+      ).map(_.message).mkString
+
+      (actual ==== expected)
+        .log(
+          """The actual error message doesn't start with the expected one.
+            |""".stripMargin
+        )
+    }
+
+    def testHash: Result = {
+      import scala.compiletime.testing.typeCheckErrors
+      val expected = ExpectedErrorMessages.missingHash
+
+      val actual = typeCheckErrors(
+        """
+        val _ = refined4s.types.numeric.NegShort.derivedNegShortHash
+        """
       ).map(_.message).mkString
 
       (actual ==== expected)
@@ -375,8 +537,8 @@ object numericWithoutCatsSpec extends Properties {
 
       val actual = typeCheckErrors(
         """
-         val _ = refined4s.types.numeric.NegShort.derivedNegShortShow
-      """
+        val _ = refined4s.types.numeric.NegShort.derivedNegShortShow
+        """
       ).map(_.message).mkString
 
       (actual ==== expected)
@@ -389,7 +551,8 @@ object numericWithoutCatsSpec extends Properties {
 
   object nonNegShortSpec {
     def tests: List[Test] = List(
-      example("test Eq[NonNegShort]", testEq),
+      example("test   Eq[NonNegShort]", testEq),
+      example("test Hash[NonNegShort]", testHash),
       example("test Show[NonNegShort]", testShow),
     )
 
@@ -399,8 +562,25 @@ object numericWithoutCatsSpec extends Properties {
 
       val actual = typeCheckErrors(
         """
-         val _ = refined4s.types.numeric.NonNegShort.derivedNonNegShortEq
-      """
+        val _ = refined4s.types.numeric.NonNegShort.derivedNonNegShortEq
+        """
+      ).map(_.message).mkString
+
+      (actual ==== expected)
+        .log(
+          """The actual error message doesn't start with the expected one.
+            |""".stripMargin
+        )
+    }
+
+    def testHash: Result = {
+      import scala.compiletime.testing.typeCheckErrors
+      val expected = ExpectedErrorMessages.missingHash
+
+      val actual = typeCheckErrors(
+        """
+        val _ = refined4s.types.numeric.NonNegShort.derivedNonNegShortHash
+        """
       ).map(_.message).mkString
 
       (actual ==== expected)
@@ -416,8 +596,8 @@ object numericWithoutCatsSpec extends Properties {
 
       val actual = typeCheckErrors(
         """
-         val _ = refined4s.types.numeric.NonNegShort.derivedNonNegShortShow
-      """
+        val _ = refined4s.types.numeric.NonNegShort.derivedNonNegShortShow
+        """
       ).map(_.message).mkString
 
       (actual ==== expected)
@@ -430,7 +610,8 @@ object numericWithoutCatsSpec extends Properties {
 
   object posShortSpec {
     def tests: List[Test] = List(
-      example("test Eq[PosShort]", testEq),
+      example("test   Eq[PosShort]", testEq),
+      example("test Hash[PosShort]", testHash),
       example("test Show[PosShort]", testShow),
     )
 
@@ -440,8 +621,25 @@ object numericWithoutCatsSpec extends Properties {
 
       val actual = typeCheckErrors(
         """
-         val _ = refined4s.types.numeric.PosShort.derivedPosShortEq
-      """
+        val _ = refined4s.types.numeric.PosShort.derivedPosShortEq
+        """
+      ).map(_.message).mkString
+
+      (actual ==== expected)
+        .log(
+          """The actual error message doesn't start with the expected one.
+            |""".stripMargin
+        )
+    }
+
+    def testHash: Result = {
+      import scala.compiletime.testing.typeCheckErrors
+      val expected = ExpectedErrorMessages.missingHash
+
+      val actual = typeCheckErrors(
+        """
+        val _ = refined4s.types.numeric.PosShort.derivedPosShortHash
+        """
       ).map(_.message).mkString
 
       (actual ==== expected)
@@ -457,8 +655,8 @@ object numericWithoutCatsSpec extends Properties {
 
       val actual = typeCheckErrors(
         """
-         val _ = refined4s.types.numeric.PosShort.derivedPosShortShow
-      """
+        val _ = refined4s.types.numeric.PosShort.derivedPosShortShow
+        """
       ).map(_.message).mkString
 
       (actual ==== expected)
@@ -471,7 +669,8 @@ object numericWithoutCatsSpec extends Properties {
 
   object nonPosShortSpec {
     def tests: List[Test] = List(
-      example("test Eq[NonPosShort]", testEq),
+      example("test   Eq[NonPosShort]", testEq),
+      example("test Hash[NonPosShort]", testHash),
       example("test Show[NonPosShort]", testShow),
     )
 
@@ -481,8 +680,25 @@ object numericWithoutCatsSpec extends Properties {
 
       val actual = typeCheckErrors(
         """
-         val _ = refined4s.types.numeric.NonPosShort.derivedNonPosShortEq
-      """
+        val _ = refined4s.types.numeric.NonPosShort.derivedNonPosShortEq
+        """
+      ).map(_.message).mkString
+
+      (actual ==== expected)
+        .log(
+          """The actual error message doesn't start with the expected one.
+            |""".stripMargin
+        )
+    }
+
+    def testHash: Result = {
+      import scala.compiletime.testing.typeCheckErrors
+      val expected = ExpectedErrorMessages.missingHash
+
+      val actual = typeCheckErrors(
+        """
+        val _ = refined4s.types.numeric.NonPosShort.derivedNonPosShortHash
+        """
       ).map(_.message).mkString
 
       (actual ==== expected)
@@ -498,8 +714,8 @@ object numericWithoutCatsSpec extends Properties {
 
       val actual = typeCheckErrors(
         """
-         val _ = refined4s.types.numeric.NonPosShort.derivedNonPosShortShow
-      """
+        val _ = refined4s.types.numeric.NonPosShort.derivedNonPosShortShow
+        """
       ).map(_.message).mkString
 
       (actual ==== expected)
@@ -512,7 +728,8 @@ object numericWithoutCatsSpec extends Properties {
 
   object negByteSpec {
     def tests: List[Test] = List(
-      example("test Eq[NegByte]", testEq),
+      example("test   Eq[NegByte]", testEq),
+      example("test Hash[NegByte]", testHash),
       example("test Show[NegByte]", testShow),
     )
 
@@ -522,8 +739,25 @@ object numericWithoutCatsSpec extends Properties {
 
       val actual = typeCheckErrors(
         """
-         val _ = refined4s.types.numeric.NegByte.derivedNegByteEq
-      """
+        val _ = refined4s.types.numeric.NegByte.derivedNegByteEq
+        """
+      ).map(_.message).mkString
+
+      (actual ==== expected)
+        .log(
+          """The actual error message doesn't start with the expected one.
+            |""".stripMargin
+        )
+    }
+
+    def testHash: Result = {
+      import scala.compiletime.testing.typeCheckErrors
+      val expected = ExpectedErrorMessages.missingHash
+
+      val actual = typeCheckErrors(
+        """
+        val _ = refined4s.types.numeric.NegByte.derivedNegByteHash
+        """
       ).map(_.message).mkString
 
       (actual ==== expected)
@@ -539,8 +773,8 @@ object numericWithoutCatsSpec extends Properties {
 
       val actual = typeCheckErrors(
         """
-         val _ = refined4s.types.numeric.NegByte.derivedNegByteShow
-      """
+        val _ = refined4s.types.numeric.NegByte.derivedNegByteShow
+        """
       ).map(_.message).mkString
 
       (actual ==== expected)
@@ -553,7 +787,8 @@ object numericWithoutCatsSpec extends Properties {
 
   object nonNegByteSpec {
     def tests: List[Test] = List(
-      example("test Eq[NonNegByte]", testEq),
+      example("test   Eq[NonNegByte]", testEq),
+      example("test Hash[NonNegByte]", testHash),
       example("test Show[NonNegByte]", testShow),
     )
 
@@ -563,8 +798,25 @@ object numericWithoutCatsSpec extends Properties {
 
       val actual = typeCheckErrors(
         """
-         val _ = refined4s.types.numeric.NonNegByte.derivedNonNegByteEq
-      """
+        val _ = refined4s.types.numeric.NonNegByte.derivedNonNegByteEq
+        """
+      ).map(_.message).mkString
+
+      (actual ==== expected)
+        .log(
+          """The actual error message doesn't start with the expected one.
+            |""".stripMargin
+        )
+    }
+
+    def testHash: Result = {
+      import scala.compiletime.testing.typeCheckErrors
+      val expected = ExpectedErrorMessages.missingHash
+
+      val actual = typeCheckErrors(
+        """
+        val _ = refined4s.types.numeric.NonNegByte.derivedNonNegByteHash
+        """
       ).map(_.message).mkString
 
       (actual ==== expected)
@@ -580,8 +832,8 @@ object numericWithoutCatsSpec extends Properties {
 
       val actual = typeCheckErrors(
         """
-         val _ = refined4s.types.numeric.NonNegByte.derivedNonNegByteShow
-      """
+        val _ = refined4s.types.numeric.NonNegByte.derivedNonNegByteShow
+        """
       ).map(_.message).mkString
 
       (actual ==== expected)
@@ -594,7 +846,8 @@ object numericWithoutCatsSpec extends Properties {
 
   object posByteSpec {
     def tests: List[Test] = List(
-      example("test Eq[PosByte]", testEq),
+      example("test   Eq[PosByte]", testEq),
+      example("test Hash[PosByte]", testHash),
       example("test Show[PosByte]", testShow),
     )
 
@@ -604,8 +857,25 @@ object numericWithoutCatsSpec extends Properties {
 
       val actual = typeCheckErrors(
         """
-         val _ = refined4s.types.numeric.PosByte.derivedPosByteEq
-      """
+        val _ = refined4s.types.numeric.PosByte.derivedPosByteEq
+        """
+      ).map(_.message).mkString
+
+      (actual ==== expected)
+        .log(
+          """The actual error message doesn't start with the expected one.
+            |""".stripMargin
+        )
+    }
+
+    def testHash: Result = {
+      import scala.compiletime.testing.typeCheckErrors
+      val expected = ExpectedErrorMessages.missingHash
+
+      val actual = typeCheckErrors(
+        """
+        val _ = refined4s.types.numeric.PosByte.derivedPosByteHash
+        """
       ).map(_.message).mkString
 
       (actual ==== expected)
@@ -621,8 +891,8 @@ object numericWithoutCatsSpec extends Properties {
 
       val actual = typeCheckErrors(
         """
-         val _ = refined4s.types.numeric.PosByte.derivedPosByteShow
-      """
+        val _ = refined4s.types.numeric.PosByte.derivedPosByteShow
+        """
       ).map(_.message).mkString
 
       (actual ==== expected)
@@ -635,7 +905,8 @@ object numericWithoutCatsSpec extends Properties {
 
   object nonPosByteSpec {
     def tests: List[Test] = List(
-      example("test Eq[NonPosByte]", testEq),
+      example("test   Eq[NonPosByte]", testEq),
+      example("test Hash[NonPosByte]", testHash),
       example("test Show[NonPosByte]", testShow),
     )
 
@@ -645,8 +916,25 @@ object numericWithoutCatsSpec extends Properties {
 
       val actual = typeCheckErrors(
         """
-         val _ = refined4s.types.numeric.NonPosByte.derivedNonPosByteEq
-      """
+        val _ = refined4s.types.numeric.NonPosByte.derivedNonPosByteEq
+        """
+      ).map(_.message).mkString
+
+      (actual ==== expected)
+        .log(
+          """The actual error message doesn't start with the expected one.
+            |""".stripMargin
+        )
+    }
+
+    def testHash: Result = {
+      import scala.compiletime.testing.typeCheckErrors
+      val expected = ExpectedErrorMessages.missingHash
+
+      val actual = typeCheckErrors(
+        """
+        val _ = refined4s.types.numeric.NonPosByte.derivedNonPosByteHash
+        """
       ).map(_.message).mkString
 
       (actual ==== expected)
@@ -662,8 +950,8 @@ object numericWithoutCatsSpec extends Properties {
 
       val actual = typeCheckErrors(
         """
-         val _ = refined4s.types.numeric.NonPosByte.derivedNonPosByteShow
-      """
+        val _ = refined4s.types.numeric.NonPosByte.derivedNonPosByteShow
+        """
       ).map(_.message).mkString
 
       (actual ==== expected)
@@ -676,7 +964,8 @@ object numericWithoutCatsSpec extends Properties {
 
   object negFloatSpec {
     def tests: List[Test] = List(
-      example("test Eq[NegFloat]", testEq),
+      example("test   Eq[NegFloat]", testEq),
+      example("test Hash[NegFloat]", testHash),
       example("test Show[NegFloat]", testShow),
     )
 
@@ -686,8 +975,25 @@ object numericWithoutCatsSpec extends Properties {
 
       val actual = typeCheckErrors(
         """
-         val _ = refined4s.types.numeric.NegFloat.derivedNegFloatEq
-      """
+        val _ = refined4s.types.numeric.NegFloat.derivedNegFloatEq
+        """
+      ).map(_.message).mkString
+
+      (actual ==== expected)
+        .log(
+          """The actual error message doesn't start with the expected one.
+            |""".stripMargin
+        )
+    }
+
+    def testHash: Result = {
+      import scala.compiletime.testing.typeCheckErrors
+      val expected = ExpectedErrorMessages.missingHash
+
+      val actual = typeCheckErrors(
+        """
+        val _ = refined4s.types.numeric.NegFloat.derivedNegFloatHash
+        """
       ).map(_.message).mkString
 
       (actual ==== expected)
@@ -703,8 +1009,8 @@ object numericWithoutCatsSpec extends Properties {
 
       val actual = typeCheckErrors(
         """
-         val _ = refined4s.types.numeric.NegFloat.derivedNegFloatShow
-      """
+        val _ = refined4s.types.numeric.NegFloat.derivedNegFloatShow
+        """
       ).map(_.message).mkString
 
       (actual ==== expected)
@@ -717,7 +1023,8 @@ object numericWithoutCatsSpec extends Properties {
 
   object nonNegFloatSpec {
     def tests: List[Test] = List(
-      example("test Eq[NonNegFloat]", testEq),
+      example("test   Eq[NonNegFloat]", testEq),
+      example("test Hash[NonNegFloat]", testHash),
       example("test Show[NonNegFloat]", testShow),
     )
 
@@ -727,8 +1034,25 @@ object numericWithoutCatsSpec extends Properties {
 
       val actual = typeCheckErrors(
         """
-         val _ = refined4s.types.numeric.NonNegFloat.derivedNonNegFloatEq
-      """
+        val _ = refined4s.types.numeric.NonNegFloat.derivedNonNegFloatEq
+        """
+      ).map(_.message).mkString
+
+      (actual ==== expected)
+        .log(
+          """The actual error message doesn't start with the expected one.
+            |""".stripMargin
+        )
+    }
+
+    def testHash: Result = {
+      import scala.compiletime.testing.typeCheckErrors
+      val expected = ExpectedErrorMessages.missingHash
+
+      val actual = typeCheckErrors(
+        """
+        val _ = refined4s.types.numeric.NonNegFloat.derivedNonNegFloatHash
+        """
       ).map(_.message).mkString
 
       (actual ==== expected)
@@ -744,8 +1068,8 @@ object numericWithoutCatsSpec extends Properties {
 
       val actual = typeCheckErrors(
         """
-         val _ = refined4s.types.numeric.NonNegFloat.derivedNonNegFloatShow
-      """
+        val _ = refined4s.types.numeric.NonNegFloat.derivedNonNegFloatShow
+        """
       ).map(_.message).mkString
 
       (actual ==== expected)
@@ -758,7 +1082,8 @@ object numericWithoutCatsSpec extends Properties {
 
   object posFloatSpec {
     def tests: List[Test] = List(
-      example("test Eq[PosFloat]", testEq),
+      example("test   Eq[PosFloat]", testEq),
+      example("test Hash[PosFloat]", testHash),
       example("test Show[PosFloat]", testShow),
     )
 
@@ -768,8 +1093,25 @@ object numericWithoutCatsSpec extends Properties {
 
       val actual = typeCheckErrors(
         """
-         val _ = refined4s.types.numeric.PosFloat.derivedPosFloatEq
-      """
+        val _ = refined4s.types.numeric.PosFloat.derivedPosFloatEq
+        """
+      ).map(_.message).mkString
+
+      (actual ==== expected)
+        .log(
+          """The actual error message doesn't start with the expected one.
+            |""".stripMargin
+        )
+    }
+
+    def testHash: Result = {
+      import scala.compiletime.testing.typeCheckErrors
+      val expected = ExpectedErrorMessages.missingHash
+
+      val actual = typeCheckErrors(
+        """
+        val _ = refined4s.types.numeric.PosFloat.derivedPosFloatHash
+        """
       ).map(_.message).mkString
 
       (actual ==== expected)
@@ -785,8 +1127,8 @@ object numericWithoutCatsSpec extends Properties {
 
       val actual = typeCheckErrors(
         """
-         val _ = refined4s.types.numeric.PosFloat.derivedPosFloatShow
-      """
+        val _ = refined4s.types.numeric.PosFloat.derivedPosFloatShow
+        """
       ).map(_.message).mkString
 
       (actual ==== expected)
@@ -799,7 +1141,8 @@ object numericWithoutCatsSpec extends Properties {
 
   object nonPosFloatSpec {
     def tests: List[Test] = List(
-      example("test Eq[NonPosFloat]", testEq),
+      example("test   Eq[NonPosFloat]", testEq),
+      example("test Hash[NonPosFloat]", testHash),
       example("test Show[NonPosFloat]", testShow),
     )
 
@@ -809,8 +1152,25 @@ object numericWithoutCatsSpec extends Properties {
 
       val actual = typeCheckErrors(
         """
-         val _ = refined4s.types.numeric.NonPosFloat.derivedNonPosFloatEq
-      """
+        val _ = refined4s.types.numeric.NonPosFloat.derivedNonPosFloatEq
+        """
+      ).map(_.message).mkString
+
+      (actual ==== expected)
+        .log(
+          """The actual error message doesn't start with the expected one.
+            |""".stripMargin
+        )
+    }
+
+    def testHash: Result = {
+      import scala.compiletime.testing.typeCheckErrors
+      val expected = ExpectedErrorMessages.missingHash
+
+      val actual = typeCheckErrors(
+        """
+        val _ = refined4s.types.numeric.NonPosFloat.derivedNonPosFloatHash
+        """
       ).map(_.message).mkString
 
       (actual ==== expected)
@@ -826,8 +1186,8 @@ object numericWithoutCatsSpec extends Properties {
 
       val actual = typeCheckErrors(
         """
-         val _ = refined4s.types.numeric.NonPosFloat.derivedNonPosFloatShow
-      """
+        val _ = refined4s.types.numeric.NonPosFloat.derivedNonPosFloatShow
+        """
       ).map(_.message).mkString
 
       (actual ==== expected)
@@ -840,7 +1200,8 @@ object numericWithoutCatsSpec extends Properties {
 
   object negDoubleSpec {
     def tests: List[Test] = List(
-      example("test Eq[NegDouble]", testEq),
+      example("test   Eq[NegDouble]", testEq),
+      example("test Hash[NegDouble]", testHash),
       example("test Show[NegDouble]", testShow),
     )
 
@@ -850,8 +1211,25 @@ object numericWithoutCatsSpec extends Properties {
 
       val actual = typeCheckErrors(
         """
-         val _ = refined4s.types.numeric.NegDouble.derivedNegDoubleEq
-      """
+        val _ = refined4s.types.numeric.NegDouble.derivedNegDoubleEq
+        """
+      ).map(_.message).mkString
+
+      (actual ==== expected)
+        .log(
+          """The actual error message doesn't start with the expected one.
+            |""".stripMargin
+        )
+    }
+
+    def testHash: Result = {
+      import scala.compiletime.testing.typeCheckErrors
+      val expected = ExpectedErrorMessages.missingHash
+
+      val actual = typeCheckErrors(
+        """
+        val _ = refined4s.types.numeric.NegDouble.derivedNegDoubleHash
+        """
       ).map(_.message).mkString
 
       (actual ==== expected)
@@ -867,8 +1245,8 @@ object numericWithoutCatsSpec extends Properties {
 
       val actual = typeCheckErrors(
         """
-         val _ = refined4s.types.numeric.NegDouble.derivedNegDoubleShow
-      """
+        val _ = refined4s.types.numeric.NegDouble.derivedNegDoubleShow
+        """
       ).map(_.message).mkString
 
       (actual ==== expected)
@@ -881,7 +1259,8 @@ object numericWithoutCatsSpec extends Properties {
 
   object nonNegDoubleSpec {
     def tests: List[Test] = List(
-      example("test Eq[NonNegDouble]", testEq),
+      example("test   Eq[NonNegDouble]", testEq),
+      example("test Hash[NonNegDouble]", testHash),
       example("test Show[NonNegDouble]", testShow),
     )
 
@@ -891,8 +1270,25 @@ object numericWithoutCatsSpec extends Properties {
 
       val actual = typeCheckErrors(
         """
-         val _ = refined4s.types.numeric.NonNegDouble.derivedNonNegDoubleEq
-      """
+        val _ = refined4s.types.numeric.NonNegDouble.derivedNonNegDoubleEq
+        """
+      ).map(_.message).mkString
+
+      (actual ==== expected)
+        .log(
+          """The actual error message doesn't start with the expected one.
+            |""".stripMargin
+        )
+    }
+
+    def testHash: Result = {
+      import scala.compiletime.testing.typeCheckErrors
+      val expected = ExpectedErrorMessages.missingHash
+
+      val actual = typeCheckErrors(
+        """
+        val _ = refined4s.types.numeric.NonNegDouble.derivedNonNegDoubleHash
+        """
       ).map(_.message).mkString
 
       (actual ==== expected)
@@ -908,8 +1304,8 @@ object numericWithoutCatsSpec extends Properties {
 
       val actual = typeCheckErrors(
         """
-         val _ = refined4s.types.numeric.NonNegDouble.derivedNonNegDoubleShow
-      """
+        val _ = refined4s.types.numeric.NonNegDouble.derivedNonNegDoubleShow
+        """
       ).map(_.message).mkString
 
       (actual ==== expected)
@@ -922,7 +1318,8 @@ object numericWithoutCatsSpec extends Properties {
 
   object posDoubleSpec {
     def tests: List[Test] = List(
-      example("test Eq[PosDouble]", testEq),
+      example("test   Eq[PosDouble]", testEq),
+      example("test Hash[PosDouble]", testHash),
       example("test Show[PosDouble]", testShow),
     )
 
@@ -932,8 +1329,25 @@ object numericWithoutCatsSpec extends Properties {
 
       val actual = typeCheckErrors(
         """
-         val _ = refined4s.types.numeric.PosDouble.derivedPosDoubleEq
-      """
+        val _ = refined4s.types.numeric.PosDouble.derivedPosDoubleEq
+        """
+      ).map(_.message).mkString
+
+      (actual ==== expected)
+        .log(
+          """The actual error message doesn't start with the expected one.
+            |""".stripMargin
+        )
+    }
+
+    def testHash: Result = {
+      import scala.compiletime.testing.typeCheckErrors
+      val expected = ExpectedErrorMessages.missingHash
+
+      val actual = typeCheckErrors(
+        """
+        val _ = refined4s.types.numeric.PosDouble.derivedPosDoubleHash
+        """
       ).map(_.message).mkString
 
       (actual ==== expected)
@@ -949,8 +1363,8 @@ object numericWithoutCatsSpec extends Properties {
 
       val actual = typeCheckErrors(
         """
-         val _ = refined4s.types.numeric.PosDouble.derivedPosDoubleShow
-      """
+        val _ = refined4s.types.numeric.PosDouble.derivedPosDoubleShow
+        """
       ).map(_.message).mkString
 
       (actual ==== expected)
@@ -963,7 +1377,8 @@ object numericWithoutCatsSpec extends Properties {
 
   object nonPosDoubleSpec {
     def tests: List[Test] = List(
-      example("test Eq[NonPosDouble]", testEq),
+      example("test   Eq[NonPosDouble]", testEq),
+      example("test Hash[NonPosDouble]", testHash),
       example("test Show[NonPosDouble]", testShow),
     )
 
@@ -973,8 +1388,25 @@ object numericWithoutCatsSpec extends Properties {
 
       val actual = typeCheckErrors(
         """
-         val _ = refined4s.types.numeric.NonPosDouble.derivedNonPosDoubleEq
-      """
+        val _ = refined4s.types.numeric.NonPosDouble.derivedNonPosDoubleEq
+        """
+      ).map(_.message).mkString
+
+      (actual ==== expected)
+        .log(
+          """The actual error message doesn't start with the expected one.
+            |""".stripMargin
+        )
+    }
+
+    def testHash: Result = {
+      import scala.compiletime.testing.typeCheckErrors
+      val expected = ExpectedErrorMessages.missingHash
+
+      val actual = typeCheckErrors(
+        """
+        val _ = refined4s.types.numeric.NonPosDouble.derivedNonPosDoubleHash
+        """
       ).map(_.message).mkString
 
       (actual ==== expected)
@@ -990,8 +1422,8 @@ object numericWithoutCatsSpec extends Properties {
 
       val actual = typeCheckErrors(
         """
-         val _ = refined4s.types.numeric.NonPosDouble.derivedNonPosDoubleShow
-      """
+        val _ = refined4s.types.numeric.NonPosDouble.derivedNonPosDoubleShow
+        """
       ).map(_.message).mkString
 
       (actual ==== expected)
@@ -1004,7 +1436,8 @@ object numericWithoutCatsSpec extends Properties {
 
   object negBigIntSpec {
     def tests: List[Test] = List(
-      example("test Eq[NegBigInt]", testEq),
+      example("test   Eq[NegBigInt]", testEq),
+      example("test Hash[NegBigInt]", testHash),
       example("test Show[NegBigInt]", testShow),
     )
 
@@ -1014,8 +1447,25 @@ object numericWithoutCatsSpec extends Properties {
 
       val actual = typeCheckErrors(
         """
-         val _ = refined4s.types.numeric.NegBigInt.derivedNegBigIntEq
-      """
+        val _ = refined4s.types.numeric.NegBigInt.derivedNegBigIntEq
+        """
+      ).map(_.message).mkString
+
+      (actual ==== expected)
+        .log(
+          """The actual error message doesn't start with the expected one.
+            |""".stripMargin
+        )
+    }
+
+    def testHash: Result = {
+      import scala.compiletime.testing.typeCheckErrors
+      val expected = ExpectedErrorMessages.missingHash
+
+      val actual = typeCheckErrors(
+        """
+        val _ = refined4s.types.numeric.NegBigInt.derivedNegBigIntHash
+        """
       ).map(_.message).mkString
 
       (actual ==== expected)
@@ -1031,8 +1481,8 @@ object numericWithoutCatsSpec extends Properties {
 
       val actual = typeCheckErrors(
         """
-         val _ = refined4s.types.numeric.NegBigInt.derivedNegBigIntShow
-      """
+        val _ = refined4s.types.numeric.NegBigInt.derivedNegBigIntShow
+        """
       ).map(_.message).mkString
 
       (actual ==== expected)
@@ -1045,7 +1495,8 @@ object numericWithoutCatsSpec extends Properties {
 
   object nonNegBigIntSpec {
     def tests: List[Test] = List(
-      example("test Eq[NonNegBigInt]", testEq),
+      example("test   Eq[NonNegBigInt]", testEq),
+      example("test Hash[NonNegBigInt]", testHash),
       example("test Show[NonNegBigInt]", testShow),
     )
 
@@ -1055,8 +1506,25 @@ object numericWithoutCatsSpec extends Properties {
 
       val actual = typeCheckErrors(
         """
-         val _ = refined4s.types.numeric.NonNegBigInt.derivedNonNegBigIntEq
-      """
+        val _ = refined4s.types.numeric.NonNegBigInt.derivedNonNegBigIntEq
+        """
+      ).map(_.message).mkString
+
+      (actual ==== expected)
+        .log(
+          """The actual error message doesn't start with the expected one.
+            |""".stripMargin
+        )
+    }
+
+    def testHash: Result = {
+      import scala.compiletime.testing.typeCheckErrors
+      val expected = ExpectedErrorMessages.missingHash
+
+      val actual = typeCheckErrors(
+        """
+        val _ = refined4s.types.numeric.NonNegBigInt.derivedNonNegBigIntHash
+        """
       ).map(_.message).mkString
 
       (actual ==== expected)
@@ -1072,8 +1540,8 @@ object numericWithoutCatsSpec extends Properties {
 
       val actual = typeCheckErrors(
         """
-         val _ = refined4s.types.numeric.NonNegBigInt.derivedNonNegBigIntShow
-      """
+        val _ = refined4s.types.numeric.NonNegBigInt.derivedNonNegBigIntShow
+        """
       ).map(_.message).mkString
 
       (actual ==== expected)
@@ -1086,7 +1554,8 @@ object numericWithoutCatsSpec extends Properties {
 
   object posBigIntSpec {
     def tests: List[Test] = List(
-      example("test Eq[PosBigInt]", testEq),
+      example("test   Eq[PosBigInt]", testEq),
+      example("test Hash[PosBigInt]", testHash),
       example("test Show[PosBigInt]", testShow),
     )
 
@@ -1096,8 +1565,25 @@ object numericWithoutCatsSpec extends Properties {
 
       val actual = typeCheckErrors(
         """
-         val _ = refined4s.types.numeric.PosBigInt.derivedPosBigIntEq
-      """
+        val _ = refined4s.types.numeric.PosBigInt.derivedPosBigIntEq
+        """
+      ).map(_.message).mkString
+
+      (actual ==== expected)
+        .log(
+          """The actual error message doesn't start with the expected one.
+            |""".stripMargin
+        )
+    }
+
+    def testHash: Result = {
+      import scala.compiletime.testing.typeCheckErrors
+      val expected = ExpectedErrorMessages.missingHash
+
+      val actual = typeCheckErrors(
+        """
+        val _ = refined4s.types.numeric.PosBigInt.derivedPosBigIntHash
+        """
       ).map(_.message).mkString
 
       (actual ==== expected)
@@ -1113,8 +1599,8 @@ object numericWithoutCatsSpec extends Properties {
 
       val actual = typeCheckErrors(
         """
-         val _ = refined4s.types.numeric.PosBigInt.derivedPosBigIntShow
-      """
+        val _ = refined4s.types.numeric.PosBigInt.derivedPosBigIntShow
+        """
       ).map(_.message).mkString
 
       (actual ==== expected)
@@ -1127,7 +1613,8 @@ object numericWithoutCatsSpec extends Properties {
 
   object nonPosBigIntSpec {
     def tests: List[Test] = List(
-      example("test Eq[NonPosBigInt]", testEq),
+      example("test   Eq[NonPosBigInt]", testEq),
+      example("test Hash[NonPosBigInt]", testHash),
       example("test Show[NonPosBigInt]", testShow),
     )
 
@@ -1137,8 +1624,25 @@ object numericWithoutCatsSpec extends Properties {
 
       val actual = typeCheckErrors(
         """
-         val _ = refined4s.types.numeric.NonPosBigInt.derivedNonPosBigIntEq
-      """
+        val _ = refined4s.types.numeric.NonPosBigInt.derivedNonPosBigIntEq
+        """
+      ).map(_.message).mkString
+
+      (actual ==== expected)
+        .log(
+          """The actual error message doesn't start with the expected one.
+            |""".stripMargin
+        )
+    }
+
+    def testHash: Result = {
+      import scala.compiletime.testing.typeCheckErrors
+      val expected = ExpectedErrorMessages.missingHash
+
+      val actual = typeCheckErrors(
+        """
+        val _ = refined4s.types.numeric.NonPosBigInt.derivedNonPosBigIntHash
+        """
       ).map(_.message).mkString
 
       (actual ==== expected)
@@ -1154,8 +1658,8 @@ object numericWithoutCatsSpec extends Properties {
 
       val actual = typeCheckErrors(
         """
-         val _ = refined4s.types.numeric.NonPosBigInt.derivedNonPosBigIntShow
-      """
+        val _ = refined4s.types.numeric.NonPosBigInt.derivedNonPosBigIntShow
+        """
       ).map(_.message).mkString
 
       (actual ==== expected)
@@ -1168,7 +1672,8 @@ object numericWithoutCatsSpec extends Properties {
 
   object negBigDecimalSpec {
     def tests: List[Test] = List(
-      example("test Eq[NegBigDecimal]", testEq),
+      example("test   Eq[NegBigDecimal]", testEq),
+      example("test Hash[NegBigDecimal]", testHash),
       example("test Show[NegBigDecimal]", testShow),
     )
 
@@ -1178,8 +1683,25 @@ object numericWithoutCatsSpec extends Properties {
 
       val actual = typeCheckErrors(
         """
-         val _ = refined4s.types.numeric.NegBigDecimal.derivedNegBigDecimalEq
-      """
+        val _ = refined4s.types.numeric.NegBigDecimal.derivedNegBigDecimalEq
+        """
+      ).map(_.message).mkString
+
+      (actual ==== expected)
+        .log(
+          """The actual error message doesn't start with the expected one.
+            |""".stripMargin
+        )
+    }
+
+    def testHash: Result = {
+      import scala.compiletime.testing.typeCheckErrors
+      val expected = ExpectedErrorMessages.missingHash
+
+      val actual = typeCheckErrors(
+        """
+        val _ = refined4s.types.numeric.NegBigDecimal.derivedNegBigDecimalHash
+        """
       ).map(_.message).mkString
 
       (actual ==== expected)
@@ -1195,8 +1717,8 @@ object numericWithoutCatsSpec extends Properties {
 
       val actual = typeCheckErrors(
         """
-         val _ = refined4s.types.numeric.NegBigDecimal.derivedNegBigDecimalShow
-      """
+        val _ = refined4s.types.numeric.NegBigDecimal.derivedNegBigDecimalShow
+        """
       ).map(_.message).mkString
 
       (actual ==== expected)
@@ -1209,7 +1731,8 @@ object numericWithoutCatsSpec extends Properties {
 
   object nonNegBigDecimalSpec {
     def tests: List[Test] = List(
-      example("test Eq[NonNegBigDecimal]", testEq),
+      example("test   Eq[NonNegBigDecimal]", testEq),
+      example("test Hash[NonNegBigDecimal]", testHash),
       example("test Show[NonNegBigDecimal]", testShow),
     )
 
@@ -1219,8 +1742,25 @@ object numericWithoutCatsSpec extends Properties {
 
       val actual = typeCheckErrors(
         """
-         val _ = refined4s.types.numeric.NonNegBigDecimal.derivedNonNegBigDecimalEq
-      """
+        val _ = refined4s.types.numeric.NonNegBigDecimal.derivedNonNegBigDecimalEq
+        """
+      ).map(_.message).mkString
+
+      (actual ==== expected)
+        .log(
+          """The actual error message doesn't start with the expected one.
+            |""".stripMargin
+        )
+    }
+
+    def testHash: Result = {
+      import scala.compiletime.testing.typeCheckErrors
+      val expected = ExpectedErrorMessages.missingHash
+
+      val actual = typeCheckErrors(
+        """
+        val _ = refined4s.types.numeric.NonNegBigDecimal.derivedNonNegBigDecimalHash
+        """
       ).map(_.message).mkString
 
       (actual ==== expected)
@@ -1236,8 +1776,8 @@ object numericWithoutCatsSpec extends Properties {
 
       val actual = typeCheckErrors(
         """
-         val _ = refined4s.types.numeric.NonNegBigDecimal.derivedNonNegBigDecimalShow
-      """
+        val _ = refined4s.types.numeric.NonNegBigDecimal.derivedNonNegBigDecimalShow
+        """
       ).map(_.message).mkString
 
       (actual ==== expected)
@@ -1250,7 +1790,8 @@ object numericWithoutCatsSpec extends Properties {
 
   object posBigDecimalSpec {
     def tests: List[Test] = List(
-      example("test Eq[PosBigDecimal]", testEq),
+      example("test   Eq[PosBigDecimal]", testEq),
+      example("test Hash[PosBigDecimal]", testHash),
       example("test Show[PosBigDecimal]", testShow),
     )
 
@@ -1260,8 +1801,25 @@ object numericWithoutCatsSpec extends Properties {
 
       val actual = typeCheckErrors(
         """
-         val _ = refined4s.types.numeric.PosBigDecimal.derivedPosBigDecimalEq
-      """
+        val _ = refined4s.types.numeric.PosBigDecimal.derivedPosBigDecimalEq
+        """
+      ).map(_.message).mkString
+
+      (actual ==== expected)
+        .log(
+          """The actual error message doesn't start with the expected one.
+            |""".stripMargin
+        )
+    }
+
+    def testHash: Result = {
+      import scala.compiletime.testing.typeCheckErrors
+      val expected = ExpectedErrorMessages.missingHash
+
+      val actual = typeCheckErrors(
+        """
+        val _ = refined4s.types.numeric.PosBigDecimal.derivedPosBigDecimalHash
+        """
       ).map(_.message).mkString
 
       (actual ==== expected)
@@ -1277,8 +1835,8 @@ object numericWithoutCatsSpec extends Properties {
 
       val actual = typeCheckErrors(
         """
-         val _ = refined4s.types.numeric.PosBigDecimal.derivedPosBigDecimalShow
-      """
+        val _ = refined4s.types.numeric.PosBigDecimal.derivedPosBigDecimalShow
+        """
       ).map(_.message).mkString
 
       (actual ==== expected)
@@ -1291,7 +1849,8 @@ object numericWithoutCatsSpec extends Properties {
 
   object nonPosBigDecimalSpec {
     def tests: List[Test] = List(
-      example("test Eq[NonPosBigDecimal]", testEq),
+      example("test   Eq[NonPosBigDecimal]", testEq),
+      example("test Hash[NonPosBigDecimal]", testHash),
       example("test Show[NonPosBigDecimal]", testShow),
     )
 
@@ -1301,8 +1860,25 @@ object numericWithoutCatsSpec extends Properties {
 
       val actual = typeCheckErrors(
         """
-         val _ = refined4s.types.numeric.NonPosBigDecimal.derivedNonPosBigDecimalEq
-      """
+        val _ = refined4s.types.numeric.NonPosBigDecimal.derivedNonPosBigDecimalEq
+        """
+      ).map(_.message).mkString
+
+      (actual ==== expected)
+        .log(
+          """The actual error message doesn't start with the expected one.
+            |""".stripMargin
+        )
+    }
+
+    def testHash: Result = {
+      import scala.compiletime.testing.typeCheckErrors
+      val expected = ExpectedErrorMessages.missingHash
+
+      val actual = typeCheckErrors(
+        """
+        val _ = refined4s.types.numeric.NonPosBigDecimal.derivedNonPosBigDecimalHash
+        """
       ).map(_.message).mkString
 
       (actual ==== expected)
@@ -1318,8 +1894,8 @@ object numericWithoutCatsSpec extends Properties {
 
       val actual = typeCheckErrors(
         """
-         val _ = refined4s.types.numeric.NonPosBigDecimal.derivedNonPosBigDecimalShow
-      """
+        val _ = refined4s.types.numeric.NonPosBigDecimal.derivedNonPosBigDecimalShow
+        """
       ).map(_.message).mkString
 
       (actual ==== expected)


### PR DESCRIPTION
## Close #491: [`refined4s-core`] Add `cats.Hash` type class instances for `refined4s.types.numeric` with `orphan-cats`

- Add `Hash` typeclass instances for all `numeric` refined types
- Add test for `Hash` for all numeric types (Int, Long, BigInt, BigDecimal variants)
- Refactor cats type class instances for `numeric`, restructuring them into hierarchical traits to resolve ambiguous `Eq` and `Hash` instances.