### PR TITLE
Close #497: [`refined4s-circe`] Add `Encoder`, `Decoder`, `KeyEncoder` and `KeyDecoder` type-class instances for `refined4s.types.time` types

### DIFF
--- a/modules/refined4s-circe/shared/src/main/scala/refined4s/modules/circe/derivation/types/all.scala
+++ b/modules/refined4s-circe/shared/src/main/scala/refined4s/modules/circe/derivation/types/all.scala
@@ -3,5 +3,5 @@ package refined4s.modules.circe.derivation.types
 /** @author Kevin Lee
   * @since 2023-12-25
   */
-trait all extends numeric, strings, network
+trait all extends numeric, strings, network, time
 object all extends all

--- a/modules/refined4s-circe/shared/src/main/scala/refined4s/modules/circe/derivation/types/time.scala
+++ b/modules/refined4s-circe/shared/src/main/scala/refined4s/modules/circe/derivation/types/time.scala
@@ -1,0 +1,71 @@
+package refined4s.modules.circe.derivation.types
+
+import io.circe.{Decoder, Encoder, KeyDecoder, KeyEncoder}
+import refined4s.types.time.*
+
+/** @author Kevin Lee
+  * @since 2025-08-30
+  */
+trait time {
+
+  /* Month { */
+  inline given derivedMonthEncoder: Encoder[Month] = Encoder[Int].contramap[Month](_.value)
+  inline given derivedMonthDecoder: Decoder[Month] = Decoder[Int].emap(Month.from)
+
+  inline given derivedMonthKeyEncoder: KeyEncoder[Month] = KeyEncoder[Int].contramap[Month](_.value)
+  inline given derivedMonthKeyDecoder: KeyDecoder[Month] with {
+    override def apply(key: String): Option[Month] = KeyDecoder.decodeKeyInt.apply(key).flatMap(Month.from(_).toOption)
+  }
+  /* } Month */
+
+  /* Day { */
+  inline given derivedDayEncoder: Encoder[Day] = Encoder[Int].contramap[Day](_.value)
+  inline given derivedDayDecoder: Decoder[Day] = Decoder[Int].emap(Day.from)
+
+  inline given derivedDayKeyEncoder: KeyEncoder[Day] = KeyEncoder[Int].contramap[Day](_.value)
+  inline given derivedDayKeyDecoder: KeyDecoder[Day] with {
+    override def apply(key: String): Option[Day] = KeyDecoder.decodeKeyInt.apply(key).flatMap(Day.from(_).toOption)
+  }
+  /* } Day */
+
+  /* Hour { */
+  inline given derivedHourEncoder: Encoder[Hour] = Encoder[Int].contramap[Hour](_.value)
+  inline given derivedHourDecoder: Decoder[Hour] = Decoder[Int].emap(Hour.from)
+
+  inline given derivedHourKeyEncoder: KeyEncoder[Hour] = KeyEncoder[Int].contramap[Hour](_.value)
+  inline given derivedHourKeyDecoder: KeyDecoder[Hour] with {
+    override def apply(key: String): Option[Hour] = KeyDecoder.decodeKeyInt.apply(key).flatMap(Hour.from(_).toOption)
+  }
+  /* } Hour */
+
+  /* Minute { */
+  inline given derivedMinuteEncoder: Encoder[Minute] = Encoder[Int].contramap[Minute](_.value)
+  inline given derivedMinuteDecoder: Decoder[Minute] = Decoder[Int].emap(Minute.from)
+
+  inline given derivedMinuteKeyEncoder: KeyEncoder[Minute] = KeyEncoder[Int].contramap[Minute](_.value)
+  inline given derivedMinuteKeyDecoder: KeyDecoder[Minute] with {
+    override def apply(key: String): Option[Minute] = KeyDecoder.decodeKeyInt.apply(key).flatMap(Minute.from(_).toOption)
+  }
+  /* } Minute */
+
+  /* Second { */
+  inline given derivedSecondEncoder: Encoder[Second] = Encoder[Int].contramap[Second](_.value)
+  inline given derivedSecondDecoder: Decoder[Second] = Decoder[Int].emap(Second.from)
+
+  inline given derivedSecondKeyEncoder: KeyEncoder[Second] = KeyEncoder[Int].contramap[Second](_.value)
+  inline given derivedSecondKeyDecoder: KeyDecoder[Second] with {
+    override def apply(key: String): Option[Second] = KeyDecoder.decodeKeyInt.apply(key).flatMap(Second.from(_).toOption)
+  }
+  /* } Second */
+
+  /* Millis { */
+  inline given derivedMillisEncoder: Encoder[Millis] = Encoder[Int].contramap[Millis](_.value)
+  inline given derivedMillisDecoder: Decoder[Millis] = Decoder[Int].emap(Millis.from)
+
+  inline given derivedMillisKeyEncoder: KeyEncoder[Millis] = KeyEncoder[Int].contramap[Millis](_.value)
+  inline given derivedMillisKeyDecoder: KeyDecoder[Millis] with {
+    override def apply(key: String): Option[Millis] = KeyDecoder.decodeKeyInt.apply(key).flatMap(Millis.from(_).toOption)
+  }
+  /* } Millis */
+}
+object time extends time

