### PR TITLE
refined4s v1.9.0

### DIFF
--- a/changelogs/1.9.0.md
+++ b/changelogs/1.9.0.md
@@ -1,0 +1,145 @@
+## [1.9.0](https://github.com/kevin-lee/refined4s/issues?q=is%3Aissue%20is%3Aclosed%20-label%3Ainvalid%20-label%3Awontfix%20milestone%3Am30) - 2025-09-05
+
+### New Features
+
+* [`refined4s-core`] Add `cats.Hash` type class instances for `refined4s.types.strings` with `orphan-cats` (#488)
+* [`refined4s-core`] Add `cats.Hash` type class instances for `refined4s.types.network` with `orphan-cats` (#490)
+* [`refined4s-core`] Add `cats.Hash` type class instances for `refined4s.types.numeric` with `orphan-cats` (#491)
+* [`refined4s-core`] Add `cats.Hash` type class instances for `refined4s.types.time` with `orphan-cats` (#492)
+* [`refined4s-circe`] Add `Encoder`, `Decoder`, `KeyEncoder` and `KeyDecoder` type-class instances for `refined4s.types.time` types (#497)
+
+  Add `Encoder`, `Decoder`, `KeyEncoder` and `KeyDecoder` instances for
+  * `Month`
+  * `Day`
+  * `Hour`
+  * `Minute`
+  * `Second`
+  * `Millis`
+
+
+* [`refined4s-extras-render`] Add `Render` type-class instances for `refined4s.types.time` types (#499)
+* [`refined4s-chimney`] Add `Transformer` and `PartialTransformer` type-class instances for `refined4s.types.time` types (#500)
+* [`refined4s-pureconfig`] Add `ConfigReader` and `ConfigWriter` type-class instances for `refined4s.types.time` types (#501)
+* [`refined4s-doobie-ce2`] Add `Get` and `Put` type-class instances for `refined4s.types.time` types (#502)
+* [`refined4s-doobie-ce3`] Add `Get` and `Put` type-class instances for `refined4s.types.time` types (#503)
+* [`refined4s-tapir`] Add `Schema` type-class instances for `refined4s.types.time` types (#504)
+* [`refined4s-cats`] Add `CatsHash` to derive `Hash` from the actual type's `Hash` (#508)
+
+  ```scala 3
+  type MyNewtype = MyNewtype.Type
+  object MyNewtype extends Newtype[String], CatsHash[String]
+  
+  type MyRefinedType = MyRefinedType.Type
+  object MyRefinedType extends Refined[String], CatsHash[String] {
+    override inline def invalidReason(a: String): String =
+      "It has to be a non-empty String but got \"" + a + "\""
+  
+    override inline def predicate(a: String): Boolean = a != ""
+  }
+  
+  type MyRefinedNewtype = MyRefinedNewtype.Type
+  object MyRefinedNewtype extends Newtype[MyRefinedType], CatsHash[MyRefinedType]
+  ```
+
+***
+
+### Internal Changes
+
+* Do not use `java.net.URL`'s constructors as they are deprecated since Java 20 (#484)
+
+  `new URL()` is used in `Url` validation, but it shouldn't be used because it was deprecated in Java 20.
+
+
+#### Reorganize type-class instances in the modules (#507)
+1. `all` => `strings`, `numeric`, `network` and `time` + `all`
+  
+   If the type class instances are in the `all` object, split them into multiple objects such as `strings`, `numeric`, `network`, and `time`, as well as an `all` object that contains all of them.
+
+2. Move type-class instances from `trait`s to `object`s
+  
+   The type-class instances in `trait`s should be moved to `object`s and the `trait`s should have the same ones from the `object`s.
+
+   e.g.)
+   ```scala 3
+   trait strings {
+   
+     /* NonEmptyString */
+     inline given derivedNonEmptyStringEncoder: Encoder[NonEmptyString] = Encoder[String].contramap[NonEmptyString](_.value)
+     inline given derivedNonEmptyStringDecoder: Decoder[NonEmptyString] = Decoder[String].emap(NonEmptyString.from)
+   }
+   object strings extends strings
+   ```
+   to
+   ```scala 3
+   trait strings {
+   
+     /* NonEmptyString */
+     inline given derivedNonEmptyStringEncoder: Encoder[NonEmptyString] = strings.derivedNonEmptyStringEncoder
+     inline given derivedNonEmptyStringDecoder: Decoder[NonEmptyString] = strings.derivedNonEmptyStringDecoder
+   
+   }
+   object strings {
+   
+     /* NonEmptyString */
+     given derivedNonEmptyStringEncoder: Encoder[NonEmptyString] = Encoder[String].contramap[NonEmptyString](_.value)
+     given derivedNonEmptyStringDecoder: Decoder[NonEmptyString] = Decoder[String].emap(NonEmptyString.from)
+   
+   }
+   ```
+
+
+##### Why?
+With
+```scala 3
+trait strings {
+
+  /* NonEmptyString */
+  inline given derivedNonEmptyStringEncoder: Encoder[NonEmptyString] = Encoder[String].contramap[NonEmptyString](_.value)
+  inline given derivedNonEmptyStringDecoder: Decoder[NonEmptyString] = Decoder[String].emap(NonEmptyString.from)
+}
+object strings extends strings
+```
+Each object extending the `trait` has new non-equal type-class instances, and it is completely unnecessary.
+```scala 3
+val strings = new refined4s.modules.circe.derivation.types.strings {}
+
+strings.derivedNonEmptyStringEncoder == refined4s.modules.circe.derivation.types.strings.derivedNonEmptyStringEncoder
+// Boolean = false
+
+strings.derivedNonEmptyStringEncoder eq refined4s.modules.circe.derivation.types.strings.derivedNonEmptyStringEncoder
+// Boolean = false
+```
+***
+With
+```scala 3
+trait strings {
+
+  /* NonEmptyString */
+  inline given derivedNonEmptyStringEncoder: Encoder[NonEmptyString] = strings.derivedNonEmptyStringEncoder
+  inline given derivedNonEmptyStringDecoder: Decoder[NonEmptyString] = strings.derivedNonEmptyStringDecoder
+
+}
+object strings {
+
+  /* NonEmptyString */
+  given derivedNonEmptyStringEncoder: Encoder[NonEmptyString] = Encoder[String].contramap[NonEmptyString](_.value)
+  given derivedNonEmptyStringDecoder: Decoder[NonEmptyString] = Decoder[String].emap(NonEmptyString.from)
+
+}
+```
+It is
+```scala 3
+val strings = new refined4s.modules.circe.derivation.types.strings {}
+
+strings.derivedNonEmptyStringEncoder == refined4s.modules.circe.derivation.types.strings.derivedNonEmptyStringEncoder
+// Boolean = true
+
+strings.derivedNonEmptyStringEncoder eq refined4s.modules.circe.derivation.types.strings.derivedNonEmptyStringEncoder
+// Boolean = true
+```
+
+***
+
+### Internal Housekeeping
+
+* [`refined4s-cats`] Add not-equal tests for `Eq` instances for the types in `refined4s.types` (#486)


### PR DESCRIPTION
## [1.9.0](https://github.com/kevin-lee/refined4s/issues?q=is%3Aissue%20is%3Aclosed%20-label%3Ainvalid%20-label%3Awontfix%20milestone%3Am30) - 2025-09-05

### New Features

* [`refined4s-core`] Add `cats.Hash` type class instances for `refined4s.types.strings` with `orphan-cats` (#488)
* [`refined4s-core`] Add `cats.Hash` type class instances for `refined4s.types.network` with `orphan-cats` (#490)
* [`refined4s-core`] Add `cats.Hash` type class instances for `refined4s.types.numeric` with `orphan-cats` (#491)
* [`refined4s-core`] Add `cats.Hash` type class instances for `refined4s.types.time` with `orphan-cats` (#492)
* [`refined4s-circe`] Add `Encoder`, `Decoder`, `KeyEncoder` and `KeyDecoder` type-class instances for `refined4s.types.time` types (#497)

  Add `Encoder`, `Decoder`, `KeyEncoder` and `KeyDecoder` instances for
  * `Month`
  * `Day`
  * `Hour`
  * `Minute`
  * `Second`
  * `Millis`


* [`refined4s-extras-render`] Add `Render` type-class instances for `refined4s.types.time` types (#499)
* [`refined4s-chimney`] Add `Transformer` and `PartialTransformer` type-class instances for `refined4s.types.time` types (#500)
* [`refined4s-pureconfig`] Add `ConfigReader` and `ConfigWriter` type-class instances for `refined4s.types.time` types (#501)
* [`refined4s-doobie-ce2`] Add `Get` and `Put` type-class instances for `refined4s.types.time` types (#502)
* [`refined4s-doobie-ce3`] Add `Get` and `Put` type-class instances for `refined4s.types.time` types (#503)
* [`refined4s-tapir`] Add `Schema` type-class instances for `refined4s.types.time` types (#504)
* [`refined4s-cats`] Add `CatsHash` to derive `Hash` from the actual type's `Hash` (#508)

  ```scala 3
  type MyNewtype = MyNewtype.Type
  object MyNewtype extends Newtype[String], CatsHash[String]
  
  type MyRefinedType = MyRefinedType.Type
  object MyRefinedType extends Refined[String], CatsHash[String] {
    override inline def invalidReason(a: String): String =
      "It has to be a non-empty String but got \"" + a + "\""
  
    override inline def predicate(a: String): Boolean = a != ""
  }
  
  type MyRefinedNewtype = MyRefinedNewtype.Type
  object MyRefinedNewtype extends Newtype[MyRefinedType], CatsHash[MyRefinedType]
  ```

***

### Internal Changes

* Do not use `java.net.URL`'s constructors as they are deprecated since Java 20 (#484)

  `new URL()` is used in `Url` validation, but it shouldn't be used because it was deprecated in Java 20.


#### Reorganize type-class instances in the modules (#507)
1. `all` => `strings`, `numeric`, `network` and `time` + `all`
  
   If the type class instances are in the `all` object, split them into multiple objects such as `strings`, `numeric`, `network`, and `time`, as well as an `all` object that contains all of them.

2. Move type-class instances from `trait`s to `object`s
  
   The type-class instances in `trait`s should be moved to `object`s and the `trait`s should have the same ones from the `object`s.

   e.g.)
   ```scala 3
   trait strings {
   
     /* NonEmptyString */
     inline given derivedNonEmptyStringEncoder: Encoder[NonEmptyString] = Encoder[String].contramap[NonEmptyString](_.value)
     inline given derivedNonEmptyStringDecoder: Decoder[NonEmptyString] = Decoder[String].emap(NonEmptyString.from)
   }
   object strings extends strings
   ```
   to
   ```scala 3
   trait strings {
   
     /* NonEmptyString */
     inline given derivedNonEmptyStringEncoder: Encoder[NonEmptyString] = strings.derivedNonEmptyStringEncoder
     inline given derivedNonEmptyStringDecoder: Decoder[NonEmptyString] = strings.derivedNonEmptyStringDecoder
   
   }
   object strings {
   
     /* NonEmptyString */
     given derivedNonEmptyStringEncoder: Encoder[NonEmptyString] = Encoder[String].contramap[NonEmptyString](_.value)
     given derivedNonEmptyStringDecoder: Decoder[NonEmptyString] = Decoder[String].emap(NonEmptyString.from)
   
   }
   ```


##### Why?
With
```scala 3
trait strings {

  /* NonEmptyString */
  inline given derivedNonEmptyStringEncoder: Encoder[NonEmptyString] = Encoder[String].contramap[NonEmptyString](_.value)
  inline given derivedNonEmptyStringDecoder: Decoder[NonEmptyString] = Decoder[String].emap(NonEmptyString.from)
}
object strings extends strings
```
Each object extending the `trait` has new non-equal type-class instances, and it is completely unnecessary.
```scala 3
val strings = new refined4s.modules.circe.derivation.types.strings {}

strings.derivedNonEmptyStringEncoder == refined4s.modules.circe.derivation.types.strings.derivedNonEmptyStringEncoder
// Boolean = false

strings.derivedNonEmptyStringEncoder eq refined4s.modules.circe.derivation.types.strings.derivedNonEmptyStringEncoder
// Boolean = false
```
***
With
```scala 3
trait strings {

  /* NonEmptyString */
  inline given derivedNonEmptyStringEncoder: Encoder[NonEmptyString] = strings.derivedNonEmptyStringEncoder
  inline given derivedNonEmptyStringDecoder: Decoder[NonEmptyString] = strings.derivedNonEmptyStringDecoder

}
object strings {

  /* NonEmptyString */
  given derivedNonEmptyStringEncoder: Encoder[NonEmptyString] = Encoder[String].contramap[NonEmptyString](_.value)
  given derivedNonEmptyStringDecoder: Decoder[NonEmptyString] = Decoder[String].emap(NonEmptyString.from)

}
```
It is
```scala 3
val strings = new refined4s.modules.circe.derivation.types.strings {}

strings.derivedNonEmptyStringEncoder == refined4s.modules.circe.derivation.types.strings.derivedNonEmptyStringEncoder
// Boolean = true

strings.derivedNonEmptyStringEncoder eq refined4s.modules.circe.derivation.types.strings.derivedNonEmptyStringEncoder
// Boolean = true
```

***

### Internal Housekeeping

* [`refined4s-cats`] Add not-equal tests for `Eq` instances for the types in `refined4s.types` (#486)
