### PR TITLE
Update GitHub Actions workflows: Bump Node version for the doc site to 22.19.0

### DIFF
--- a/.github/workflows/doc-site-build-only.yml
+++ b/.github/workflows/doc-site-build-only.yml
@@ -18,7 +18,7 @@ jobs:
         scala:
           - { version: "3.3.5", binary-version: "3", java-version: "17", java-distribution: "temurin" }
         node:
-          - { version: "22.17.0" }
+          - { version: "22.19.0" }
 
     steps:
       - uses: actions/checkout@v5

--- a/.github/workflows/doc-site-publish.yml
+++ b/.github/workflows/doc-site-publish.yml
@@ -18,7 +18,7 @@ jobs:
         scala:
           - { version: "3.3.5", binary-version: "3", java-version: "17", java-distribution: "temurin" }
         node:
-          - { version: "22.17.0" }
+          - { version: "22.19.0" }
 
     steps:
       - uses: actions/checkout@v5


### PR DESCRIPTION
Update GitHub Actions workflows: Bump Node version for the doc site to 22.19.0