### PR TITLE
Close #504: [`refined4s-tapir`] Add `Schema` type-class instances for `refined4s.types.time` types

### DIFF
--- a/modules/refined4s-tapir/shared/src/main/scala/refined4s/modules/tapir/derivation/types/all.scala
+++ b/modules/refined4s-tapir/shared/src/main/scala/refined4s/modules/tapir/derivation/types/all.scala
@@ -3,5 +3,5 @@ package refined4s.modules.tapir.derivation.types
 /** @author Kevin Lee
   * @since 2024-04-03
   */
-trait all extends numeric with strings with network
+trait all extends numeric, strings, network, time
 object all extends all

--- a/modules/refined4s-tapir/shared/src/main/scala/refined4s/modules/tapir/derivation/types/time.scala
+++ b/modules/refined4s-tapir/shared/src/main/scala/refined4s/modules/tapir/derivation/types/time.scala
@@ -1,0 +1,38 @@
+package refined4s.modules.tapir.derivation.types
+
+import sttp.tapir.Schema
+import refined4s.types.time.*
+
+/** @author Kevin Lee
+  * @since 2025-09-03
+  */
+trait time {
+
+  inline given derivedMonthSchema: Schema[Month] = time.derivedMonthSchema
+
+  inline given derivedDaySchema: Schema[Day] = time.derivedDaySchema
+
+  inline given derivedHourSchema: Schema[Hour] = time.derivedHourSchema
+
+  inline given derivedMinuteSchema: Schema[Minute] = time.derivedMinuteSchema
+
+  inline given derivedSecondSchema: Schema[Second] = time.derivedSecondSchema
+
+  inline given derivedMillisSchema: Schema[Millis] = time.derivedMillisSchema
+
+}
+object time {
+
+  given derivedMonthSchema(using actualSchema: Schema[Int]): Schema[Month] = actualSchema.map(Month.from(_).toOption)(_.value)
+
+  given derivedDaySchema(using actualSchema: Schema[Int]): Schema[Day] = actualSchema.map(Day.from(_).toOption)(_.value)
+
+  given derivedHourSchema(using actualSchema: Schema[Int]): Schema[Hour] = actualSchema.map(Hour.from(_).toOption)(_.value)
+
+  given derivedMinuteSchema(using actualSchema: Schema[Int]): Schema[Minute] = actualSchema.map(Minute.from(_).toOption)(_.value)
+
+  given derivedSecondSchema(using actualSchema: Schema[Int]): Schema[Second] = actualSchema.map(Second.from(_).toOption)(_.value)
+
+  given derivedMillisSchema(using actualSchema: Schema[Int]): Schema[Millis] = actualSchema.map(Millis.from(_).toOption)(_.value)
+
+}

--- a/modules/refined4s-tapir/shared/src/test/scala/refined4s/modules/tapir/derivation/types/allSpec.scala
+++ b/modules/refined4s-tapir/shared/src/test/scala/refined4s/modules/tapir/derivation/types/allSpec.scala
@@ -20,7 +20,11 @@ object allSpec extends Properties {
     override protected val networkTypeClasses: network = refined4s.modules.tapir.derivation.types.all
   }
 
+  object timeSpecWithAll extends timeSpec {
+    override protected val timeTypeClasses: time = refined4s.modules.tapir.derivation.types.all
+  }
+
   override def tests: List[Test] =
-    numericSpecWithAll.allTests ++ stringsSpecWithAll.allTests ++ networkSpecWithAll.allTests
+    numericSpecWithAll.allTests ++ stringsSpecWithAll.allTests ++ networkSpecWithAll.allTests ++ timeSpecWithAll.allTests
 
 }

--- a/modules/refined4s-tapir/shared/src/test/scala/refined4s/modules/tapir/derivation/types/timeSpec.scala
+++ b/modules/refined4s-tapir/shared/src/test/scala/refined4s/modules/tapir/derivation/types/timeSpec.scala
@@ -1,0 +1,111 @@
+package refined4s.modules.tapir.derivation.types
+
+import hedgehog.*
+import hedgehog.runner.*
+import refined4s.types.TimeGens
+import refined4s.types.time.*
+import sttp.tapir.{Schema, ValidationError}
+
+/** @author Kevin Lee
+  * @since 2025-09-03
+  */
+trait timeSpec {
+
+  protected val timeTypeClasses: refined4s.modules.tapir.derivation.types.time
+  import timeTypeClasses.given
+
+  def allTests: List[Test] = List(
+    property("test Schema[Month]", testSchemaMonth),
+    property("test Schema[Day]", testSchemaDay),
+    property("test Schema[Hour]", testSchemaHour),
+    property("test Schema[Minute]", testSchemaMinute),
+    property("test Schema[Second]", testSchemaSecond),
+    property("test Schema[Millis]", testSchemaMillis),
+  )
+
+  def testSchemaMonth: Property =
+    for {
+      month <- TimeGens.genMonthInt.log("month")
+    } yield {
+
+      val input = Month.unsafeFrom(month)
+
+      val expected = List.empty[ValidationError[?]]
+      val actual   = summon[Schema[Month]].applyValidation(input)
+
+      actual ==== expected
+    }
+
+  def testSchemaDay: Property =
+    for {
+      day <- TimeGens.genDayInt.log("day")
+    } yield {
+
+      val input = Day.unsafeFrom(day)
+
+      val expected = List.empty[ValidationError[?]]
+      val actual   = summon[Schema[Day]].applyValidation(input)
+
+      actual ==== expected
+    }
+
+  def testSchemaHour: Property =
+    for {
+      hour <- TimeGens.genHourInt.log("hour")
+    } yield {
+
+      val input = Hour.unsafeFrom(hour)
+
+      val expected = List.empty[ValidationError[?]]
+      val actual   = summon[Schema[Hour]].applyValidation(input)
+
+      actual ==== expected
+    }
+
+  def testSchemaMinute: Property =
+    for {
+      minute <- TimeGens.genMinuteInt.log("minute")
+    } yield {
+
+      val input = Minute.unsafeFrom(minute)
+
+      val expected = List.empty[ValidationError[?]]
+      val actual   = summon[Schema[Minute]].applyValidation(input)
+
+      actual ==== expected
+    }
+
+  def testSchemaSecond: Property =
+    for {
+      second <- TimeGens.genSecondInt.log("second")
+    } yield {
+
+      val input = Second.unsafeFrom(second)
+
+      val expected = List.empty[ValidationError[?]]
+      val actual   = summon[Schema[Second]].applyValidation(input)
+
+      actual ==== expected
+    }
+
+  def testSchemaMillis: Property =
+    for {
+      millis <- TimeGens.genMillisInt.log("millis")
+    } yield {
+
+      val input = Millis.unsafeFrom(millis)
+
+      val expected = List.empty[ValidationError[?]]
+      val actual   = summon[Schema[Millis]].applyValidation(input)
+
+      actual ==== expected
+    }
+
+}
+object timeSpec extends Properties, timeSpec {
+
+  override protected object timeTypeClasses extends refined4s.modules.tapir.derivation.types.time
+
+  override def tests: List[Test] = allTests
+
+}


### PR DESCRIPTION
Close #504: [`refined4s-tapir`] Add `Schema` type-class instances for `refined4s.types.time` types