--- a/modules/refined4s-circe/shared/src/test/scala/refined4s/modules/circe/derivation/types/timeSpec.scala
+++ b/modules/refined4s-circe/shared/src/test/scala/refined4s/modules/circe/derivation/types/timeSpec.scala
@@ -1,0 +1,443 @@
+package refined4s.modules.circe.derivation.types
+
+import cats.syntax.all.*
+import hedgehog.*
+import hedgehog.runner.*
+import io.circe.*
+import io.circe.parser.*
+import io.circe.syntax.*
+import refined4s.types.TimeGens
+import refined4s.types.all.*
+
+/** @author Kevin Lee
+  * @since 2025-08-30
+  */
+trait timeSpec {
+  protected val timeTypeClasses: refined4s.modules.circe.derivation.types.time
+
+  import timeTypeClasses.given
+
+  def allTests: List[Test] = monthSpec.tests ++ daySpec.tests ++ hourSpec.tests ++ minuteSpec.tests ++ secondSpec.tests ++ millisSpec.tests
+
+  object monthSpec {
+
+    def tests: List[Test] = List(
+      property("test    Encoder[Month]", testEncoder),
+      property("test    Decoder[Month]", testDecoder),
+      property("test KeyEncoder[Month]", testKeyEncoder),
+      property("test KeyDecoder[Month]", testKeyDecoder),
+    )
+
+    def testEncoder: Property =
+      for {
+        monthIntAndMonth <- TimeGens.genMonth.map(month => month.value -> month).log("(monthInt, month)")
+        (monthInt, month) = monthIntAndMonth
+      } yield {
+        val expected = monthInt.asJson
+        val actual   = month.asJson
+
+        Result.all(
+          List(
+            actual ==== expected,
+            actual.noSpaces ==== expected.noSpaces,
+          )
+        )
+      }
+
+    def testDecoder: Property =
+      for {
+        monthIntAndMonth <- TimeGens.genMonth.map(month => month.value -> month).log("(monthInt, month)")
+        (monthInt, month) = monthIntAndMonth
+      } yield {
+        val input = month.asJson
+
+        val expected = month.asRight[io.circe.Error]
+        val actual   = decode[Month](input.noSpaces)
+
+        actual ==== expected
+      }
+
+    def testKeyEncoder: Property =
+      for {
+        keys   <- TimeGens.genMonth.list(Range.linear(1, 20)).log("keys")
+        values <- Gen.string(Gen.alpha, Range.linear(1, 10)).list(Range.singleton(keys.length)).log("values")
+        map    <- Gen.constant(keys.zip(values).toMap).log("map")
+      } yield {
+        val expected = Json.fromFields(map.map { case (key, value) => key.value.toString -> value.asJson })
+
+        val actual = map.asJson
+        Result.all(
+          List(
+            actual ==== expected,
+            actual.noSpacesSortKeys ==== expected.noSpacesSortKeys,
+          )
+        )
+      }
+
+    def testKeyDecoder: Property =
+      for {
+        keys     <- TimeGens.genMonth.list(Range.linear(1, 20)).log("keys")
+        values   <- Gen.string(Gen.alpha, Range.linear(1, 10)).list(Range.singleton(keys.length)).log("values")
+        expected <- Gen.constant(keys.zip(values).toMap).log("expected")
+      } yield {
+        val input = Json.fromFields(expected.map { case (key, value) => key.value.toString -> value.asJson })
+
+        val actual = decode[Map[Month, String]](input.noSpaces)
+
+        actual ==== expected.asRight
+      }
+
+  }
+
+  object daySpec {
+    def tests: List[Test] = List(
+      property("test    Encoder[Day]", testEncoder),
+      property("test    Decoder[Day]", testDecoder),
+      property("test KeyEncoder[Day]", testKeyEncoder),
+      property("test KeyDecoder[Day]", testKeyDecoder),
+    )
+
+    def testEncoder: Property =
+      for {
+        dayIntAndDay <- TimeGens.genDay.map(day => day.value -> day).log("(dayInt, day)")
+        (dayInt, day) = dayIntAndDay
+      } yield {
+        val expected = dayInt.asJson
+        val actual   = day.asJson
+
+        Result.all(
+          List(
+            actual ==== expected,
+            actual.noSpaces ==== expected.noSpaces,
+          )
+        )
+      }
+
+    def testDecoder: Property =
+      for {
+        dayIntAndDay <- TimeGens.genDay.map(day => day.value -> day).log("(dayInt, day)")
+        (dayInt, day) = dayIntAndDay
+      } yield {
+        val input = day.asJson
+
+        val expected = day.asRight[io.circe.Error]
+        val actual   = decode[Day](input.noSpaces)
+
+        actual ==== expected
+      }
+
+    def testKeyEncoder: Property =
+      for {
+        keys   <- TimeGens.genDay.list(Range.linear(1, 20)).log("keys")
+        values <- Gen.string(Gen.alpha, Range.linear(1, 10)).list(Range.singleton(keys.length)).log("values")
+        map    <- Gen.constant(keys.zip(values).toMap).log("map")
+      } yield {
+        val expected = Json.fromFields(map.map { case (key, value) => key.value.toString -> value.asJson })
+
+        val actual = map.asJson
+        Result.all(
+          List(
+            actual ==== expected,
+            actual.noSpacesSortKeys ==== expected.noSpacesSortKeys,
+          )
+        )
+      }
+
+    def testKeyDecoder: Property =
+      for {
+        keys     <- TimeGens.genDay.list(Range.linear(1, 20)).log("keys")
+        values   <- Gen.string(Gen.alpha, Range.linear(1, 10)).list(Range.singleton(keys.length)).log("values")
+        expected <- Gen.constant(keys.zip(values).toMap).log("expected")
+      } yield {
+        val input = Json.fromFields(expected.map { case (key, value) => key.value.toString -> value.asJson })
+
+        val actual = decode[Map[Day, String]](input.noSpaces)
+
+        actual ==== expected.asRight
+      }
+
+  }
+
+  object hourSpec {
+    def tests: List[Test] = List(
+      property("test    Encoder[Hour]", testEncoder),
+      property("test    Decoder[Hour]", testDecoder),
+      property("test KeyEncoder[Hour]", testKeyEncoder),
+      property("test KeyDecoder[Hour]", testKeyDecoder),
+    )
+
+    def testEncoder: Property =
+      for {
+        hourIntAndHour <- TimeGens.genHour.map(hour => hour.value -> hour).log("(hourInt, hour)")
+        (hourInt, hour) = hourIntAndHour
+      } yield {
+        val expected = hourInt.asJson
+        val actual   = hour.asJson
+
+        Result.all(
+          List(
+            actual ==== expected,
+            actual.noSpaces ==== expected.noSpaces,
+          )
+        )
+      }
+
+    def testDecoder: Property =
+      for {
+        hourIntAndHour <- TimeGens.genHour.map(hour => hour.value -> hour).log("(hourInt, hour)")
+        (hourInt, hour) = hourIntAndHour
+      } yield {
+        val input = hour.asJson
+
+        val expected = hour.asRight[io.circe.Error]
+        val actual   = decode[Hour](input.noSpaces)
+
+        actual ==== expected
+      }
+
+    def testKeyEncoder: Property =
+      for {
+        keys   <- TimeGens.genHour.list(Range.linear(1, 20)).log("keys")
+        values <- Gen.string(Gen.alpha, Range.linear(1, 10)).list(Range.singleton(keys.length)).log("values")
+        map    <- Gen.constant(keys.zip(values).toMap).log("map")
+      } yield {
+        val expected = Json.fromFields(map.map { case (key, value) => key.value.toString -> value.asJson })
+
+        val actual = map.asJson
+        Result.all(
+          List(
+            actual ==== expected,
+            actual.noSpacesSortKeys ==== expected.noSpacesSortKeys,
+          )
+        )
+      }
+
+    def testKeyDecoder: Property =
+      for {
+        keys     <- TimeGens.genHour.list(Range.linear(1, 20)).log("keys")
+        values   <- Gen.string(Gen.alpha, Range.linear(1, 10)).list(Range.singleton(keys.length)).log("values")
+        expected <- Gen.constant(keys.zip(values).toMap).log("expected")
+      } yield {
+        val input = Json.fromFields(expected.map { case (key, value) => key.value.toString -> value.asJson })
+
+        val actual = decode[Map[Hour, String]](input.noSpaces)
+
+        actual ==== expected.asRight
+      }
+
+  }
+
+  object minuteSpec {
+    def tests: List[Test] = List(
+      property("test    Encoder[Minute]", testEncoder),
+      property("test    Decoder[Minute]", testDecoder),
+      property("test KeyEncoder[Minute]", testKeyEncoder),
+      property("test KeyDecoder[Minute]", testKeyDecoder),
+    )
+
+    def testEncoder: Property =
+      for {
+        minuteIntAndMinute <- TimeGens.genMinute.map(minute => minute.value -> minute).log("(minuteInt, minute)")
+        (minuteInt, minute) = minuteIntAndMinute
+      } yield {
+        val expected = minuteInt.asJson
+        val actual   = minute.asJson
+
+        Result.all(
+          List(
+            actual ==== expected,
+            actual.noSpaces ==== expected.noSpaces,
+          )
+        )
+      }
+
+    def testDecoder: Property =
+      for {
+        minuteIntAndMinute <- TimeGens.genMinute.map(minute => minute.value -> minute).log("(minuteInt, minute)")
+        (minuteInt, minute) = minuteIntAndMinute
+      } yield {
+        val input = minute.asJson
+
+        val expected = minute.asRight[io.circe.Error]
+        val actual   = decode[Minute](input.noSpaces)
+
+        actual ==== expected
+      }
+
+    def testKeyEncoder: Property =
+      for {
+        keys   <- TimeGens.genMinute.list(Range.linear(1, 20)).log("keys")
+        values <- Gen.string(Gen.alpha, Range.linear(1, 10)).list(Range.singleton(keys.length)).log("values")
+        map    <- Gen.constant(keys.zip(values).toMap).log("map")
+      } yield {
+        val expected = Json.fromFields(map.map { case (key, value) => key.value.toString -> value.asJson })
+
+        val actual = map.asJson
+        Result.all(
+          List(
+            actual ==== expected,
+            actual.noSpacesSortKeys ==== expected.noSpacesSortKeys,
+          )
+        )
+      }
+
+    def testKeyDecoder: Property =
+      for {
+        keys     <- TimeGens.genMinute.list(Range.linear(1, 20)).log("keys")
+        values   <- Gen.string(Gen.alpha, Range.linear(1, 10)).list(Range.singleton(keys.length)).log("values")
+        expected <- Gen.constant(keys.zip(values).toMap).log("expected")
+      } yield {
+        val input = Json.fromFields(expected.map { case (key, value) => key.value.toString -> value.asJson })
+
+        val actual = decode[Map[Minute, String]](input.noSpaces)
+
+        actual ==== expected.asRight
+      }
+
+  }
+
+  object secondSpec {
+    def tests: List[Test] = List(
+      property("test    Encoder[Second]", testEncoder),
+      property("test    Decoder[Second]", testDecoder),
+      property("test KeyEncoder[Second]", testKeyEncoder),
+      property("test KeyDecoder[Second]", testKeyDecoder),
+    )
+
+    def testEncoder: Property =
+      for {
+        secondIntAndSecond <- TimeGens.genSecond.map(second => second.value -> second).log("(secondInt, second)")
+        (secondInt, second) = secondIntAndSecond
+      } yield {
+        val expected = secondInt.asJson
+        val actual   = second.asJson
+
+        Result.all(
+          List(
+            actual ==== expected,
+            actual.noSpaces ==== expected.noSpaces,
+          )
+        )
+      }
+
+    def testDecoder: Property =
+      for {
+        secondIntAndSecond <- TimeGens.genSecond.map(second => second.value -> second).log("(secondInt, second)")
+        (secondInt, second) = secondIntAndSecond
+      } yield {
+        val input = second.asJson
+
+        val expected = second.asRight[io.circe.Error]
+        val actual   = decode[Second](input.noSpaces)
+
+        actual ==== expected
+      }
+
+    def testKeyEncoder: Property =
+      for {
+        keys   <- TimeGens.genSecond.list(Range.linear(1, 20)).log("keys")
+        values <- Gen.string(Gen.alpha, Range.linear(1, 10)).list(Range.singleton(keys.length)).log("values")
+        map    <- Gen.constant(keys.zip(values).toMap).log("map")
+      } yield {
+        val expected = Json.fromFields(map.map { case (key, value) => key.value.toString -> value.asJson })
+
+        val actual = map.asJson
+        Result.all(
+          List(
+            actual ==== expected,
+            actual.noSpacesSortKeys ==== expected.noSpacesSortKeys,
+          )
+        )
+      }
+
+    def testKeyDecoder: Property =
+      for {
+        keys     <- TimeGens.genSecond.list(Range.linear(1, 20)).log("keys")
+        values   <- Gen.string(Gen.alpha, Range.linear(1, 10)).list(Range.singleton(keys.length)).log("values")
+        expected <- Gen.constant(keys.zip(values).toMap).log("expected")
+      } yield {
+        val input = Json.fromFields(expected.map { case (key, value) => key.value.toString -> value.asJson })
+
+        val actual = decode[Map[Second, String]](input.noSpaces)
+
+        actual ==== expected.asRight
+      }
+
+  }
+
+  object millisSpec {
+    def tests: List[Test] = List(
+      property("test    Encoder[Millis]", testEncoder),
+      property("test    Decoder[Millis]", testDecoder),
+      property("test KeyEncoder[Millis]", testKeyEncoder),
+      property("test KeyDecoder[Millis]", testKeyDecoder),
+    )
+
+    def testEncoder: Property =
+      for {
+        millisIntAndMillis <- TimeGens.genMillis.map(millis => millis.value -> millis).log("(millisInt, millis)")
+        (millisInt, millis) = millisIntAndMillis
+      } yield {
+        val expected = millisInt.asJson
+        val actual   = millis.asJson
+
+        Result.all(
+          List(
+            actual ==== expected,
+            actual.noSpaces ==== expected.noSpaces,
+          )
+        )
+      }
+
+    def testDecoder: Property =
+      for {
+        millisIntAndMillis <- TimeGens.genMillis.map(millis => millis.value -> millis).log("(millisInt, millis)")
+        (millisInt, millis) = millisIntAndMillis
+      } yield {
+        val input = millis.asJson
+
+        val expected = millis.asRight[io.circe.Error]
+        val actual   = decode[Millis](input.noSpaces)
+
+        actual ==== expected
+      }
+
+    def testKeyEncoder: Property =
+      for {
+        keys   <- TimeGens.genMillis.list(Range.linear(1, 20)).log("keys")
+        values <- Gen.string(Gen.alpha, Range.linear(1, 10)).list(Range.singleton(keys.length)).log("values")
+        map    <- Gen.constant(keys.zip(values).toMap).log("map")
+      } yield {
+        val expected = Json.fromFields(map.map { case (key, value) => key.value.toString -> value.asJson })
+
+        val actual = map.asJson
+        Result.all(
+          List(
+            actual ==== expected,
+            actual.noSpacesSortKeys ==== expected.noSpacesSortKeys,
+          )
+        )
+      }
+
+    def testKeyDecoder: Property =
+      for {
+        keys     <- TimeGens.genMillis.list(Range.linear(1, 20)).log("keys")
+        values   <- Gen.string(Gen.alpha, Range.linear(1, 10)).list(Range.singleton(keys.length)).log("values")
+        expected <- Gen.constant(keys.zip(values).toMap).log("expected")
+      } yield {
+        val input = Json.fromFields(expected.map { case (key, value) => key.value.toString -> value.asJson })
+
+        val actual = decode[Map[Millis, String]](input.noSpaces)
+
+        actual ==== expected.asRight
+      }
+
+  }
+
+}
+object timeSpec extends Properties, timeSpec {
+  override protected val timeTypeClasses: refined4s.modules.circe.derivation.types.time =
+    refined4s.modules.circe.derivation.types.time
+
+  override def tests: List[Test] = allTests
+}


### PR DESCRIPTION
Close #497: [`refined4s-circe`] Add `Encoder`, `Decoder`, `KeyEncoder` and `KeyDecoder` type-class instances for `refined4s.types.time` types