### PR TITLE
Fix #531: `inline given`s in `trait`s for type classes cause `unused import` warnings

### DIFF
--- a/modules/refined4s-cats/shared/src/main/scala/refined4s/modules/cats/derivation/CatsEq.scala
+++ b/modules/refined4s-cats/shared/src/main/scala/refined4s/modules/cats/derivation/CatsEq.scala
@@ -9,5 +9,5 @@ import refined4s.*
 trait CatsEq[A: Eq] {
   self: NewtypeBase[A] =>
 
-  inline given derivedEq: Eq[Type] = deriving[Eq]
+  given derivedEq: Eq[Type] = deriving[Eq]
 }

--- a/modules/refined4s-cats/shared/src/main/scala/refined4s/modules/cats/derivation/CatsHash.scala
+++ b/modules/refined4s-cats/shared/src/main/scala/refined4s/modules/cats/derivation/CatsHash.scala
@@ -9,5 +9,5 @@ import refined4s.*
 trait CatsHash[A: Hash] {
   self: NewtypeBase[A] =>
 
-  inline given derivedHash: Hash[Type] = deriving[Hash]
+  given derivedHash: Hash[Type] = deriving[Hash]
 }

--- a/modules/refined4s-cats/shared/src/main/scala/refined4s/modules/cats/derivation/CatsOrder.scala
+++ b/modules/refined4s-cats/shared/src/main/scala/refined4s/modules/cats/derivation/CatsOrder.scala
@@ -9,5 +9,5 @@ import refined4s.*
 trait CatsOrder[A: Order] {
   self: NewtypeBase[A] =>
 
-  inline given derivedOrder: Order[Type] = deriving[Order]
+  given derivedOrder: Order[Type] = deriving[Order]
 }

--- a/modules/refined4s-cats/shared/src/main/scala/refined4s/modules/cats/derivation/generic/auto.scala
+++ b/modules/refined4s-cats/shared/src/main/scala/refined4s/modules/cats/derivation/generic/auto.scala
@@ -6,17 +6,14 @@ import refined4s.*
 /** @author Kevin Lee
   * @since 2023-12-07
   */
-
 trait auto {
-
-  inline given derivedEq[A, B](using coercible: Coercible[A, B], eqB: Eq[B]): Eq[A] =
+  given derivedEq[A, B](using coercible: Coercible[A, B], eqB: Eq[B]): Eq[A] =
     refined4s.modules.cats.syntax.contraCoercible(eqB)
 
-  inline given derivedOrder[A, B](using coercible: Coercible[A, B], orderB: Order[B]): Order[A] =
+  given derivedOrder[A, B](using coercible: Coercible[A, B], orderB: Order[B]): Order[A] =
     refined4s.modules.cats.syntax.contraCoercible(orderB)
 
-  inline given derivedShow[A, B](using coercible: Coercible[A, B], showB: Show[B]): Show[A] =
+  given derivedShow[A, B](using coercible: Coercible[A, B], showB: Show[B]): Show[A] =
     refined4s.modules.cats.syntax.contraCoercible(showB)
-
 }
 object auto extends auto

--- a/modules/refined4s-cats/shared/src/test/scala/refined4s/modules/cats/derivation/generic/autoSpec.scala
+++ b/modules/refined4s-cats/shared/src/test/scala/refined4s/modules/cats/derivation/generic/autoSpec.scala
@@ -147,9 +147,11 @@ object autoSpec extends Properties {
     property("test Show[NonPosBigDecimal]", testShowNonPosBigDecimal),
     //
     property("test Eq[NonEmptyString]", testEqNonEmptyString),
+    property("test Order[NonEmptyString]", testOrderNonEmptyString),
     property("test Show[NonEmptyString]", testShowNonEmptyString),
     //
     property("test Eq[NonBlankString]", testEqNonBlankString),
+    property("test Order[NonBlankString]", testOrderNonBlankString),
     property("test Show[NonBlankString]", testShowNonBlankString),
     //
     property("test Eq[Uri]", testEqUri),
@@ -179,6 +181,8 @@ object autoSpec extends Properties {
     property("test Eq[MyNum]", testEqMyNum),
     property("test Order[MyNum]", testOrderMyNum),
     property("test Show[MyNum]", testShowMyNum),
+    //
+    property("test Eq[MyType] with MyType(MyTypeWithEq) where MyTypeWithEq has its own Eq", testEqMyType),
   )
 
   def testEqNegInt: Property =
@@ -190,7 +194,7 @@ object autoSpec extends Properties {
       val expected = input
       val actual   = input
 
-      Result.diffNamed("NegInt(value) === NegInt(value)", actual, expected)(_ === _)
+      Result.diffNamed("NegInt(value) === NegInt(value)", actual, expected)(Eq[NegInt].eqv(_, _))
     }
 
   def testOrderNegInt: Property =
@@ -226,7 +230,7 @@ object autoSpec extends Properties {
       val expected = input
       val actual   = input
 
-      Result.diffNamed("NegInt(value) === NegInt(value)", actual, expected)(_ === _)
+      Result.diffNamed("NonNegInt(value) === NonNegInt(value)", actual, expected)(Eq[NonNegInt].eqv(_, _))
     }
 
   def testOrderNonNegInt: Property =
@@ -262,7 +266,7 @@ object autoSpec extends Properties {
       val expected = input
       val actual   = input
 
-      Result.diffNamed("PosInt(value) === PosInt(value)", actual, expected)(_ === _)
+      Result.diffNamed("PosInt(value) === PosInt(value)", actual, expected)(Eq[PosInt].eqv(_, _))
     }
 
   def testOrderPosInt: Property =
@@ -298,7 +302,7 @@ object autoSpec extends Properties {
       val expected = input
       val actual   = input
 
-      Result.diffNamed("NonPosInt(value) === NonPosInt(value)", actual, expected)(_ === _)
+      Result.diffNamed("NonPosInt(value) === NonPosInt(value)", actual, expected)(Eq[NonPosInt].eqv(_, _))
     }
 
   def testOrderNonPosInt: Property =
@@ -334,7 +338,7 @@ object autoSpec extends Properties {
       val expected = input
       val actual   = input
 
-      Result.diffNamed("NegLong(value) === NegLong(value)", actual, expected)(_ === _)
+      Result.diffNamed("NegLong(value) === NegLong(value)", actual, expected)(Eq[NegLong].eqv(_, _))
     }
 
   def testOrderNegLong: Property =
@@ -370,7 +374,7 @@ object autoSpec extends Properties {
       val expected = input
       val actual   = input
 
-      Result.diffNamed("NonNegLong(value) === NonNegLong(value)", actual, expected)(_ === _)
+      Result.diffNamed("NonNegLong(value) === NonNegLong(value)", actual, expected)(Eq[NonNegLong].eqv(_, _))
     }
 
   def testOrderNonNegLong: Property =
@@ -406,7 +410,7 @@ object autoSpec extends Properties {
       val expected = input
       val actual   = input
 
-      Result.diffNamed("PosLong(value) === PosLong(value)", actual, expected)(_ === _)
+      Result.diffNamed("PosLong(value) === PosLong(value)", actual, expected)(Eq[PosLong].eqv(_, _))
     }
 
   def testOrderPosLong: Property =
@@ -442,7 +446,7 @@ object autoSpec extends Properties {
       val expected = input
       val actual   = input
 
-      Result.diffNamed("NonPosLong(value) === NonPosLong(value)", actual, expected)(_ === _)
+      Result.diffNamed("NonPosLong(value) === NonPosLong(value)", actual, expected)(Eq[NonPosLong].eqv(_, _))
     }
 
   def testOrderNonPosLong: Property =
@@ -478,7 +482,7 @@ object autoSpec extends Properties {
       val expected = input
       val actual   = input
 
-      Result.diffNamed("NegShort(value) === NegShort(value)", actual, expected)(_ === _)
+      Result.diffNamed("NegShort(value) === NegShort(value)", actual, expected)(Eq[NegShort].eqv(_, _))
     }
 
   def testOrderNegShort: Property =
@@ -514,7 +518,7 @@ object autoSpec extends Properties {
       val expected = input
       val actual   = input
 
-      Result.diffNamed("NonNegShort(value) === NonNegShort(value)", actual, expected)(_ === _)
+      Result.diffNamed("NonNegShort(value) === NonNegShort(value)", actual, expected)(Eq[NonNegShort].eqv(_, _))
     }
 
   def testOrderNonNegShort: Property =
@@ -550,7 +554,7 @@ object autoSpec extends Properties {
       val expected = input
       val actual   = input
 
-      Result.diffNamed("PosShort(value) === PosShort(value)", actual, expected)(_ === _)
+      Result.diffNamed("PosShort(value) === PosShort(value)", actual, expected)(Eq[PosShort].eqv(_, _))
     }
 
   def testOrderPosShort: Property =
@@ -586,7 +590,7 @@ object autoSpec extends Properties {
       val expected = input
       val actual   = input
 
-      Result.diffNamed("NonPosShort(value) === NonPosShort(value)", actual, expected)(_ === _)
+      Result.diffNamed("NonPosShort(value) === NonPosShort(value)", actual, expected)(Eq[NonPosShort].eqv(_, _))
     }
 
   def testOrderNonPosShort: Property =
@@ -622,7 +626,7 @@ object autoSpec extends Properties {
       val expected = input
       val actual   = input
 
-      Result.diffNamed("NegByte(value) === NegByte(value)", actual, expected)(_ === _)
+      Result.diffNamed("NegByte(value) === NegByte(value)", actual, expected)(Eq[NegByte].eqv(_, _))
     }
 
   def testOrderNegByte: Property =
@@ -658,7 +662,7 @@ object autoSpec extends Properties {
       val expected = input
       val actual   = input
 
-      Result.diffNamed("NonNegByte(value) === NonNegByte(value)", actual, expected)(_ === _)
+      Result.diffNamed("NonNegByte(value) === NonNegByte(value)", actual, expected)(Eq[NonNegByte].eqv(_, _))
     }
 
   def testOrderNonNegByte: Property =
@@ -694,7 +698,7 @@ object autoSpec extends Properties {
       val expected = input
       val actual   = input
 
-      Result.diffNamed("PosByte(value) === PosByte(value)", actual, expected)(_ === _)
+      Result.diffNamed("PosByte(value) === PosByte(value)", actual, expected)(Eq[PosByte].eqv(_, _))
     }
 
   def testOrderPosByte: Property =
@@ -730,7 +734,7 @@ object autoSpec extends Properties {
       val expected = input
       val actual   = input
 
-      Result.diffNamed("NonPosByte(value) === NonPosByte(value)", actual, expected)(_ === _)
+      Result.diffNamed("NonPosByte(value) === NonPosByte(value)", actual, expected)(Eq[NonPosByte].eqv(_, _))
     }
 
   def testOrderNonPosByte: Property =
@@ -766,7 +770,7 @@ object autoSpec extends Properties {
       val expected = input
       val actual   = input
 
-      Result.diffNamed("NegFloat(value) === NegFloat(value)", actual, expected)(_ === _)
+      Result.diffNamed("NegFloat(value) === NegFloat(value)", actual, expected)(Eq[NegFloat].eqv(_, _))
     }
 
   def testOrderNegFloat: Property =
@@ -802,7 +806,7 @@ object autoSpec extends Properties {
       val expected = input
       val actual   = input
 
-      Result.diffNamed("NonNegFloat(value) === NonNegFloat(value)", actual, expected)(_ === _)
+      Result.diffNamed("NonNegFloat(value) === NonNegFloat(value)", actual, expected)(Eq[NonNegFloat].eqv(_, _))
     }
 
   def testOrderNonNegFloat: Property =
@@ -838,7 +842,7 @@ object autoSpec extends Properties {
       val expected = input
       val actual   = input
 
-      Result.diffNamed("PosFloat(value) === PosFloat(value)", actual, expected)(_ === _)
+      Result.diffNamed("PosFloat(value) === PosFloat(value)", actual, expected)(Eq[PosFloat].eqv(_, _))
     }
 
   def testOrderPosFloat: Property =
@@ -874,7 +878,7 @@ object autoSpec extends Properties {
       val expected = input
       val actual   = input
 
-      Result.diffNamed("NonPosFloat(value) === NonPosFloat(value)", actual, expected)(_ === _)
+      Result.diffNamed("NonPosFloat(value) === NonPosFloat(value)", actual, expected)(Eq[NonPosFloat].eqv(_, _))
     }
 
   def testOrderNonPosFloat: Property =
@@ -910,7 +914,7 @@ object autoSpec extends Properties {
       val expected = input
       val actual   = input
 
-      Result.diffNamed("NegDouble(value) === NegDouble(value)", actual, expected)(_ === _)
+      Result.diffNamed("NegDouble(value) === NegDouble(value)", actual, expected)(Eq[NegDouble].eqv(_, _))
     }
 
   def testOrderNegDouble: Property =
@@ -946,7 +950,7 @@ object autoSpec extends Properties {
       val expected = input
       val actual   = input
 
-      Result.diffNamed("NonNegDouble(value) === NonNegDouble(value)", actual, expected)(_ === _)
+      Result.diffNamed("NonNegDouble(value) === NonNegDouble(value)", actual, expected)(Eq[NonNegDouble].eqv(_, _))
     }
 
   def testOrderNonNegDouble: Property =
@@ -982,7 +986,7 @@ object autoSpec extends Properties {
       val expected = input
       val actual   = input
 
-      Result.diffNamed("PosDouble(value) === PosDouble(value)", actual, expected)(_ === _)
+      Result.diffNamed("PosDouble(value) === PosDouble(value)", actual, expected)(Eq[PosDouble].eqv(_, _))
     }
 
   def testOrderPosDouble: Property =
@@ -1018,7 +1022,7 @@ object autoSpec extends Properties {
       val expected = input
       val actual   = input
 
-      Result.diffNamed("NonPosDouble(value) === NonPosDouble(value)", actual, expected)(_ === _)
+      Result.diffNamed("NonPosDouble(value) === NonPosDouble(value)", actual, expected)(Eq[NonPosDouble].eqv(_, _))
     }
 
   def testOrderNonPosDouble: Property =
@@ -1054,7 +1058,7 @@ object autoSpec extends Properties {
       val expected = input
       val actual   = input
 
-      Result.diffNamed("NegBigInt(value) === NegBigInt(value)", actual, expected)(_ === _)
+      Result.diffNamed("NegBigInt(value) === NegBigInt(value)", actual, expected)(Eq[NegBigInt].eqv(_, _))
     }
 
   def testOrderNegBigInt: Property =
@@ -1090,7 +1094,7 @@ object autoSpec extends Properties {
       val expected = input
       val actual   = input
 
-      Result.diffNamed("NonNegBigInt(value) === NonNegBigInt(value)", actual, expected)(_ === _)
+      Result.diffNamed("NonNegBigInt(value) === NonNegBigInt(value)", actual, expected)(Eq[NonNegBigInt].eqv(_, _))
     }
 
   def testOrderNonNegBigInt: Property =
@@ -1126,7 +1130,7 @@ object autoSpec extends Properties {
       val expected = input
       val actual   = input
 
-      Result.diffNamed("PosBigInt(value) === PosBigInt(value)", actual, expected)(_ === _)
+      Result.diffNamed("PosBigInt(value) === PosBigInt(value)", actual, expected)(Eq[PosBigInt].eqv(_, _))
     }
 
   def testOrderPosBigInt: Property =
@@ -1162,7 +1166,7 @@ object autoSpec extends Properties {
       val expected = input
       val actual   = input
 
-      Result.diffNamed("NonPosBigInt(value) === NonPosBigInt(value)", actual, expected)(_ === _)
+      Result.diffNamed("NonPosBigInt(value) === NonPosBigInt(value)", actual, expected)(Eq[NonPosBigInt].eqv(_, _))
     }
 
   def testOrderNonPosBigInt: Property =
@@ -1198,7 +1202,7 @@ object autoSpec extends Properties {
       val expected = input
       val actual   = input
 
-      Result.diffNamed("NegBigDecimal(value) === NegBigDecimal(value)", actual, expected)(_ === _)
+      Result.diffNamed("NegBigDecimal(value) === NegBigDecimal(value)", actual, expected)(Eq[NegBigDecimal].eqv(_, _))
     }
 
   def testOrderNegBigDecimal: Property =
@@ -1234,7 +1238,7 @@ object autoSpec extends Properties {
       val expected = input
       val actual   = input
 
-      Result.diffNamed("NonNegBigDecimal(value) === NonNegBigDecimal(value)", actual, expected)(_ === _)
+      Result.diffNamed("NonNegBigDecimal(value) === NonNegBigDecimal(value)", actual, expected)(Eq[NonNegBigDecimal].eqv(_, _))
     }
 
   def testOrderNonNegBigDecimal: Property =
@@ -1270,7 +1274,7 @@ object autoSpec extends Properties {
       val expected = input
       val actual   = input
 
-      Result.diffNamed("PosBigDecimal(value) === PosBigDecimal(value)", actual, expected)(_ === _)
+      Result.diffNamed("PosBigDecimal(value) === PosBigDecimal(value)", actual, expected)(Eq[PosBigDecimal].eqv(_, _))
     }
 
   def testOrderPosBigDecimal: Property =
@@ -1306,7 +1310,7 @@ object autoSpec extends Properties {
       val expected = input
       val actual   = input
 
-      Result.diffNamed("NonPosBigDecimal(value) === NonPosBigDecimal(value)", actual, expected)(_ === _)
+      Result.diffNamed("NonPosBigDecimal(value) === NonPosBigDecimal(value)", actual, expected)(Eq[NonPosBigDecimal].eqv(_, _))
     }
 
   def testOrderNonPosBigDecimal: Property =
@@ -1342,7 +1346,22 @@ object autoSpec extends Properties {
       val expected = input
       val actual   = input
 
-      Result.diffNamed("NonEmptyString(value) === NonEmptyString(value)", actual, expected)(_ === _)
+      Result.diffNamed("NonEmptyString(value) === NonEmptyString(value)", actual, expected)(Eq[NonEmptyString].eqv(_, _))
+    }
+
+  def testOrderNonEmptyString: Property =
+    for {
+      s1 <- Gen.string(Gen.unicode, Range.linear(1, 10)).log("s1")
+      s2 <- Gen.string(Gen.unicode, Range.linear(1, 10)).log("s2")
+    } yield {
+      val input1 = NonEmptyString.unsafeFrom(s1)
+      val input2 = NonEmptyString.unsafeFrom(s2)
+
+      val expected = s1.compare(s2)
+
+      Result.diffNamed(show"Comparing $input1 and $input2 with Order[NonEmptyString]", input1, input2)(
+        Order[NonEmptyString].compare(_, _) === expected
+      )
     }
 
   def testShowNonEmptyString: Property =
@@ -1374,7 +1393,39 @@ object autoSpec extends Properties {
       val expected = input
       val actual   = input
 
-      Result.diffNamed("NonEmptyString(value) === NonEmptyString(value)", actual, expected)(_ === _)
+      Result.diffNamed("NonBlankString(value) === NonBlankString(value)", actual, expected)(Eq[NonBlankString].eqv(_, _))
+    }
+
+  def testOrderNonBlankString: Property =
+    for {
+      nonWhitespaceString1 <- Gen.string(hedgehog.extra.Gens.genNonWhitespaceChar, Range.linear(1, 10)).log("nonWhitespaceString1")
+      whitespaceString1    <- Gen
+                                .string(
+                                  hedgehog.extra.Gens.genCharByRange(refined4s.types.strings.WhitespaceCharRange),
+                                  Range.linear(1, 10),
+                                )
+                                .log("whitespaceString1")
+
+      s1 <- Gen.constant(scala.util.Random.shuffle((nonWhitespaceString1 + whitespaceString1).toList).mkString).log("s1")
+
+      nonWhitespaceString2 <- Gen.string(hedgehog.extra.Gens.genNonWhitespaceChar, Range.linear(1, 10)).log("nonWhitespaceString2")
+      whitespaceString2    <- Gen
+                                .string(
+                                  hedgehog.extra.Gens.genCharByRange(refined4s.types.strings.WhitespaceCharRange),
+                                  Range.linear(1, 10),
+                                )
+                                .log("whitespaceString2")
+
+      s2 <- Gen.constant(scala.util.Random.shuffle((nonWhitespaceString2 + whitespaceString2).toList).mkString).log("s2")
+    } yield {
+      val input1 = NonBlankString.unsafeFrom(s1)
+      val input2 = NonBlankString.unsafeFrom(s2)
+
+      val expected = s1.compare(s2)
+
+      Result.diffNamed(show"Comparing $input1 and $input2 with Order[NonBlankString]", input1, input2)(
+        Order[NonBlankString].compare(_, _) === expected
+      )
     }
 
   def testShowNonBlankString: Property =
@@ -1406,7 +1457,7 @@ object autoSpec extends Properties {
       val expected = input
       val actual   = input
 
-      Result.diffNamed("Uri(value) === Uri(value)", actual, expected)(_ === _)
+      Result.diffNamed("Uri(value) === Uri(value)", actual, expected)(Eq[Uri].eqv(_, _))
     }
 
   def testShowUri: Property =
@@ -1436,8 +1487,8 @@ object autoSpec extends Properties {
       val input2 = PortNumber.unsafeFrom(portNumber2)
       Result.all(
         List(
-          Result.diffNamed("Comparing the same objects with ===", input1, input1)(_ === _),
-          Result.diffNamed("Comparing the different objects with =!=", input2, input2)(_ === _),
+          Result.diffNamed("Comparing the same objects with ===", input1, input1)(Eq[PortNumber].eqv(_, _)),
+          Result.diffNamed("Comparing the different objects with =!=", input1, input2)(Eq[PortNumber].neqv(_, _)),
         )
       )
     }
@@ -1487,8 +1538,8 @@ object autoSpec extends Properties {
       val input2 = SystemPortNumber.unsafeFrom(systemPortNumber2)
       Result.all(
         List(
-          Result.diffNamed("Comparing the same objects with ===", input1, input1)(_ === _),
-          Result.diffNamed("Comparing the different objects with =!=", input2, input2)(_ === _),
+          Result.diffNamed("Comparing the same objects with ===", input1, input1)(Eq[SystemPortNumber].eqv(_, _)),
+          Result.diffNamed("Comparing the different objects with =!=", input1, input2)(Eq[SystemPortNumber].neqv(_, _)),
         )
       )
     }
@@ -1538,8 +1589,8 @@ object autoSpec extends Properties {
       val input2 = NonSystemPortNumber.unsafeFrom(nonSystemPortNumber2)
       Result.all(
         List(
-          Result.diffNamed("Comparing the same objects with ===", input1, input1)(_ === _),
-          Result.diffNamed("Comparing the different objects with =!=", input2, input2)(_ === _),
+          Result.diffNamed("Comparing the same objects with ===", input1, input1)(Eq[NonSystemPortNumber].eqv(_, _)),
+          Result.diffNamed("Comparing the different objects with =!=", input1, input2)(Eq[NonSystemPortNumber].neqv(_, _)),
         )
       )
     }
@@ -1589,8 +1640,8 @@ object autoSpec extends Properties {
       val input2 = UserPortNumber.unsafeFrom(userPortNumber2)
       Result.all(
         List(
-          Result.diffNamed("Comparing the same objects with ===", input1, input1)(_ === _),
-          Result.diffNamed("Comparing the different objects with =!=", input2, input2)(_ === _),
+          Result.diffNamed("Comparing the same objects with ===", input1, input1)(Eq[UserPortNumber].eqv(_, _)),
+          Result.diffNamed("Comparing the different objects with =!=", input1, input2)(Eq[UserPortNumber].neqv(_, _)),
         )
       )
     }
@@ -1640,8 +1691,8 @@ object autoSpec extends Properties {
       val input2 = DynamicPortNumber.unsafeFrom(dynamicPortNumber2)
       Result.all(
         List(
-          Result.diffNamed("Comparing the same objects with ===", input1, input1)(_ === _),
-          Result.diffNamed("Comparing the different objects with =!=", input2, input2)(_ === _),
+          Result.diffNamed("Comparing the same objects with ===", input1, input1)(Eq[DynamicPortNumber].eqv(_, _)),
+          Result.diffNamed("Comparing the different objects with =!=", input1, input2)(Eq[DynamicPortNumber].neqv(_, _)),
         )
       )
     }
@@ -1688,8 +1739,8 @@ object autoSpec extends Properties {
       val input2 = MyNum(n2)
       Result.all(
         List(
-          Result.diffNamed("Comparing the same objects with ===", input1, input1)(_ === _),
-          Result.diffNamed("Comparing the different objects with =!=", input2, input2)(_ === _),
+          Result.diffNamed("Comparing the same objects with ===", input1, input1)(Eq[MyNum].eqv(_, _)),
+          Result.diffNamed("Comparing the different objects with =!=", input1, input2)(Eq[MyNum].neqv(_, _)),
         )
       )
     }
@@ -1710,7 +1761,6 @@ object autoSpec extends Properties {
     for {
       dynamicPortNumber <- networkGens.genDynamicPortNumberInt.log("dynamicPortNumber")
     } yield {
-
       val input = DynamicPortNumber.unsafeFrom(dynamicPortNumber)
 
       val expected = dynamicPortNumber.toString
@@ -1719,6 +1769,33 @@ object autoSpec extends Properties {
       actual ==== expected
     }
 
+  def testEqMyType: Property =
+    for {
+      b1 <- Gen.boolean.log("b1")
+      b2 <- Gen.constant(if b1 then false else true).log("b2")
+    } yield {
+      val input1 = MyType(MyTypeWithEq(b1))
+      val input2 = MyType(MyTypeWithEq(b2))
+      Result.all(
+        List(
+          Result.diffNamed("Comparing the same objects with ===", input1, input1)(Eq[MyType].eqv(_, _)),
+          Result.diffNamed("Comparing the different objects with =!=", input1, input2)(Eq[MyType].neqv(_, _)),
+        )
+      )
+    }
+
   type MyNum = MyNum.Type
   object MyNum extends Newtype[Int]
+
+  final case class MyTypeWithEq(value: Boolean)
+  object MyTypeWithEq {
+    given eqMyTypeWithEq: Eq[MyTypeWithEq] with {
+      override def eqv(x: MyTypeWithEq, y: MyTypeWithEq): Boolean = {
+        x.value === y.value
+      }
+    }
+  }
+
+  type MyType = MyType.Type
+  object MyType extends Newtype[MyTypeWithEq]
 }

--- a/modules/refined4s-cats/shared/src/test/scala/refined4s/modules/cats/derivation/types/allSpec.scala
+++ b/modules/refined4s-cats/shared/src/test/scala/refined4s/modules/cats/derivation/types/allSpec.scala
@@ -31,7 +31,7 @@ object allSpec extends Properties {
       uuidSpec.tests ++
       uriSpec.tests ++
       urlSpec.tests ++
-      portNumberSpec.tests ++ systemPortNumberSpec.tests ++ userPortNumberSpec.tests ++ dynamicPortNumberSpec.tests ++
+      portNumberSpec.tests ++ systemPortNumberSpec.tests ++ nonSystemPortNumberSpec.tests ++ userPortNumberSpec.tests ++ dynamicPortNumberSpec.tests ++
       timeSpec.tests
 
   object negIntSpec {

--- a/modules/refined4s-chimney/shared/src/main/scala/refined4s/modules/chimney/derivation/types/network.scala
+++ b/modules/refined4s-chimney/shared/src/main/scala/refined4s/modules/chimney/derivation/types/network.scala
@@ -9,32 +9,32 @@ import refined4s.types.network.*
   */
 trait network {
 
-  inline given derivedUriToStringTransformer: Transformer[Uri, String]               = network.derivedUriToStringTransformer
-  inline given derivedStringToUriPartialTransformer: PartialTransformer[String, Uri] = network.derivedStringToUriPartialTransformer
+  given derivedUriToStringTransformer: Transformer[Uri, String]               = network.derivedUriToStringTransformer
+  given derivedStringToUriPartialTransformer: PartialTransformer[String, Uri] = network.derivedStringToUriPartialTransformer
 
-  inline given derivedUrlToStringTransformer: Transformer[Url, String]               = network.derivedUrlToStringTransformer
-  inline given derivedStringToUrlPartialTransformer: PartialTransformer[String, Url] = network.derivedStringToUrlPartialTransformer
+  given derivedUrlToStringTransformer: Transformer[Url, String]               = network.derivedUrlToStringTransformer
+  given derivedStringToUrlPartialTransformer: PartialTransformer[String, Url] = network.derivedStringToUrlPartialTransformer
 
-  inline given derivedPortNumberToIntTransformer: Transformer[PortNumber, Int]               = network.derivedPortNumberToIntTransformer
-  inline given derivedIntToPortNumberPartialTransformer: PartialTransformer[Int, PortNumber] =
+  given derivedPortNumberToIntTransformer: Transformer[PortNumber, Int]               = network.derivedPortNumberToIntTransformer
+  given derivedIntToPortNumberPartialTransformer: PartialTransformer[Int, PortNumber] =
     network.derivedIntToPortNumberPartialTransformer
 
-  inline given derivedSystemPortNumberToIntTransformer: Transformer[SystemPortNumber, Int] = network.derivedSystemPortNumberToIntTransformer
-  inline given derivedIntToSystemPortNumberPartialTransformer: PartialTransformer[Int, SystemPortNumber] =
+  given derivedSystemPortNumberToIntTransformer: Transformer[SystemPortNumber, Int] = network.derivedSystemPortNumberToIntTransformer
+  given derivedIntToSystemPortNumberPartialTransformer: PartialTransformer[Int, SystemPortNumber] =
     network.derivedIntToSystemPortNumberPartialTransformer
 
-  inline given derivedNonSystemPortNumberToIntTransformer: Transformer[NonSystemPortNumber, Int]               =
+  given derivedNonSystemPortNumberToIntTransformer: Transformer[NonSystemPortNumber, Int]               =
     network.derivedNonSystemPortNumberToIntTransformer
-  inline given derivedIntToNonSystemPortNumberPartialTransformer: PartialTransformer[Int, NonSystemPortNumber] =
+  given derivedIntToNonSystemPortNumberPartialTransformer: PartialTransformer[Int, NonSystemPortNumber] =
     network.derivedIntToNonSystemPortNumberPartialTransformer
 
-  inline given derivedUserPortNumberToIntTransformer: Transformer[UserPortNumber, Int] = network.derivedUserPortNumberToIntTransformer
-  inline given derivedIntToUserPortNumberPartialTransformer: PartialTransformer[Int, UserPortNumber] =
+  given derivedUserPortNumberToIntTransformer: Transformer[UserPortNumber, Int] = network.derivedUserPortNumberToIntTransformer
+  given derivedIntToUserPortNumberPartialTransformer: PartialTransformer[Int, UserPortNumber] =
     network.derivedIntToUserPortNumberPartialTransformer
 
-  inline given derivedDynamicPortNumberToIntTransformer: Transformer[DynamicPortNumber, Int]               =
+  given derivedDynamicPortNumberToIntTransformer: Transformer[DynamicPortNumber, Int]               =
     network.derivedDynamicPortNumberToIntTransformer
-  inline given derivedIntToDynamicPortNumberPartialTransformer: PartialTransformer[Int, DynamicPortNumber] =
+  given derivedIntToDynamicPortNumberPartialTransformer: PartialTransformer[Int, DynamicPortNumber] =
     network.derivedIntToDynamicPortNumberPartialTransformer
 
 }

--- a/modules/refined4s-chimney/shared/src/main/scala/refined4s/modules/chimney/derivation/types/numeric.scala
+++ b/modules/refined4s-chimney/shared/src/main/scala/refined4s/modules/chimney/derivation/types/numeric.scala
@@ -9,108 +9,108 @@ import refined4s.types.numeric.*
   */
 trait numeric {
 
-  inline given derivedNegIntTransformer: Transformer[NegInt, Int]               = numeric.derivedNegIntTransformer
-  inline given derivedNegIntPartialTransformer: PartialTransformer[Int, NegInt] = numeric.derivedNegIntPartialTransformer
+  given derivedNegIntTransformer: Transformer[NegInt, Int]               = numeric.derivedNegIntTransformer
+  given derivedNegIntPartialTransformer: PartialTransformer[Int, NegInt] = numeric.derivedNegIntPartialTransformer
 
-  inline given derivedNonNegIntTransformer: Transformer[NonNegInt, Int]               = numeric.derivedNonNegIntTransformer
-  inline given derivedNonNegIntPartialTransformer: PartialTransformer[Int, NonNegInt] = numeric.derivedNonNegIntPartialTransformer
+  given derivedNonNegIntTransformer: Transformer[NonNegInt, Int]               = numeric.derivedNonNegIntTransformer
+  given derivedNonNegIntPartialTransformer: PartialTransformer[Int, NonNegInt] = numeric.derivedNonNegIntPartialTransformer
 
-  inline given derivedPosIntTransformer: Transformer[PosInt, Int]               = numeric.derivedPosIntTransformer
-  inline given derivedPosIntPartialTransformer: PartialTransformer[Int, PosInt] = numeric.derivedPosIntPartialTransformer
+  given derivedPosIntTransformer: Transformer[PosInt, Int]               = numeric.derivedPosIntTransformer
+  given derivedPosIntPartialTransformer: PartialTransformer[Int, PosInt] = numeric.derivedPosIntPartialTransformer
 
-  inline given derivedNonPosIntTransformer: Transformer[NonPosInt, Int]               = numeric.derivedNonPosIntTransformer
-  inline given derivedNonPosIntPartialTransformer: PartialTransformer[Int, NonPosInt] = numeric.derivedNonPosIntPartialTransformer
+  given derivedNonPosIntTransformer: Transformer[NonPosInt, Int]               = numeric.derivedNonPosIntTransformer
+  given derivedNonPosIntPartialTransformer: PartialTransformer[Int, NonPosInt] = numeric.derivedNonPosIntPartialTransformer
 
-  inline given derivedNegLongTransformer: Transformer[NegLong, Long]               = numeric.derivedNegLongTransformer
-  inline given derivedNegLongPartialTransformer: PartialTransformer[Long, NegLong] = numeric.derivedNegLongPartialTransformer
+  given derivedNegLongTransformer: Transformer[NegLong, Long]               = numeric.derivedNegLongTransformer
+  given derivedNegLongPartialTransformer: PartialTransformer[Long, NegLong] = numeric.derivedNegLongPartialTransformer
 
-  inline given derivedNonNegLongTransformer: Transformer[NonNegLong, Long]               = numeric.derivedNonNegLongTransformer
-  inline given derivedNonNegLongPartialTransformer: PartialTransformer[Long, NonNegLong] = numeric.derivedNonNegLongPartialTransformer
+  given derivedNonNegLongTransformer: Transformer[NonNegLong, Long]               = numeric.derivedNonNegLongTransformer
+  given derivedNonNegLongPartialTransformer: PartialTransformer[Long, NonNegLong] = numeric.derivedNonNegLongPartialTransformer
 
-  inline given derivedPosLongTransformer: Transformer[PosLong, Long]               = numeric.derivedPosLongTransformer
-  inline given derivedPosLongPartialTransformer: PartialTransformer[Long, PosLong] = numeric.derivedPosLongPartialTransformer
+  given derivedPosLongTransformer: Transformer[PosLong, Long]               = numeric.derivedPosLongTransformer
+  given derivedPosLongPartialTransformer: PartialTransformer[Long, PosLong] = numeric.derivedPosLongPartialTransformer
 
-  inline given derivedNonPosLongTransformer: Transformer[NonPosLong, Long]               = numeric.derivedNonPosLongTransformer
-  inline given derivedNonPosLongPartialTransformer: PartialTransformer[Long, NonPosLong] = numeric.derivedNonPosLongPartialTransformer
+  given derivedNonPosLongTransformer: Transformer[NonPosLong, Long]               = numeric.derivedNonPosLongTransformer
+  given derivedNonPosLongPartialTransformer: PartialTransformer[Long, NonPosLong] = numeric.derivedNonPosLongPartialTransformer
 
-  inline given derivedNegShortTransformer: Transformer[NegShort, Short]               = numeric.derivedNegShortTransformer
-  inline given derivedNegShortPartialTransformer: PartialTransformer[Short, NegShort] = numeric.derivedNegShortPartialTransformer
+  given derivedNegShortTransformer: Transformer[NegShort, Short]               = numeric.derivedNegShortTransformer
+  given derivedNegShortPartialTransformer: PartialTransformer[Short, NegShort] = numeric.derivedNegShortPartialTransformer
 
-  inline given derivedNonNegShortTransformer: Transformer[NonNegShort, Short]               = numeric.derivedNonNegShortTransformer
-  inline given derivedNonNegShortPartialTransformer: PartialTransformer[Short, NonNegShort] = numeric.derivedNonNegShortPartialTransformer
+  given derivedNonNegShortTransformer: Transformer[NonNegShort, Short]               = numeric.derivedNonNegShortTransformer
+  given derivedNonNegShortPartialTransformer: PartialTransformer[Short, NonNegShort] = numeric.derivedNonNegShortPartialTransformer
 
-  inline given derivedPosShortTransformer: Transformer[PosShort, Short]               = numeric.derivedPosShortTransformer
-  inline given derivedPosShortPartialTransformer: PartialTransformer[Short, PosShort] = numeric.derivedPosShortPartialTransformer
+  given derivedPosShortTransformer: Transformer[PosShort, Short]               = numeric.derivedPosShortTransformer
+  given derivedPosShortPartialTransformer: PartialTransformer[Short, PosShort] = numeric.derivedPosShortPartialTransformer
 
-  inline given derivedNonPosShortTransformer: Transformer[NonPosShort, Short]               = numeric.derivedNonPosShortTransformer
-  inline given derivedNonPosShortPartialTransformer: PartialTransformer[Short, NonPosShort] = numeric.derivedNonPosShortPartialTransformer
+  given derivedNonPosShortTransformer: Transformer[NonPosShort, Short]               = numeric.derivedNonPosShortTransformer
+  given derivedNonPosShortPartialTransformer: PartialTransformer[Short, NonPosShort] = numeric.derivedNonPosShortPartialTransformer
 
-  inline given derivedNegByteTransformer: Transformer[NegByte, Byte]               = numeric.derivedNegByteTransformer
-  inline given derivedNegBytePartialTransformer: PartialTransformer[Byte, NegByte] = numeric.derivedNegBytePartialTransformer
+  given derivedNegByteTransformer: Transformer[NegByte, Byte]               = numeric.derivedNegByteTransformer
+  given derivedNegBytePartialTransformer: PartialTransformer[Byte, NegByte] = numeric.derivedNegBytePartialTransformer
 
-  inline given derivedNonNegByteTransformer: Transformer[NonNegByte, Byte]               = numeric.derivedNonNegByteTransformer
-  inline given derivedNonNegBytePartialTransformer: PartialTransformer[Byte, NonNegByte] = numeric.derivedNonNegBytePartialTransformer
+  given derivedNonNegByteTransformer: Transformer[NonNegByte, Byte]               = numeric.derivedNonNegByteTransformer
+  given derivedNonNegBytePartialTransformer: PartialTransformer[Byte, NonNegByte] = numeric.derivedNonNegBytePartialTransformer
 
-  inline given derivedPosByteTransformer: Transformer[PosByte, Byte]               = numeric.derivedPosByteTransformer
-  inline given derivedPosBytePartialTransformer: PartialTransformer[Byte, PosByte] = numeric.derivedPosBytePartialTransformer
+  given derivedPosByteTransformer: Transformer[PosByte, Byte]               = numeric.derivedPosByteTransformer
+  given derivedPosBytePartialTransformer: PartialTransformer[Byte, PosByte] = numeric.derivedPosBytePartialTransformer
 
-  inline given derivedNonPosByteTransformer: Transformer[NonPosByte, Byte]               = numeric.derivedNonPosByteTransformer
-  inline given derivedNonPosBytePartialTransformer: PartialTransformer[Byte, NonPosByte] = numeric.derivedNonPosBytePartialTransformer
+  given derivedNonPosByteTransformer: Transformer[NonPosByte, Byte]               = numeric.derivedNonPosByteTransformer
+  given derivedNonPosBytePartialTransformer: PartialTransformer[Byte, NonPosByte] = numeric.derivedNonPosBytePartialTransformer
 
-  inline given derivedNegFloatTransformer: Transformer[NegFloat, Float]               = numeric.derivedNegFloatTransformer
-  inline given derivedNegFloatPartialTransformer: PartialTransformer[Float, NegFloat] = numeric.derivedNegFloatPartialTransformer
+  given derivedNegFloatTransformer: Transformer[NegFloat, Float]               = numeric.derivedNegFloatTransformer
+  given derivedNegFloatPartialTransformer: PartialTransformer[Float, NegFloat] = numeric.derivedNegFloatPartialTransformer
 
-  inline given derivedNonNegFloatTransformer: Transformer[NonNegFloat, Float]               = numeric.derivedNonNegFloatTransformer
-  inline given derivedNonNegFloatPartialTransformer: PartialTransformer[Float, NonNegFloat] = numeric.derivedNonNegFloatPartialTransformer
+  given derivedNonNegFloatTransformer: Transformer[NonNegFloat, Float]               = numeric.derivedNonNegFloatTransformer
+  given derivedNonNegFloatPartialTransformer: PartialTransformer[Float, NonNegFloat] = numeric.derivedNonNegFloatPartialTransformer
 
-  inline given derivedPosFloatTransformer: Transformer[PosFloat, Float]               = numeric.derivedPosFloatTransformer
-  inline given derivedPosFloatPartialTransformer: PartialTransformer[Float, PosFloat] = numeric.derivedPosFloatPartialTransformer
+  given derivedPosFloatTransformer: Transformer[PosFloat, Float]               = numeric.derivedPosFloatTransformer
+  given derivedPosFloatPartialTransformer: PartialTransformer[Float, PosFloat] = numeric.derivedPosFloatPartialTransformer
 
-  inline given derivedNonPosFloatTransformer: Transformer[NonPosFloat, Float]               = numeric.derivedNonPosFloatTransformer
-  inline given derivedNonPosFloatPartialTransformer: PartialTransformer[Float, NonPosFloat] = numeric.derivedNonPosFloatPartialTransformer
+  given derivedNonPosFloatTransformer: Transformer[NonPosFloat, Float]               = numeric.derivedNonPosFloatTransformer
+  given derivedNonPosFloatPartialTransformer: PartialTransformer[Float, NonPosFloat] = numeric.derivedNonPosFloatPartialTransformer
 
-  inline given derivedNegDoubleTransformer: Transformer[NegDouble, Double]               = numeric.derivedNegDoubleTransformer
-  inline given derivedNegDoublePartialTransformer: PartialTransformer[Double, NegDouble] = numeric.derivedNegDoublePartialTransformer
+  given derivedNegDoubleTransformer: Transformer[NegDouble, Double]               = numeric.derivedNegDoubleTransformer
+  given derivedNegDoublePartialTransformer: PartialTransformer[Double, NegDouble] = numeric.derivedNegDoublePartialTransformer
 
-  inline given derivedNonNegDoubleTransformer: Transformer[NonNegDouble, Double]               = numeric.derivedNonNegDoubleTransformer
-  inline given derivedNonNegDoublePartialTransformer: PartialTransformer[Double, NonNegDouble] =
+  given derivedNonNegDoubleTransformer: Transformer[NonNegDouble, Double]               = numeric.derivedNonNegDoubleTransformer
+  given derivedNonNegDoublePartialTransformer: PartialTransformer[Double, NonNegDouble] =
     numeric.derivedNonNegDoublePartialTransformer
 
-  inline given derivedPosDoubleTransformer: Transformer[PosDouble, Double]               = numeric.derivedPosDoubleTransformer
-  inline given derivedPosDoublePartialTransformer: PartialTransformer[Double, PosDouble] = numeric.derivedPosDoublePartialTransformer
+  given derivedPosDoubleTransformer: Transformer[PosDouble, Double]               = numeric.derivedPosDoubleTransformer
+  given derivedPosDoublePartialTransformer: PartialTransformer[Double, PosDouble] = numeric.derivedPosDoublePartialTransformer
 
-  inline given derivedNonPosDoubleTransformer: Transformer[NonPosDouble, Double]               = numeric.derivedNonPosDoubleTransformer
-  inline given derivedNonPosDoublePartialTransformer: PartialTransformer[Double, NonPosDouble] =
+  given derivedNonPosDoubleTransformer: Transformer[NonPosDouble, Double]               = numeric.derivedNonPosDoubleTransformer
+  given derivedNonPosDoublePartialTransformer: PartialTransformer[Double, NonPosDouble] =
     numeric.derivedNonPosDoublePartialTransformer
 
-  inline given derivedNegBigIntTransformer: Transformer[NegBigInt, BigInt]               = numeric.derivedNegBigIntTransformer
-  inline given derivedNegBigIntPartialTransformer: PartialTransformer[BigInt, NegBigInt] = numeric.derivedNegBigIntPartialTransformer
+  given derivedNegBigIntTransformer: Transformer[NegBigInt, BigInt]               = numeric.derivedNegBigIntTransformer
+  given derivedNegBigIntPartialTransformer: PartialTransformer[BigInt, NegBigInt] = numeric.derivedNegBigIntPartialTransformer
 
-  inline given derivedNonNegBigIntTransformer: Transformer[NonNegBigInt, BigInt]               = numeric.derivedNonNegBigIntTransformer
-  inline given derivedNonNegBigIntPartialTransformer: PartialTransformer[BigInt, NonNegBigInt] =
+  given derivedNonNegBigIntTransformer: Transformer[NonNegBigInt, BigInt]               = numeric.derivedNonNegBigIntTransformer
+  given derivedNonNegBigIntPartialTransformer: PartialTransformer[BigInt, NonNegBigInt] =
     numeric.derivedNonNegBigIntPartialTransformer
 
-  inline given derivedPosBigIntTransformer: Transformer[PosBigInt, BigInt]               = numeric.derivedPosBigIntTransformer
-  inline given derivedPosBigIntPartialTransformer: PartialTransformer[BigInt, PosBigInt] = numeric.derivedPosBigIntPartialTransformer
+  given derivedPosBigIntTransformer: Transformer[PosBigInt, BigInt]               = numeric.derivedPosBigIntTransformer
+  given derivedPosBigIntPartialTransformer: PartialTransformer[BigInt, PosBigInt] = numeric.derivedPosBigIntPartialTransformer
 
-  inline given derivedNonPosBigIntTransformer: Transformer[NonPosBigInt, BigInt]               = numeric.derivedNonPosBigIntTransformer
-  inline given derivedNonPosBigIntPartialTransformer: PartialTransformer[BigInt, NonPosBigInt] =
+  given derivedNonPosBigIntTransformer: Transformer[NonPosBigInt, BigInt]               = numeric.derivedNonPosBigIntTransformer
+  given derivedNonPosBigIntPartialTransformer: PartialTransformer[BigInt, NonPosBigInt] =
     numeric.derivedNonPosBigIntPartialTransformer
 
-  inline given derivedNegBigDecimalTransformer: Transformer[NegBigDecimal, BigDecimal] = numeric.derivedNegBigDecimalTransformer
-  inline given derivedNegBigDecimalPartialTransformer: PartialTransformer[BigDecimal, NegBigDecimal] =
+  given derivedNegBigDecimalTransformer: Transformer[NegBigDecimal, BigDecimal]               = numeric.derivedNegBigDecimalTransformer
+  given derivedNegBigDecimalPartialTransformer: PartialTransformer[BigDecimal, NegBigDecimal] =
     numeric.derivedNegBigDecimalPartialTransformer
 
-  inline given derivedNonNegBigDecimalTransformer: Transformer[NonNegBigDecimal, BigDecimal] = numeric.derivedNonNegBigDecimalTransformer
-  inline given derivedNonNegBigDecimalPartialTransformer: PartialTransformer[BigDecimal, NonNegBigDecimal] =
+  given derivedNonNegBigDecimalTransformer: Transformer[NonNegBigDecimal, BigDecimal] = numeric.derivedNonNegBigDecimalTransformer
+  given derivedNonNegBigDecimalPartialTransformer: PartialTransformer[BigDecimal, NonNegBigDecimal] =
     numeric.derivedNonNegBigDecimalPartialTransformer
 
-  inline given derivedPosBigDecimalTransformer: Transformer[PosBigDecimal, BigDecimal] = numeric.derivedPosBigDecimalTransformer
-  inline given derivedPosBigDecimalPartialTransformer: PartialTransformer[BigDecimal, PosBigDecimal] =
+  given derivedPosBigDecimalTransformer: Transformer[PosBigDecimal, BigDecimal]               = numeric.derivedPosBigDecimalTransformer
+  given derivedPosBigDecimalPartialTransformer: PartialTransformer[BigDecimal, PosBigDecimal] =
     numeric.derivedPosBigDecimalPartialTransformer
 
-  inline given derivedNonPosBigDecimalTransformer: Transformer[NonPosBigDecimal, BigDecimal] = numeric.derivedNonPosBigDecimalTransformer
-  inline given derivedNonPosBigDecimalPartialTransformer: PartialTransformer[BigDecimal, NonPosBigDecimal] =
+  given derivedNonPosBigDecimalTransformer: Transformer[NonPosBigDecimal, BigDecimal] = numeric.derivedNonPosBigDecimalTransformer
+  given derivedNonPosBigDecimalPartialTransformer: PartialTransformer[BigDecimal, NonPosBigDecimal] =
     numeric.derivedNonPosBigDecimalPartialTransformer
 
 }

--- a/modules/refined4s-chimney/shared/src/main/scala/refined4s/modules/chimney/derivation/types/strings.scala
+++ b/modules/refined4s-chimney/shared/src/main/scala/refined4s/modules/chimney/derivation/types/strings.scala
@@ -10,23 +10,23 @@ import refined4s.types.strings.*
 trait strings {
 
   /* NonEmptyString */
-  inline given derivedNonEmptyStringToStringTransformer: Transformer[NonEmptyString, String] =
+  given derivedNonEmptyStringToStringTransformer: Transformer[NonEmptyString, String] =
     strings.derivedNonEmptyStringToStringTransformer
 
-  inline given derivedStringToNonEmptyStringPartialTransformer: PartialTransformer[String, NonEmptyString] =
+  given derivedStringToNonEmptyStringPartialTransformer: PartialTransformer[String, NonEmptyString] =
     strings.derivedStringToNonEmptyStringPartialTransformer
 
   /* NonBlankString */
-  inline given derivedNonBlankStringToStringTransformer: Transformer[NonBlankString, String] =
+  given derivedNonBlankStringToStringTransformer: Transformer[NonBlankString, String] =
     strings.derivedNonBlankStringToStringTransformer
 
-  inline given derivedStringToNonBlankStringPartialTransformer: PartialTransformer[String, NonBlankString] =
+  given derivedStringToNonBlankStringPartialTransformer: PartialTransformer[String, NonBlankString] =
     strings.derivedStringToNonBlankStringPartialTransformer
 
   /* Uuid */
-  inline given derivedUuidToStringTransformer: Transformer[Uuid, String] = strings.derivedUuidToStringTransformer
+  given derivedUuidToStringTransformer: Transformer[Uuid, String] = strings.derivedUuidToStringTransformer
 
-  inline given derivedStringToUuidPartialTransformer: PartialTransformer[String, Uuid] = strings.derivedStringToUuidPartialTransformer
+  given derivedStringToUuidPartialTransformer: PartialTransformer[String, Uuid] = strings.derivedStringToUuidPartialTransformer
 
 }
 object strings {

--- a/modules/refined4s-chimney/shared/src/main/scala/refined4s/modules/chimney/derivation/types/time.scala
+++ b/modules/refined4s-chimney/shared/src/main/scala/refined4s/modules/chimney/derivation/types/time.scala
@@ -9,23 +9,23 @@ import refined4s.types.time.*
   * @since 2025-09-01
   */
 trait time {
-  inline given derivedMonthToIntTransformer: Transformer[Month, Int]               = time.derivedMonthToIntTransformer
-  inline given derivedIntToMonthPartialTransformer: PartialTransformer[Int, Month] = time.derivedIntToMonthPartialTransformer
+  given derivedMonthToIntTransformer: Transformer[Month, Int]               = time.derivedMonthToIntTransformer
+  given derivedIntToMonthPartialTransformer: PartialTransformer[Int, Month] = time.derivedIntToMonthPartialTransformer
 
-  inline given derivedDayToIntTransformer: Transformer[Day, Int]               = time.derivedDayToIntTransformer
-  inline given derivedIntToDayPartialTransformer: PartialTransformer[Int, Day] = time.derivedIntToDayPartialTransformer
+  given derivedDayToIntTransformer: Transformer[Day, Int]               = time.derivedDayToIntTransformer
+  given derivedIntToDayPartialTransformer: PartialTransformer[Int, Day] = time.derivedIntToDayPartialTransformer
 
-  inline given derivedHourToIntTransformer: Transformer[Hour, Int]               = time.derivedHourToIntTransformer
-  inline given derivedIntToHourPartialTransformer: PartialTransformer[Int, Hour] = time.derivedIntToHourPartialTransformer
+  given derivedHourToIntTransformer: Transformer[Hour, Int]               = time.derivedHourToIntTransformer
+  given derivedIntToHourPartialTransformer: PartialTransformer[Int, Hour] = time.derivedIntToHourPartialTransformer
 
-  inline given derivedMinuteToIntTransformer: Transformer[Minute, Int]               = time.derivedMinuteToIntTransformer
-  inline given derivedIntToMinutePartialTransformer: PartialTransformer[Int, Minute] = time.derivedIntToMinutePartialTransformer
+  given derivedMinuteToIntTransformer: Transformer[Minute, Int]               = time.derivedMinuteToIntTransformer
+  given derivedIntToMinutePartialTransformer: PartialTransformer[Int, Minute] = time.derivedIntToMinutePartialTransformer
 
-  inline given derivedSecondToIntTransformer: Transformer[Second, Int]               = time.derivedSecondToIntTransformer
-  inline given derivedIntToSecondPartialTransformer: PartialTransformer[Int, Second] = time.derivedIntToSecondPartialTransformer
+  given derivedSecondToIntTransformer: Transformer[Second, Int]               = time.derivedSecondToIntTransformer
+  given derivedIntToSecondPartialTransformer: PartialTransformer[Int, Second] = time.derivedIntToSecondPartialTransformer
 
-  inline given derivedMillisToIntTransformer: Transformer[Millis, Int]               = time.derivedMillisToIntTransformer
-  inline given derivedIntToMillisPartialTransformer: PartialTransformer[Int, Millis] = time.derivedIntToMillisPartialTransformer
+  given derivedMillisToIntTransformer: Transformer[Millis, Int]               = time.derivedMillisToIntTransformer
+  given derivedIntToMillisPartialTransformer: PartialTransformer[Int, Millis] = time.derivedIntToMillisPartialTransformer
 
 }
 object time {

--- a/modules/refined4s-circe/shared/src/main/scala/refined4s/modules/circe/derivation/generic/auto.scala
+++ b/modules/refined4s-circe/shared/src/main/scala/refined4s/modules/circe/derivation/generic/auto.scala
@@ -9,22 +9,22 @@ import refined4s.{Coercible, RefinedCtor}
   */
 trait auto {
 
-  inline given derivedEncoder[A, B](using coercible: Coercible[A, B], encoder: Encoder[B]): Encoder[A] =
+  given derivedEncoder[A, B](using coercible: Coercible[A, B], encoder: Encoder[B]): Encoder[A] =
     contraCoercible(encoder)
 
-  inline given derivedNewtypeDecoder[A, B](using coercible: Coercible[A, B], decoder: Decoder[A]): Decoder[B] =
+  given derivedNewtypeDecoder[A, B](using coercible: Coercible[A, B], decoder: Decoder[A]): Decoder[B] =
     Coercible.unsafeWrapTC(decoder)
 
-  inline given derivedRefinedDecoder[A, B](using refinedCtor: RefinedCtor[B, A], decoder: Decoder[A]): Decoder[B] =
+  given derivedRefinedDecoder[A, B](using refinedCtor: RefinedCtor[B, A], decoder: Decoder[A]): Decoder[B] =
     decoder.emap(refinedCtor.create)
 
-  inline given derivedKeyEncoder[A, B](using coercible: Coercible[A, B], encoder: KeyEncoder[B]): KeyEncoder[A] =
+  given derivedKeyEncoder[A, B](using coercible: Coercible[A, B], encoder: KeyEncoder[B]): KeyEncoder[A] =
     contraCoercible(encoder)
 
-  inline given derivedNewtypeKeyDecoder[A, B](using coercible: Coercible[A, B], decoder: KeyDecoder[A]): KeyDecoder[B] =
+  given derivedNewtypeKeyDecoder[A, B](using coercible: Coercible[A, B], decoder: KeyDecoder[A]): KeyDecoder[B] =
     Coercible.unsafeWrapTC(decoder)
 
-  inline given derivedRefinedKeyDecoder[A, B](using refinedCtor: RefinedCtor[B, A], decoder: KeyDecoder[A]): KeyDecoder[B] with {
+  given derivedRefinedKeyDecoder[A, B](using refinedCtor: RefinedCtor[B, A], decoder: KeyDecoder[A]): KeyDecoder[B] with {
     override def apply(key: String): Option[B] =
       decoder.apply(key).flatMap(refinedCtor.create(_).toOption)
   }
@@ -44,7 +44,7 @@ trait auto {
     *   // The KeyDecoder is fine here, but the value Decoder `decode` uses is not Decoder[Int] but Decoder[PortNumber].
     * }}}
     */
-  inline given derivedMapDecoder[A, B](using KeyDecoder[A], Decoder[B]): Decoder[Map[A, B]] = io.circe.Decoder.decodeMap
+  given derivedMapDecoder[A, B](using KeyDecoder[A], Decoder[B]): Decoder[Map[A, B]] = io.circe.Decoder.decodeMap
 
 }
 object auto extends auto

--- a/modules/refined4s-circe/shared/src/main/scala/refined4s/modules/circe/derivation/types/network.scala
+++ b/modules/refined4s-circe/shared/src/main/scala/refined4s/modules/circe/derivation/types/network.scala
@@ -10,53 +10,53 @@ import refined4s.types.all.*
 trait network {
 
   /* Uri */
-  inline given derivedUriEncoder: Encoder[Uri] = network.derivedUriEncoder
-  inline given derivedUriDecoder: Decoder[Uri] = network.derivedUriDecoder
+  given derivedUriEncoder: Encoder[Uri] = network.derivedUriEncoder
+  given derivedUriDecoder: Decoder[Uri] = network.derivedUriDecoder
 
-  inline given derivedUriKeyEncoder: KeyEncoder[Uri] = network.derivedUriKeyEncoder
-  inline given derivedUriKeyDecoder: KeyDecoder[Uri] = network.derivedUriKeyDecoder
+  given derivedUriKeyEncoder: KeyEncoder[Uri] = network.derivedUriKeyEncoder
+  given derivedUriKeyDecoder: KeyDecoder[Uri] = network.derivedUriKeyDecoder
 
   /* Url */
-  inline given derivedUrlEncoder: Encoder[Url] = network.derivedUrlEncoder
-  inline given derivedUrlDecoder: Decoder[Url] = network.derivedUrlDecoder
+  given derivedUrlEncoder: Encoder[Url] = network.derivedUrlEncoder
+  given derivedUrlDecoder: Decoder[Url] = network.derivedUrlDecoder
 
-  inline given derivedUrlKeyEncoder: KeyEncoder[Url] = network.derivedUrlKeyEncoder
-  inline given derivedUrlKeyDecoder: KeyDecoder[Url] = network.derivedUrlKeyDecoder
+  given derivedUrlKeyEncoder: KeyEncoder[Url] = network.derivedUrlKeyEncoder
+  given derivedUrlKeyDecoder: KeyDecoder[Url] = network.derivedUrlKeyDecoder
 
   /* PortNumber */
-  inline given derivedPortNumberEncoder: Encoder[PortNumber] = network.derivedPortNumberEncoder
-  inline given derivedPortNumberDecoder: Decoder[PortNumber] = network.derivedPortNumberDecoder
+  given derivedPortNumberEncoder: Encoder[PortNumber] = network.derivedPortNumberEncoder
+  given derivedPortNumberDecoder: Decoder[PortNumber] = network.derivedPortNumberDecoder
 
-  inline given derivedPortNumberKeyEncoder: KeyEncoder[PortNumber] = network.derivedPortNumberKeyEncoder
-  inline given derivedPortNumberKeyDecoder: KeyDecoder[PortNumber] = network.derivedPortNumberKeyDecoder
+  given derivedPortNumberKeyEncoder: KeyEncoder[PortNumber] = network.derivedPortNumberKeyEncoder
+  given derivedPortNumberKeyDecoder: KeyDecoder[PortNumber] = network.derivedPortNumberKeyDecoder
 
   /* SystemPortNumber */
-  inline given derivedSystemPortNumberEncoder: Encoder[SystemPortNumber] = network.derivedSystemPortNumberEncoder
-  inline given derivedSystemPortNumberDecoder: Decoder[SystemPortNumber] = network.derivedSystemPortNumberDecoder
+  given derivedSystemPortNumberEncoder: Encoder[SystemPortNumber] = network.derivedSystemPortNumberEncoder
+  given derivedSystemPortNumberDecoder: Decoder[SystemPortNumber] = network.derivedSystemPortNumberDecoder
 
-  inline given derivedSystemPortNumberKeyEncoder: KeyEncoder[SystemPortNumber] = network.derivedSystemPortNumberKeyEncoder
-  inline given derivedSystemPortNumberKeyDecoder: KeyDecoder[SystemPortNumber] = network.derivedSystemPortNumberKeyDecoder
+  given derivedSystemPortNumberKeyEncoder: KeyEncoder[SystemPortNumber] = network.derivedSystemPortNumberKeyEncoder
+  given derivedSystemPortNumberKeyDecoder: KeyDecoder[SystemPortNumber] = network.derivedSystemPortNumberKeyDecoder
 
   /* NonSystemPortNumber */
-  inline given derivedNonSystemPortNumberEncoder: Encoder[NonSystemPortNumber] = network.derivedNonSystemPortNumberEncoder
-  inline given derivedNonSystemPortNumberDecoder: Decoder[NonSystemPortNumber] = network.derivedNonSystemPortNumberDecoder
+  given derivedNonSystemPortNumberEncoder: Encoder[NonSystemPortNumber] = network.derivedNonSystemPortNumberEncoder
+  given derivedNonSystemPortNumberDecoder: Decoder[NonSystemPortNumber] = network.derivedNonSystemPortNumberDecoder
 
-  inline given derivedNonSystemPortNumberKeyEncoder: KeyEncoder[NonSystemPortNumber] = network.derivedNonSystemPortNumberKeyEncoder
-  inline given derivedNonSystemPortNumberKeyDecoder: KeyDecoder[NonSystemPortNumber] = network.derivedNonSystemPortNumberKeyDecoder
+  given derivedNonSystemPortNumberKeyEncoder: KeyEncoder[NonSystemPortNumber] = network.derivedNonSystemPortNumberKeyEncoder
+  given derivedNonSystemPortNumberKeyDecoder: KeyDecoder[NonSystemPortNumber] = network.derivedNonSystemPortNumberKeyDecoder
 
   /* UserPortNumber */
-  inline given derivedUserPortNumberEncoder: Encoder[UserPortNumber] = network.derivedUserPortNumberEncoder
-  inline given derivedUserPortNumberDecoder: Decoder[UserPortNumber] = network.derivedUserPortNumberDecoder
+  given derivedUserPortNumberEncoder: Encoder[UserPortNumber] = network.derivedUserPortNumberEncoder
+  given derivedUserPortNumberDecoder: Decoder[UserPortNumber] = network.derivedUserPortNumberDecoder
 
-  inline given derivedUserPortNumberKeyEncoder: KeyEncoder[UserPortNumber] = network.derivedUserPortNumberKeyEncoder
-  inline given derivedUserPortNumberKeyDecoder: KeyDecoder[UserPortNumber] = network.derivedUserPortNumberKeyDecoder
+  given derivedUserPortNumberKeyEncoder: KeyEncoder[UserPortNumber] = network.derivedUserPortNumberKeyEncoder
+  given derivedUserPortNumberKeyDecoder: KeyDecoder[UserPortNumber] = network.derivedUserPortNumberKeyDecoder
 
   /* DynamicPortNumber */
-  inline given derivedDynamicPortNumberEncoder: Encoder[DynamicPortNumber] = network.derivedDynamicPortNumberEncoder
-  inline given derivedDynamicPortNumberDecoder: Decoder[DynamicPortNumber] = network.derivedDynamicPortNumberDecoder
+  given derivedDynamicPortNumberEncoder: Encoder[DynamicPortNumber] = network.derivedDynamicPortNumberEncoder
+  given derivedDynamicPortNumberDecoder: Decoder[DynamicPortNumber] = network.derivedDynamicPortNumberDecoder
 
-  inline given derivedDynamicPortNumberKeyEncoder: KeyEncoder[DynamicPortNumber] = network.derivedDynamicPortNumberKeyEncoder
-  inline given derivedDynamicPortNumberKeyDecoder: KeyDecoder[DynamicPortNumber] = network.derivedDynamicPortNumberKeyDecoder
+  given derivedDynamicPortNumberKeyEncoder: KeyEncoder[DynamicPortNumber] = network.derivedDynamicPortNumberKeyEncoder
+  given derivedDynamicPortNumberKeyDecoder: KeyDecoder[DynamicPortNumber] = network.derivedDynamicPortNumberKeyDecoder
 
 }
 object network {

--- a/modules/refined4s-circe/shared/src/main/scala/refined4s/modules/circe/derivation/types/numeric.scala
+++ b/modules/refined4s-circe/shared/src/main/scala/refined4s/modules/circe/derivation/types/numeric.scala
@@ -10,192 +10,192 @@ import refined4s.types.all.*
 trait numeric {
 
   /* NegInt */
-  inline given derivedNegIntEncoder: Encoder[NegInt] = numeric.derivedNegIntEncoder
-  inline given derivedNegIntDecoder: Decoder[NegInt] = numeric.derivedNegIntDecoder
+  given derivedNegIntEncoder: Encoder[NegInt] = numeric.derivedNegIntEncoder
+  given derivedNegIntDecoder: Decoder[NegInt] = numeric.derivedNegIntDecoder
 
-  inline given derivedNegIntKeyEncoder: KeyEncoder[NegInt] = numeric.derivedNegIntKeyEncoder
-  inline given derivedNegIntKeyDecoder: KeyDecoder[NegInt] = numeric.derivedNegIntKeyDecoder
+  given derivedNegIntKeyEncoder: KeyEncoder[NegInt] = numeric.derivedNegIntKeyEncoder
+  given derivedNegIntKeyDecoder: KeyDecoder[NegInt] = numeric.derivedNegIntKeyDecoder
 
   /* NonNegInt */
-  inline given derivedNonNegIntEncoder: Encoder[NonNegInt] = numeric.derivedNonNegIntEncoder
-  inline given derivedNonNegIntDecoder: Decoder[NonNegInt] = numeric.derivedNonNegIntDecoder
+  given derivedNonNegIntEncoder: Encoder[NonNegInt] = numeric.derivedNonNegIntEncoder
+  given derivedNonNegIntDecoder: Decoder[NonNegInt] = numeric.derivedNonNegIntDecoder
 
-  inline given derivedNonNegIntKeyEncoder: KeyEncoder[NonNegInt] = numeric.derivedNonNegIntKeyEncoder
-  inline given derivedNonNegIntKeyDecoder: KeyDecoder[NonNegInt] = numeric.derivedNonNegIntKeyDecoder
+  given derivedNonNegIntKeyEncoder: KeyEncoder[NonNegInt] = numeric.derivedNonNegIntKeyEncoder
+  given derivedNonNegIntKeyDecoder: KeyDecoder[NonNegInt] = numeric.derivedNonNegIntKeyDecoder
 
   /* PosInt */
-  inline given derivedPosIntEncoder: Encoder[PosInt] = numeric.derivedPosIntEncoder
-  inline given derivedPosIntDecoder: Decoder[PosInt] = numeric.derivedPosIntDecoder
+  given derivedPosIntEncoder: Encoder[PosInt] = numeric.derivedPosIntEncoder
+  given derivedPosIntDecoder: Decoder[PosInt] = numeric.derivedPosIntDecoder
 
-  inline given derivedPosIntKeyEncoder: KeyEncoder[PosInt] = numeric.derivedPosIntKeyEncoder
-  inline given derivedPosIntKeyDecoder: KeyDecoder[PosInt] = numeric.derivedPosIntKeyDecoder
+  given derivedPosIntKeyEncoder: KeyEncoder[PosInt] = numeric.derivedPosIntKeyEncoder
+  given derivedPosIntKeyDecoder: KeyDecoder[PosInt] = numeric.derivedPosIntKeyDecoder
 
   /* NonPosInt */
-  inline given derivedNonPosIntEncoder: Encoder[NonPosInt] = numeric.derivedNonPosIntEncoder
-  inline given derivedNonPosIntDecoder: Decoder[NonPosInt] = numeric.derivedNonPosIntDecoder
+  given derivedNonPosIntEncoder: Encoder[NonPosInt] = numeric.derivedNonPosIntEncoder
+  given derivedNonPosIntDecoder: Decoder[NonPosInt] = numeric.derivedNonPosIntDecoder
 
-  inline given derivedNonPosIntKeyEncoder: KeyEncoder[NonPosInt] = numeric.derivedNonPosIntKeyEncoder
-  inline given derivedNonPosIntKeyDecoder: KeyDecoder[NonPosInt] = numeric.derivedNonPosIntKeyDecoder
+  given derivedNonPosIntKeyEncoder: KeyEncoder[NonPosInt] = numeric.derivedNonPosIntKeyEncoder
+  given derivedNonPosIntKeyDecoder: KeyDecoder[NonPosInt] = numeric.derivedNonPosIntKeyDecoder
 
   /* NegLong */
-  inline given derivedNegLongEncoder: Encoder[NegLong] = numeric.derivedNegLongEncoder
-  inline given derivedNegLongDecoder: Decoder[NegLong] = numeric.derivedNegLongDecoder
+  given derivedNegLongEncoder: Encoder[NegLong] = numeric.derivedNegLongEncoder
+  given derivedNegLongDecoder: Decoder[NegLong] = numeric.derivedNegLongDecoder
 
-  inline given derivedNegLongKeyEncoder: KeyEncoder[NegLong] = numeric.derivedNegLongKeyEncoder
-  inline given derivedNegLongKeyDecoder: KeyDecoder[NegLong] = numeric.derivedNegLongKeyDecoder
+  given derivedNegLongKeyEncoder: KeyEncoder[NegLong] = numeric.derivedNegLongKeyEncoder
+  given derivedNegLongKeyDecoder: KeyDecoder[NegLong] = numeric.derivedNegLongKeyDecoder
 
   /* NonNegLong */
-  inline given derivedNonNegLongEncoder: Encoder[NonNegLong] = numeric.derivedNonNegLongEncoder
-  inline given derivedNonNegLongDecoder: Decoder[NonNegLong] = numeric.derivedNonNegLongDecoder
+  given derivedNonNegLongEncoder: Encoder[NonNegLong] = numeric.derivedNonNegLongEncoder
+  given derivedNonNegLongDecoder: Decoder[NonNegLong] = numeric.derivedNonNegLongDecoder
 
-  inline given derivedNonNegLongKeyEncoder: KeyEncoder[NonNegLong] = numeric.derivedNonNegLongKeyEncoder
-  inline given derivedNonNegLongKeyDecoder: KeyDecoder[NonNegLong] = numeric.derivedNonNegLongKeyDecoder
+  given derivedNonNegLongKeyEncoder: KeyEncoder[NonNegLong] = numeric.derivedNonNegLongKeyEncoder
+  given derivedNonNegLongKeyDecoder: KeyDecoder[NonNegLong] = numeric.derivedNonNegLongKeyDecoder
 
   /* PosLong */
-  inline given derivedPosLongEncoder: Encoder[PosLong] = numeric.derivedPosLongEncoder
-  inline given derivedPosLongDecoder: Decoder[PosLong] = numeric.derivedPosLongDecoder
+  given derivedPosLongEncoder: Encoder[PosLong] = numeric.derivedPosLongEncoder
+  given derivedPosLongDecoder: Decoder[PosLong] = numeric.derivedPosLongDecoder
 
-  inline given derivedPosLongKeyEncoder: KeyEncoder[PosLong] = numeric.derivedPosLongKeyEncoder
-  inline given derivedPosLongKeyDecoder: KeyDecoder[PosLong] = numeric.derivedPosLongKeyDecoder
+  given derivedPosLongKeyEncoder: KeyEncoder[PosLong] = numeric.derivedPosLongKeyEncoder
+  given derivedPosLongKeyDecoder: KeyDecoder[PosLong] = numeric.derivedPosLongKeyDecoder
 
   /* NonPosLong */
-  inline given derivedNonPosLongEncoder: Encoder[NonPosLong] = numeric.derivedNonPosLongEncoder
-  inline given derivedNonPosLongDecoder: Decoder[NonPosLong] = numeric.derivedNonPosLongDecoder
+  given derivedNonPosLongEncoder: Encoder[NonPosLong] = numeric.derivedNonPosLongEncoder
+  given derivedNonPosLongDecoder: Decoder[NonPosLong] = numeric.derivedNonPosLongDecoder
 
-  inline given derivedNonPosLongKeyEncoder: KeyEncoder[NonPosLong] = numeric.derivedNonPosLongKeyEncoder
-  inline given derivedNonPosLongKeyDecoder: KeyDecoder[NonPosLong] = numeric.derivedNonPosLongKeyDecoder
+  given derivedNonPosLongKeyEncoder: KeyEncoder[NonPosLong] = numeric.derivedNonPosLongKeyEncoder
+  given derivedNonPosLongKeyDecoder: KeyDecoder[NonPosLong] = numeric.derivedNonPosLongKeyDecoder
 
   /* NegShort */
-  inline given derivedNegShortEncoder: Encoder[NegShort] = numeric.derivedNegShortEncoder
-  inline given derivedNegShortDecoder: Decoder[NegShort] = numeric.derivedNegShortDecoder
+  given derivedNegShortEncoder: Encoder[NegShort] = numeric.derivedNegShortEncoder
+  given derivedNegShortDecoder: Decoder[NegShort] = numeric.derivedNegShortDecoder
 
-  inline given derivedNegShortKeyEncoder: KeyEncoder[NegShort] = numeric.derivedNegShortKeyEncoder
-  inline given derivedNegShortKeyDecoder: KeyDecoder[NegShort] = numeric.derivedNegShortKeyDecoder
+  given derivedNegShortKeyEncoder: KeyEncoder[NegShort] = numeric.derivedNegShortKeyEncoder
+  given derivedNegShortKeyDecoder: KeyDecoder[NegShort] = numeric.derivedNegShortKeyDecoder
 
   /* NonNegShort */
-  inline given derivedNonNegShortEncoder: Encoder[NonNegShort] = numeric.derivedNonNegShortEncoder
-  inline given derivedNonNegShortDecoder: Decoder[NonNegShort] = numeric.derivedNonNegShortDecoder
+  given derivedNonNegShortEncoder: Encoder[NonNegShort] = numeric.derivedNonNegShortEncoder
+  given derivedNonNegShortDecoder: Decoder[NonNegShort] = numeric.derivedNonNegShortDecoder
 
-  inline given derivedNonNegShortKeyEncoder: KeyEncoder[NonNegShort] = numeric.derivedNonNegShortKeyEncoder
-  inline given derivedNonNegShortKeyDecoder: KeyDecoder[NonNegShort] = numeric.derivedNonNegShortKeyDecoder
+  given derivedNonNegShortKeyEncoder: KeyEncoder[NonNegShort] = numeric.derivedNonNegShortKeyEncoder
+  given derivedNonNegShortKeyDecoder: KeyDecoder[NonNegShort] = numeric.derivedNonNegShortKeyDecoder
 
   /* PosShort */
-  inline given derivedPosShortEncoder: Encoder[PosShort] = numeric.derivedPosShortEncoder
-  inline given derivedPosShortDecoder: Decoder[PosShort] = numeric.derivedPosShortDecoder
+  given derivedPosShortEncoder: Encoder[PosShort] = numeric.derivedPosShortEncoder
+  given derivedPosShortDecoder: Decoder[PosShort] = numeric.derivedPosShortDecoder
 
-  inline given derivedPosShortKeyEncoder: KeyEncoder[PosShort] = numeric.derivedPosShortKeyEncoder
-  inline given derivedPosShortKeyDecoder: KeyDecoder[PosShort] = numeric.derivedPosShortKeyDecoder
+  given derivedPosShortKeyEncoder: KeyEncoder[PosShort] = numeric.derivedPosShortKeyEncoder
+  given derivedPosShortKeyDecoder: KeyDecoder[PosShort] = numeric.derivedPosShortKeyDecoder
 
   /* NonPosShort */
-  inline given derivedNonPosShortEncoder: Encoder[NonPosShort] = numeric.derivedNonPosShortEncoder
-  inline given derivedNonPosShortDecoder: Decoder[NonPosShort] = numeric.derivedNonPosShortDecoder
+  given derivedNonPosShortEncoder: Encoder[NonPosShort] = numeric.derivedNonPosShortEncoder
+  given derivedNonPosShortDecoder: Decoder[NonPosShort] = numeric.derivedNonPosShortDecoder
 
-  inline given derivedNonPosShortKeyEncoder: KeyEncoder[NonPosShort] = numeric.derivedNonPosShortKeyEncoder
-  inline given derivedNonPosShortKeyDecoder: KeyDecoder[NonPosShort] = numeric.derivedNonPosShortKeyDecoder
+  given derivedNonPosShortKeyEncoder: KeyEncoder[NonPosShort] = numeric.derivedNonPosShortKeyEncoder
+  given derivedNonPosShortKeyDecoder: KeyDecoder[NonPosShort] = numeric.derivedNonPosShortKeyDecoder
 
   /* NegByte */
-  inline given derivedNegByteEncoder: Encoder[NegByte] = numeric.derivedNegByteEncoder
-  inline given derivedNegByteDecoder: Decoder[NegByte] = numeric.derivedNegByteDecoder
+  given derivedNegByteEncoder: Encoder[NegByte] = numeric.derivedNegByteEncoder
+  given derivedNegByteDecoder: Decoder[NegByte] = numeric.derivedNegByteDecoder
 
-  inline given derivedNegByteKeyEncoder: KeyEncoder[NegByte] = numeric.derivedNegByteKeyEncoder
-  inline given derivedNegByteKeyDecoder: KeyDecoder[NegByte] = numeric.derivedNegByteKeyDecoder
+  given derivedNegByteKeyEncoder: KeyEncoder[NegByte] = numeric.derivedNegByteKeyEncoder
+  given derivedNegByteKeyDecoder: KeyDecoder[NegByte] = numeric.derivedNegByteKeyDecoder
 
   /* NonNegByte */
-  inline given derivedNonNegByteEncoder: Encoder[NonNegByte] = numeric.derivedNonNegByteEncoder
-  inline given derivedNonNegByteDecoder: Decoder[NonNegByte] = numeric.derivedNonNegByteDecoder
+  given derivedNonNegByteEncoder: Encoder[NonNegByte] = numeric.derivedNonNegByteEncoder
+  given derivedNonNegByteDecoder: Decoder[NonNegByte] = numeric.derivedNonNegByteDecoder
 
-  inline given derivedNonNegByteKeyEncoder: KeyEncoder[NonNegByte] = numeric.derivedNonNegByteKeyEncoder
-  inline given derivedNonNegByteKeyDecoder: KeyDecoder[NonNegByte] = numeric.derivedNonNegByteKeyDecoder
+  given derivedNonNegByteKeyEncoder: KeyEncoder[NonNegByte] = numeric.derivedNonNegByteKeyEncoder
+  given derivedNonNegByteKeyDecoder: KeyDecoder[NonNegByte] = numeric.derivedNonNegByteKeyDecoder
 
   /* PosByte */
-  inline given derivedPosByteEncoder: Encoder[PosByte] = numeric.derivedPosByteEncoder
-  inline given derivedPosByteDecoder: Decoder[PosByte] = numeric.derivedPosByteDecoder
+  given derivedPosByteEncoder: Encoder[PosByte] = numeric.derivedPosByteEncoder
+  given derivedPosByteDecoder: Decoder[PosByte] = numeric.derivedPosByteDecoder
 
-  inline given derivedPosByteKeyEncoder: KeyEncoder[PosByte] = numeric.derivedPosByteKeyEncoder
-  inline given derivedPosByteKeyDecoder: KeyDecoder[PosByte] = numeric.derivedPosByteKeyDecoder
+  given derivedPosByteKeyEncoder: KeyEncoder[PosByte] = numeric.derivedPosByteKeyEncoder
+  given derivedPosByteKeyDecoder: KeyDecoder[PosByte] = numeric.derivedPosByteKeyDecoder
 
   /* NonPosByte */
-  inline given derivedNonPosByteEncoder: Encoder[NonPosByte] = numeric.derivedNonPosByteEncoder
-  inline given derivedNonPosByteDecoder: Decoder[NonPosByte] = numeric.derivedNonPosByteDecoder
+  given derivedNonPosByteEncoder: Encoder[NonPosByte] = numeric.derivedNonPosByteEncoder
+  given derivedNonPosByteDecoder: Decoder[NonPosByte] = numeric.derivedNonPosByteDecoder
 
-  inline given derivedNonPosByteKeyEncoder: KeyEncoder[NonPosByte] = numeric.derivedNonPosByteKeyEncoder
-  inline given derivedNonPosByteKeyDecoder: KeyDecoder[NonPosByte] = numeric.derivedNonPosByteKeyDecoder
+  given derivedNonPosByteKeyEncoder: KeyEncoder[NonPosByte] = numeric.derivedNonPosByteKeyEncoder
+  given derivedNonPosByteKeyDecoder: KeyDecoder[NonPosByte] = numeric.derivedNonPosByteKeyDecoder
 
   /* NegFloat */
-  inline given derivedNegFloatEncoder: Encoder[NegFloat] = numeric.derivedNegFloatEncoder
-  inline given derivedNegFloatDecoder: Decoder[NegFloat] = numeric.derivedNegFloatDecoder
+  given derivedNegFloatEncoder: Encoder[NegFloat] = numeric.derivedNegFloatEncoder
+  given derivedNegFloatDecoder: Decoder[NegFloat] = numeric.derivedNegFloatDecoder
 
   /* NonNegFloat */
-  inline given derivedNonNegFloatEncoder: Encoder[NonNegFloat] = numeric.derivedNonNegFloatEncoder
-  inline given derivedNonNegFloatDecoder: Decoder[NonNegFloat] = numeric.derivedNonNegFloatDecoder
+  given derivedNonNegFloatEncoder: Encoder[NonNegFloat] = numeric.derivedNonNegFloatEncoder
+  given derivedNonNegFloatDecoder: Decoder[NonNegFloat] = numeric.derivedNonNegFloatDecoder
 
   /* PosFloat */
-  inline given derivedPosFloatEncoder: Encoder[PosFloat] = numeric.derivedPosFloatEncoder
-  inline given derivedPosFloatDecoder: Decoder[PosFloat] = numeric.derivedPosFloatDecoder
+  given derivedPosFloatEncoder: Encoder[PosFloat] = numeric.derivedPosFloatEncoder
+  given derivedPosFloatDecoder: Decoder[PosFloat] = numeric.derivedPosFloatDecoder
 
   /* NonPosFloat */
-  inline given derivedNonPosFloatEncoder: Encoder[NonPosFloat] = numeric.derivedNonPosFloatEncoder
-  inline given derivedNonPosFloatDecoder: Decoder[NonPosFloat] = numeric.derivedNonPosFloatDecoder
+  given derivedNonPosFloatEncoder: Encoder[NonPosFloat] = numeric.derivedNonPosFloatEncoder
+  given derivedNonPosFloatDecoder: Decoder[NonPosFloat] = numeric.derivedNonPosFloatDecoder
 
   /* NegDouble */
-  inline given derivedNegDoubleEncoder: Encoder[NegDouble] = numeric.derivedNegDoubleEncoder
-  inline given derivedNegDoubleDecoder: Decoder[NegDouble] = numeric.derivedNegDoubleDecoder
+  given derivedNegDoubleEncoder: Encoder[NegDouble] = numeric.derivedNegDoubleEncoder
+  given derivedNegDoubleDecoder: Decoder[NegDouble] = numeric.derivedNegDoubleDecoder
 
   /* NonNegDouble */
-  inline given derivedNonNegDoubleEncoder: Encoder[NonNegDouble] = numeric.derivedNonNegDoubleEncoder
-  inline given derivedNonNegDoubleDecoder: Decoder[NonNegDouble] = numeric.derivedNonNegDoubleDecoder
+  given derivedNonNegDoubleEncoder: Encoder[NonNegDouble] = numeric.derivedNonNegDoubleEncoder
+  given derivedNonNegDoubleDecoder: Decoder[NonNegDouble] = numeric.derivedNonNegDoubleDecoder
 
   /* PosDouble */
-  inline given derivedPosDoubleEncoder: Encoder[PosDouble] = numeric.derivedPosDoubleEncoder
-  inline given derivedPosDoubleDecoder: Decoder[PosDouble] = numeric.derivedPosDoubleDecoder
+  given derivedPosDoubleEncoder: Encoder[PosDouble] = numeric.derivedPosDoubleEncoder
+  given derivedPosDoubleDecoder: Decoder[PosDouble] = numeric.derivedPosDoubleDecoder
 
   /* NonPosDouble */
-  inline given derivedNonPosDoubleEncoder: Encoder[NonPosDouble] = numeric.derivedNonPosDoubleEncoder
-  inline given derivedNonPosDoubleDecoder: Decoder[NonPosDouble] = numeric.derivedNonPosDoubleDecoder
+  given derivedNonPosDoubleEncoder: Encoder[NonPosDouble] = numeric.derivedNonPosDoubleEncoder
+  given derivedNonPosDoubleDecoder: Decoder[NonPosDouble] = numeric.derivedNonPosDoubleDecoder
 
   /* NegBigInt */
-  inline given derivedNegBigIntEncoder: Encoder[NegBigInt] = numeric.derivedNegBigIntEncoder
-  inline given derivedNegBigIntDecoder: Decoder[NegBigInt] = numeric.derivedNegBigIntDecoder
+  given derivedNegBigIntEncoder: Encoder[NegBigInt] = numeric.derivedNegBigIntEncoder
+  given derivedNegBigIntDecoder: Decoder[NegBigInt] = numeric.derivedNegBigIntDecoder
 
-  inline given derivedNegBigIntKeyEncoder: KeyEncoder[NegBigInt] = numeric.derivedNegBigIntKeyEncoder
-  inline given derivedNegBigIntKeyDecoder: KeyDecoder[NegBigInt] = numeric.derivedNegBigIntKeyDecoder
+  given derivedNegBigIntKeyEncoder: KeyEncoder[NegBigInt] = numeric.derivedNegBigIntKeyEncoder
+  given derivedNegBigIntKeyDecoder: KeyDecoder[NegBigInt] = numeric.derivedNegBigIntKeyDecoder
 
   /* NonNegBigInt */
-  inline given derivedNonNegBigIntEncoder: Encoder[NonNegBigInt] = numeric.derivedNonNegBigIntEncoder
-  inline given derivedNonNegBigIntDecoder: Decoder[NonNegBigInt] = numeric.derivedNonNegBigIntDecoder
+  given derivedNonNegBigIntEncoder: Encoder[NonNegBigInt] = numeric.derivedNonNegBigIntEncoder
+  given derivedNonNegBigIntDecoder: Decoder[NonNegBigInt] = numeric.derivedNonNegBigIntDecoder
 
-  inline given derivedNonNegBigIntKeyEncoder: KeyEncoder[NonNegBigInt] = numeric.derivedNonNegBigIntKeyEncoder
-  inline given derivedNonNegBigIntKeyDecoder: KeyDecoder[NonNegBigInt] = numeric.derivedNonNegBigIntKeyDecoder
+  given derivedNonNegBigIntKeyEncoder: KeyEncoder[NonNegBigInt] = numeric.derivedNonNegBigIntKeyEncoder
+  given derivedNonNegBigIntKeyDecoder: KeyDecoder[NonNegBigInt] = numeric.derivedNonNegBigIntKeyDecoder
 
   /* PosBigInt */
-  inline given derivedPosBigIntEncoder: Encoder[PosBigInt] = numeric.derivedPosBigIntEncoder
-  inline given derivedPosBigIntDecoder: Decoder[PosBigInt] = numeric.derivedPosBigIntDecoder
+  given derivedPosBigIntEncoder: Encoder[PosBigInt] = numeric.derivedPosBigIntEncoder
+  given derivedPosBigIntDecoder: Decoder[PosBigInt] = numeric.derivedPosBigIntDecoder
 
-  inline given derivedPosBigIntKeyEncoder: KeyEncoder[PosBigInt] = numeric.derivedPosBigIntKeyEncoder
-  inline given derivedPosBigIntKeyDecoder: KeyDecoder[PosBigInt] = numeric.derivedPosBigIntKeyDecoder
+  given derivedPosBigIntKeyEncoder: KeyEncoder[PosBigInt] = numeric.derivedPosBigIntKeyEncoder
+  given derivedPosBigIntKeyDecoder: KeyDecoder[PosBigInt] = numeric.derivedPosBigIntKeyDecoder
 
   /* NonPosBigInt */
-  inline given derivedNonPosBigIntEncoder: Encoder[NonPosBigInt] = numeric.derivedNonPosBigIntEncoder
-  inline given derivedNonPosBigIntDecoder: Decoder[NonPosBigInt] = numeric.derivedNonPosBigIntDecoder
+  given derivedNonPosBigIntEncoder: Encoder[NonPosBigInt] = numeric.derivedNonPosBigIntEncoder
+  given derivedNonPosBigIntDecoder: Decoder[NonPosBigInt] = numeric.derivedNonPosBigIntDecoder
 
-  inline given derivedNonPosBigIntKeyEncoder: KeyEncoder[NonPosBigInt] = numeric.derivedNonPosBigIntKeyEncoder
-  inline given derivedNonPosBigIntKeyDecoder: KeyDecoder[NonPosBigInt] = numeric.derivedNonPosBigIntKeyDecoder
+  given derivedNonPosBigIntKeyEncoder: KeyEncoder[NonPosBigInt] = numeric.derivedNonPosBigIntKeyEncoder
+  given derivedNonPosBigIntKeyDecoder: KeyDecoder[NonPosBigInt] = numeric.derivedNonPosBigIntKeyDecoder
 
   /* NegBigDecimal */
-  inline given derivedNegBigDecimalEncoder: Encoder[NegBigDecimal] = numeric.derivedNegBigDecimalEncoder
-  inline given derivedNegBigDecimalDecoder: Decoder[NegBigDecimal] = numeric.derivedNegBigDecimalDecoder
+  given derivedNegBigDecimalEncoder: Encoder[NegBigDecimal] = numeric.derivedNegBigDecimalEncoder
+  given derivedNegBigDecimalDecoder: Decoder[NegBigDecimal] = numeric.derivedNegBigDecimalDecoder
 
   /* NonNegBigDecimal */
-  inline given derivedNonNegBigDecimalEncoder: Encoder[NonNegBigDecimal] = numeric.derivedNonNegBigDecimalEncoder
-  inline given derivedNonNegBigDecimalDecoder: Decoder[NonNegBigDecimal] = numeric.derivedNonNegBigDecimalDecoder
+  given derivedNonNegBigDecimalEncoder: Encoder[NonNegBigDecimal] = numeric.derivedNonNegBigDecimalEncoder
+  given derivedNonNegBigDecimalDecoder: Decoder[NonNegBigDecimal] = numeric.derivedNonNegBigDecimalDecoder
 
   /* PosBigDecimal */
-  inline given derivedPosBigDecimalEncoder: Encoder[PosBigDecimal] = numeric.derivedPosBigDecimalEncoder
-  inline given derivedPosBigDecimalDecoder: Decoder[PosBigDecimal] = numeric.derivedPosBigDecimalDecoder
+  given derivedPosBigDecimalEncoder: Encoder[PosBigDecimal] = numeric.derivedPosBigDecimalEncoder
+  given derivedPosBigDecimalDecoder: Decoder[PosBigDecimal] = numeric.derivedPosBigDecimalDecoder
 
   /* NonPosBigDecimal */
-  inline given derivedNonPosBigDecimalEncoder: Encoder[NonPosBigDecimal] = numeric.derivedNonPosBigDecimalEncoder
-  inline given derivedNonPosBigDecimalDecoder: Decoder[NonPosBigDecimal] = numeric.derivedNonPosBigDecimalDecoder
+  given derivedNonPosBigDecimalEncoder: Encoder[NonPosBigDecimal] = numeric.derivedNonPosBigDecimalEncoder
+  given derivedNonPosBigDecimalDecoder: Decoder[NonPosBigDecimal] = numeric.derivedNonPosBigDecimalDecoder
 
 }
 object numeric {

--- a/modules/refined4s-circe/shared/src/main/scala/refined4s/modules/circe/derivation/types/strings.scala
+++ b/modules/refined4s-circe/shared/src/main/scala/refined4s/modules/circe/derivation/types/strings.scala
@@ -10,25 +10,25 @@ import refined4s.types.strings.*
 trait strings {
 
   /* NonEmptyString */
-  inline given derivedNonEmptyStringEncoder: Encoder[NonEmptyString] = strings.derivedNonEmptyStringEncoder
-  inline given derivedNonEmptyStringDecoder: Decoder[NonEmptyString] = strings.derivedNonEmptyStringDecoder
+  given derivedNonEmptyStringEncoder: Encoder[NonEmptyString] = strings.derivedNonEmptyStringEncoder
+  given derivedNonEmptyStringDecoder: Decoder[NonEmptyString] = strings.derivedNonEmptyStringDecoder
 
-  inline given derivedNonEmptyStringKeyEncoder: KeyEncoder[NonEmptyString] = strings.derivedNonEmptyStringKeyEncoder
-  inline given derivedNonEmptyStringKeyDecoder: KeyDecoder[NonEmptyString] = strings.derivedNonEmptyStringKeyDecoder
+  given derivedNonEmptyStringKeyEncoder: KeyEncoder[NonEmptyString] = strings.derivedNonEmptyStringKeyEncoder
+  given derivedNonEmptyStringKeyDecoder: KeyDecoder[NonEmptyString] = strings.derivedNonEmptyStringKeyDecoder
 
   /* NonBlankString */
-  inline given derivedNonBlankStringEncoder: Encoder[NonBlankString] = strings.derivedNonBlankStringEncoder
-  inline given derivedNonBlankStringDecoder: Decoder[NonBlankString] = strings.derivedNonBlankStringDecoder
+  given derivedNonBlankStringEncoder: Encoder[NonBlankString] = strings.derivedNonBlankStringEncoder
+  given derivedNonBlankStringDecoder: Decoder[NonBlankString] = strings.derivedNonBlankStringDecoder
 
-  inline given derivedNonBlankStringKeyEncoder: KeyEncoder[NonBlankString] = strings.derivedNonBlankStringKeyEncoder
-  inline given derivedNonBlankStringKeyDecoder: KeyDecoder[NonBlankString] = strings.derivedNonBlankStringKeyDecoder
+  given derivedNonBlankStringKeyEncoder: KeyEncoder[NonBlankString] = strings.derivedNonBlankStringKeyEncoder
+  given derivedNonBlankStringKeyDecoder: KeyDecoder[NonBlankString] = strings.derivedNonBlankStringKeyDecoder
 
   /* Uuid */
-  inline given derivedUuidEncoder: Encoder[Uuid] = strings.derivedUuidEncoder
-  inline given derivedUuidDecoder: Decoder[Uuid] = strings.derivedUuidDecoder
+  given derivedUuidEncoder: Encoder[Uuid] = strings.derivedUuidEncoder
+  given derivedUuidDecoder: Decoder[Uuid] = strings.derivedUuidDecoder
 
-  inline given derivedUuidKeyEncoder: KeyEncoder[Uuid] = strings.derivedUuidKeyEncoder
-  inline given derivedUuidKeyDecoder: KeyDecoder[Uuid] = strings.derivedUuidKeyDecoder
+  given derivedUuidKeyEncoder: KeyEncoder[Uuid] = strings.derivedUuidKeyEncoder
+  given derivedUuidKeyDecoder: KeyDecoder[Uuid] = strings.derivedUuidKeyDecoder
 }
 object strings {
 

--- a/modules/refined4s-circe/shared/src/main/scala/refined4s/modules/circe/derivation/types/time.scala
+++ b/modules/refined4s-circe/shared/src/main/scala/refined4s/modules/circe/derivation/types/time.scala
@@ -9,51 +9,51 @@ import refined4s.types.time.*
 trait time {
 
   /* Month { */
-  inline given derivedMonthEncoder: Encoder[Month] = time.derivedMonthEncoder
-  inline given derivedMonthDecoder: Decoder[Month] = time.derivedMonthDecoder
+  given derivedMonthEncoder: Encoder[Month] = time.derivedMonthEncoder
+  given derivedMonthDecoder: Decoder[Month] = time.derivedMonthDecoder
 
-  inline given derivedMonthKeyEncoder: KeyEncoder[Month] = time.derivedMonthKeyEncoder
-  inline given derivedMonthKeyDecoder: KeyDecoder[Month] = time.derivedMonthKeyDecoder
+  given derivedMonthKeyEncoder: KeyEncoder[Month] = time.derivedMonthKeyEncoder
+  given derivedMonthKeyDecoder: KeyDecoder[Month] = time.derivedMonthKeyDecoder
   /* } Month */
 
   /* Day { */
-  inline given derivedDayEncoder: Encoder[Day] = time.derivedDayEncoder
-  inline given derivedDayDecoder: Decoder[Day] = time.derivedDayDecoder
+  given derivedDayEncoder: Encoder[Day] = time.derivedDayEncoder
+  given derivedDayDecoder: Decoder[Day] = time.derivedDayDecoder
 
-  inline given derivedDayKeyEncoder: KeyEncoder[Day] = time.derivedDayKeyEncoder
-  inline given derivedDayKeyDecoder: KeyDecoder[Day] = time.derivedDayKeyDecoder
+  given derivedDayKeyEncoder: KeyEncoder[Day] = time.derivedDayKeyEncoder
+  given derivedDayKeyDecoder: KeyDecoder[Day] = time.derivedDayKeyDecoder
   /* } Day */
 
   /* Hour { */
-  inline given derivedHourEncoder: Encoder[Hour] = time.derivedHourEncoder
-  inline given derivedHourDecoder: Decoder[Hour] = time.derivedHourDecoder
+  given derivedHourEncoder: Encoder[Hour] = time.derivedHourEncoder
+  given derivedHourDecoder: Decoder[Hour] = time.derivedHourDecoder
 
-  inline given derivedHourKeyEncoder: KeyEncoder[Hour] = time.derivedHourKeyEncoder
-  inline given derivedHourKeyDecoder: KeyDecoder[Hour] = time.derivedHourKeyDecoder
+  given derivedHourKeyEncoder: KeyEncoder[Hour] = time.derivedHourKeyEncoder
+  given derivedHourKeyDecoder: KeyDecoder[Hour] = time.derivedHourKeyDecoder
   /* } Hour */
 
   /* Minute { */
-  inline given derivedMinuteEncoder: Encoder[Minute] = time.derivedMinuteEncoder
-  inline given derivedMinuteDecoder: Decoder[Minute] = time.derivedMinuteDecoder
+  given derivedMinuteEncoder: Encoder[Minute] = time.derivedMinuteEncoder
+  given derivedMinuteDecoder: Decoder[Minute] = time.derivedMinuteDecoder
 
-  inline given derivedMinuteKeyEncoder: KeyEncoder[Minute] = time.derivedMinuteKeyEncoder
-  inline given derivedMinuteKeyDecoder: KeyDecoder[Minute] = time.derivedMinuteKeyDecoder
+  given derivedMinuteKeyEncoder: KeyEncoder[Minute] = time.derivedMinuteKeyEncoder
+  given derivedMinuteKeyDecoder: KeyDecoder[Minute] = time.derivedMinuteKeyDecoder
   /* } Minute */
 
   /* Second { */
-  inline given derivedSecondEncoder: Encoder[Second] = time.derivedSecondEncoder
-  inline given derivedSecondDecoder: Decoder[Second] = time.derivedSecondDecoder
+  given derivedSecondEncoder: Encoder[Second] = time.derivedSecondEncoder
+  given derivedSecondDecoder: Decoder[Second] = time.derivedSecondDecoder
 
-  inline given derivedSecondKeyEncoder: KeyEncoder[Second] = time.derivedSecondKeyEncoder
-  inline given derivedSecondKeyDecoder: KeyDecoder[Second] = time.derivedSecondKeyDecoder
+  given derivedSecondKeyEncoder: KeyEncoder[Second] = time.derivedSecondKeyEncoder
+  given derivedSecondKeyDecoder: KeyDecoder[Second] = time.derivedSecondKeyDecoder
   /* } Second */
 
   /* Millis { */
-  inline given derivedMillisEncoder: Encoder[Millis] = time.derivedMillisEncoder
-  inline given derivedMillisDecoder: Decoder[Millis] = time.derivedMillisDecoder
+  given derivedMillisEncoder: Encoder[Millis] = time.derivedMillisEncoder
+  given derivedMillisDecoder: Decoder[Millis] = time.derivedMillisDecoder
 
-  inline given derivedMillisKeyEncoder: KeyEncoder[Millis] = time.derivedMillisKeyEncoder
-  inline given derivedMillisKeyDecoder: KeyDecoder[Millis] = time.derivedMillisKeyDecoder
+  given derivedMillisKeyEncoder: KeyEncoder[Millis] = time.derivedMillisKeyEncoder
+  given derivedMillisKeyDecoder: KeyDecoder[Millis] = time.derivedMillisKeyDecoder
   /* } Millis */
 }
 object time {

--- a/modules/refined4s-core/js/src/main/scala/refined4s/types/networkCompat.scala
+++ b/modules/refined4s-core/js/src/main/scala/refined4s/types/networkCompat.scala
@@ -83,19 +83,19 @@ object networkCompat {
   }
   private[types] trait UrlTypeClassInstances extends UrlTypeClassInstance1 {
     @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
-    inline given derivedUrlEq[F[*]: CatsEq, G[*]: CatsEq](using eqActual: G[String]): F[Url] = {
+    given derivedUrlEq[F[*]: CatsEq, G[*]: CatsEq](using eqActual: G[String]): F[Url] = {
       internalDef.contraCoercible[cats.Eq, Url, String, cats.Contravariant](eqActual.asInstanceOf[cats.Eq[String]])
     }.asInstanceOf[F[Url]] // scalafix:ok DisableSyntax.asInstanceOf
   }
   private[types] trait UrlTypeClassInstance1 extends UrlTypeClassInstance2 {
     @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
-    inline given derivedUrlHash[F[*]: CatsHash, G[*]: CatsHash](using hashActual: G[String]): F[Url] = {
+    given derivedUrlHash[F[*]: CatsHash, G[*]: CatsHash](using hashActual: G[String]): F[Url] = {
       internalDef.contraCoercible[cats.Hash, Url, String, cats.Contravariant](hashActual.asInstanceOf[cats.Hash[String]])
     }.asInstanceOf[F[Url]] // scalafix:ok DisableSyntax.asInstanceOf
   }
   private[types] trait UrlTypeClassInstance2 extends OrphanCats, OrphanCatsKernel {
     @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
-    inline given derivedUrlShow[F[*]: CatsShow, G[*]: CatsShow](using showActual: G[String]): F[Url] = {
+    given derivedUrlShow[F[*]: CatsShow, G[*]: CatsShow](using showActual: G[String]): F[Url] = {
       internalDef.contraCoercible[cats.Show, Url, String, cats.Contravariant](showActual.asInstanceOf[cats.Show[String]])
     }.asInstanceOf[F[Url]] // scalafix:ok DisableSyntax.asInstanceOf
   }

--- a/modules/refined4s-core/jvm/src/main/scala/refined4s/types/networkCompat.scala
+++ b/modules/refined4s-core/jvm/src/main/scala/refined4s/types/networkCompat.scala
@@ -47,19 +47,19 @@ object networkCompat {
   }
   private[types] trait UrlTypeClassInstances extends UrlTypeClassInstance1 {
     @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
-    inline given derivedUrlEq[F[*]: CatsEq, G[*]: CatsEq](using eqActual: G[String]): F[Url] = {
+    given derivedUrlEq[F[*]: CatsEq, G[*]: CatsEq](using eqActual: G[String]): F[Url] = {
       internalDef.contraCoercible[cats.Eq, Url, String, cats.Contravariant](eqActual.asInstanceOf[cats.Eq[String]])
     }.asInstanceOf[F[Url]] // scalafix:ok DisableSyntax.asInstanceOf
   }
   private[types] trait UrlTypeClassInstance1 extends UrlTypeClassInstance2 {
     @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
-    inline given derivedUrlHash[F[*]: CatsHash, G[*]: CatsHash](using hashActual: G[String]): F[Url] = {
+    given derivedUrlHash[F[*]: CatsHash, G[*]: CatsHash](using hashActual: G[String]): F[Url] = {
       internalDef.contraCoercible[cats.Hash, Url, String, cats.Contravariant](hashActual.asInstanceOf[cats.Hash[String]])
     }.asInstanceOf[F[Url]] // scalafix:ok DisableSyntax.asInstanceOf
   }
   private[types] trait UrlTypeClassInstance2 extends OrphanCats, OrphanCatsKernel {
     @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
-    inline given derivedUrlShow[F[*]: CatsShow, G[*]: CatsShow](using showActual: G[String]): F[Url] = {
+    given derivedUrlShow[F[*]: CatsShow, G[*]: CatsShow](using showActual: G[String]): F[Url] = {
       internalDef.contraCoercible[cats.Show, Url, String, cats.Contravariant](showActual.asInstanceOf[cats.Show[String]])
     }.asInstanceOf[F[Url]] // scalafix:ok DisableSyntax.asInstanceOf
   }

--- a/modules/refined4s-core/native/src/main/scala/refined4s/types/networkCompat.scala
+++ b/modules/refined4s-core/native/src/main/scala/refined4s/types/networkCompat.scala
@@ -83,19 +83,19 @@ object networkCompat {
   }
   private[types] trait UrlTypeClassInstances extends UrlTypeClassInstance1 {
     @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
-    inline given derivedUrlEq[F[*]: CatsEq, G[*]: CatsEq](using eqActual: G[String]): F[Url] = {
+    given derivedUrlEq[F[*]: CatsEq, G[*]: CatsEq](using eqActual: G[String]): F[Url] = {
       internalDef.contraCoercible[cats.Eq, Url, String, cats.Contravariant](eqActual.asInstanceOf[cats.Eq[String]])
     }.asInstanceOf[F[Url]] // scalafix:ok DisableSyntax.asInstanceOf
   }
   private[types] trait UrlTypeClassInstance1 extends UrlTypeClassInstance2 {
     @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
-    inline given derivedUrlHash[F[*]: CatsHash, G[*]: CatsHash](using hashActual: G[String]): F[Url] = {
+    given derivedUrlHash[F[*]: CatsHash, G[*]: CatsHash](using hashActual: G[String]): F[Url] = {
       internalDef.contraCoercible[cats.Hash, Url, String, cats.Contravariant](hashActual.asInstanceOf[cats.Hash[String]])
     }.asInstanceOf[F[Url]] // scalafix:ok DisableSyntax.asInstanceOf
   }
   private[types] trait UrlTypeClassInstance2 extends OrphanCats, OrphanCatsKernel {
     @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
-    inline given derivedUrlShow[F[*]: CatsShow, G[*]: CatsShow](using showActual: G[String]): F[Url] = {
+    given derivedUrlShow[F[*]: CatsShow, G[*]: CatsShow](using showActual: G[String]): F[Url] = {
       internalDef.contraCoercible[cats.Show, Url, String, cats.Contravariant](showActual.asInstanceOf[cats.Show[String]])
     }.asInstanceOf[F[Url]] // scalafix:ok DisableSyntax.asInstanceOf
   }

--- a/modules/refined4s-core/shared/src/main/scala/refined4s/Newtype.scala
+++ b/modules/refined4s-core/shared/src/main/scala/refined4s/Newtype.scala
@@ -14,9 +14,9 @@ trait Newtype[@specialized A] extends NewtypeBase[A] {
    */
   def unapply(typ: Type): Some[A] = Some(typ)
 
-  inline given wrap: Coercible[A, Type] = Coercible.instance
+  given wrap: Coercible[A, Type] = Coercible.instance
 
-  inline given wrapTC[F[*]]: Coercible[F[A], F[Type]] = Coercible.instance
+  given wrapTC[F[*]]: Coercible[F[A], F[Type]] = Coercible.instance
 
   extension (typ: Type) {
     override inline def value: A = typ

--- a/modules/refined4s-core/shared/src/main/scala/refined4s/NewtypeBase.scala
+++ b/modules/refined4s-core/shared/src/main/scala/refined4s/NewtypeBase.scala
@@ -8,9 +8,9 @@ trait NewtypeBase[@specialized A] {
 
   given newRefinedCanEqual: CanEqual[Type, Type] = CanEqual.derived
 
-  inline given unwrap: Coercible[Type, A] = Coercible.instance
+  given unwrap: Coercible[Type, A] = Coercible.instance
 
-  inline given unwrapTC[F[*]]: Coercible[F[Type], F[A]] = Coercible.instance
+  given unwrapTC[F[*]]: Coercible[F[Type], F[A]] = Coercible.instance
 
   extension (typ: Type) {
     def value: A

--- a/modules/refined4s-core/shared/src/main/scala/refined4s/RefinedBase.scala
+++ b/modules/refined4s-core/shared/src/main/scala/refined4s/RefinedBase.scala
@@ -8,7 +8,7 @@ trait RefinedBase[@specialized A] extends NewtypeBase[A] {
 
   override opaque type Type = A
 
-  inline given RefinedCtor[Type, A] with {
+  given RefinedCtor[Type, A] with {
     override def create(a: A): Either[String, Type] = from(a)
   }
 

--- a/modules/refined4s-core/shared/src/main/scala/refined4s/types/network.scala
+++ b/modules/refined4s-core/shared/src/main/scala/refined4s/types/network.scala
@@ -81,19 +81,19 @@ object network {
   }
   private[types] trait UriTypeClassInstances extends UriTypeClassInstance1 {
     @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
-    inline given derivedUriEq[F[*]: CatsEq, G[*]: CatsEq](using eqActual: G[String]): F[Uri] = {
+    given derivedUriEq[F[*]: CatsEq, G[*]: CatsEq](using eqActual: G[String]): F[Uri] = {
       internalDef.contraCoercible[cats.Eq, Uri, String, cats.Contravariant](eqActual.asInstanceOf[cats.Eq[String]])
     }.asInstanceOf[F[Uri]] // scalafix:ok DisableSyntax.asInstanceOf
   }
   private[types] trait UriTypeClassInstance1 extends UriTypeClassInstance2 {
     @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
-    inline given derivedUriHash[F[*]: CatsHash, G[*]: CatsHash](using hashActual: G[String]): F[Uri] = {
+    given derivedUriHash[F[*]: CatsHash, G[*]: CatsHash](using hashActual: G[String]): F[Uri] = {
       internalDef.contraCoercible[cats.Hash, Uri, String, cats.Contravariant](hashActual.asInstanceOf[cats.Hash[String]])
     }.asInstanceOf[F[Uri]] // scalafix:ok DisableSyntax.asInstanceOf
   }
   private[types] trait UriTypeClassInstance2 extends OrphanCats, OrphanCatsKernel {
     @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
-    inline given derivedUriShow[F[*]: CatsShow, G[*]: CatsShow](using showActual: G[String]): F[Uri] = {
+    given derivedUriShow[F[*]: CatsShow, G[*]: CatsShow](using showActual: G[String]): F[Uri] = {
       internalDef.contraCoercible[cats.Show, Uri, String, cats.Contravariant](showActual.asInstanceOf[cats.Show[String]])
     }.asInstanceOf[F[Uri]] // scalafix:ok DisableSyntax.asInstanceOf
   }
@@ -110,19 +110,19 @@ object network {
   }
   private[types] trait PortNumberTypeClassInstances extends PortNumberTypeClassInstance1 {
     @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
-    inline given derivedPortNumberEq[F[*]: CatsEq, G[*]: CatsEq](using eqActual: G[Int]): F[PortNumber] = {
+    given derivedPortNumberEq[F[*]: CatsEq, G[*]: CatsEq](using eqActual: G[Int]): F[PortNumber] = {
       internalDef.contraCoercible[cats.Eq, PortNumber, Int, cats.Contravariant](eqActual.asInstanceOf[cats.Eq[Int]])
     }.asInstanceOf[F[PortNumber]] // scalafix:ok DisableSyntax.asInstanceOf
   }
   private[types] trait PortNumberTypeClassInstance1 extends PortNumberTypeClassInstance2 {
     @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
-    inline given derivedPortNumberHash[F[*]: CatsHash, G[*]: CatsHash](using hashActual: G[Int]): F[PortNumber] = {
+    given derivedPortNumberHash[F[*]: CatsHash, G[*]: CatsHash](using hashActual: G[Int]): F[PortNumber] = {
       internalDef.contraCoercible[cats.Hash, PortNumber, Int, cats.Contravariant](hashActual.asInstanceOf[cats.Hash[Int]])
     }.asInstanceOf[F[PortNumber]] // scalafix:ok DisableSyntax.asInstanceOf
   }
   private[types] trait PortNumberTypeClassInstance2 extends OrphanCats, OrphanCatsKernel {
     @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
-    inline given derivedPortNumberShow[F[*]: CatsShow, G[*]: CatsShow](using showActual: G[Int]): F[PortNumber] = {
+    given derivedPortNumberShow[F[*]: CatsShow, G[*]: CatsShow](using showActual: G[Int]): F[PortNumber] = {
       internalDef.contraCoercible[cats.Show, PortNumber, Int, cats.Contravariant](showActual.asInstanceOf[cats.Show[Int]])
     }.asInstanceOf[F[PortNumber]] // scalafix:ok DisableSyntax.asInstanceOf
   }
@@ -139,19 +139,19 @@ object network {
   }
   private[types] trait SystemPortNumberTypeClassInstances extends SystemPortNumberTypeClassInstance1 {
     @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
-    inline given derivedSystemPortNumberEq[F[*]: CatsEq, G[*]: CatsEq](using eqActual: G[Int]): F[SystemPortNumber] = {
+    given derivedSystemPortNumberEq[F[*]: CatsEq, G[*]: CatsEq](using eqActual: G[Int]): F[SystemPortNumber] = {
       internalDef.contraCoercible[cats.Eq, SystemPortNumber, Int, cats.Contravariant](eqActual.asInstanceOf[cats.Eq[Int]])
     }.asInstanceOf[F[SystemPortNumber]] // scalafix:ok DisableSyntax.asInstanceOf
   }
   private[types] trait SystemPortNumberTypeClassInstance1 extends SystemPortNumberTypeClassInstance2 {
     @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
-    inline given derivedSystemPortNumberHash[F[*]: CatsHash, G[*]: CatsHash](using hashActual: G[Int]): F[SystemPortNumber] = {
+    given derivedSystemPortNumberHash[F[*]: CatsHash, G[*]: CatsHash](using hashActual: G[Int]): F[SystemPortNumber] = {
       internalDef.contraCoercible[cats.Hash, SystemPortNumber, Int, cats.Contravariant](hashActual.asInstanceOf[cats.Hash[Int]])
     }.asInstanceOf[F[SystemPortNumber]] // scalafix:ok DisableSyntax.asInstanceOf
   }
   private[types] trait SystemPortNumberTypeClassInstance2 extends OrphanCats, OrphanCatsKernel {
     @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
-    inline given derivedSystemPortNumberShow[F[*]: CatsShow, G[*]: CatsShow](using showActual: G[Int]): F[SystemPortNumber] = {
+    given derivedSystemPortNumberShow[F[*]: CatsShow, G[*]: CatsShow](using showActual: G[Int]): F[SystemPortNumber] = {
       internalDef.contraCoercible[cats.Show, SystemPortNumber, Int, cats.Contravariant](showActual.asInstanceOf[cats.Show[Int]])
     }.asInstanceOf[F[SystemPortNumber]] // scalafix:ok DisableSyntax.asInstanceOf
   }
@@ -168,19 +168,19 @@ object network {
   }
   private[types] trait NonSystemPortNumberTypeClassInstances extends NonSystemPortNumberTypeClassInstance1 {
     @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
-    inline given derivedNonSystemPortNumberEq[F[*]: CatsEq, G[*]: CatsEq](using eqActual: G[Int]): F[NonSystemPortNumber] = {
+    given derivedNonSystemPortNumberEq[F[*]: CatsEq, G[*]: CatsEq](using eqActual: G[Int]): F[NonSystemPortNumber] = {
       internalDef.contraCoercible[cats.Eq, NonSystemPortNumber, Int, cats.Contravariant](eqActual.asInstanceOf[cats.Eq[Int]])
     }.asInstanceOf[F[NonSystemPortNumber]] // scalafix:ok DisableSyntax.asInstanceOf
   }
   private[types] trait NonSystemPortNumberTypeClassInstance1 extends NonSystemPortNumberTypeClassInstance2 {
     @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
-    inline given derivedNonSystemPortNumberHash[F[*]: CatsHash, G[*]: CatsHash](using hashActual: G[Int]): F[NonSystemPortNumber] = {
+    given derivedNonSystemPortNumberHash[F[*]: CatsHash, G[*]: CatsHash](using hashActual: G[Int]): F[NonSystemPortNumber] = {
       internalDef.contraCoercible[cats.Hash, NonSystemPortNumber, Int, cats.Contravariant](hashActual.asInstanceOf[cats.Hash[Int]])
     }.asInstanceOf[F[NonSystemPortNumber]] // scalafix:ok DisableSyntax.asInstanceOf
   }
   private[types] trait NonSystemPortNumberTypeClassInstance2 extends OrphanCats, OrphanCatsKernel {
     @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
-    inline given derivedNonSystemPortNumberShow[F[*]: CatsShow, G[*]: CatsShow](using showActual: G[Int]): F[NonSystemPortNumber] = {
+    given derivedNonSystemPortNumberShow[F[*]: CatsShow, G[*]: CatsShow](using showActual: G[Int]): F[NonSystemPortNumber] = {
       internalDef.contraCoercible[cats.Show, NonSystemPortNumber, Int, cats.Contravariant](showActual.asInstanceOf[cats.Show[Int]])
     }.asInstanceOf[F[NonSystemPortNumber]] // scalafix:ok DisableSyntax.asInstanceOf
   }
@@ -197,19 +197,19 @@ object network {
   }
   private[types] trait UserPortNumberTypeClassInstances extends UserPortNumberTypeClassInstance1 {
     @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
-    inline given derivedUserPortNumberEq[F[*]: CatsEq, G[*]: CatsEq](using eqActual: G[Int]): F[UserPortNumber] = {
+    given derivedUserPortNumberEq[F[*]: CatsEq, G[*]: CatsEq](using eqActual: G[Int]): F[UserPortNumber] = {
       internalDef.contraCoercible[cats.Eq, UserPortNumber, Int, cats.Contravariant](eqActual.asInstanceOf[cats.Eq[Int]])
     }.asInstanceOf[F[UserPortNumber]] // scalafix:ok DisableSyntax.asInstanceOf
   }
   private[types] trait UserPortNumberTypeClassInstance1 extends UserPortNumberTypeClassInstance2 {
     @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
-    inline given derivedUserPortNumberHash[F[*]: CatsHash, G[*]: CatsHash](using hashActual: G[Int]): F[UserPortNumber] = {
+    given derivedUserPortNumberHash[F[*]: CatsHash, G[*]: CatsHash](using hashActual: G[Int]): F[UserPortNumber] = {
       internalDef.contraCoercible[cats.Hash, UserPortNumber, Int, cats.Contravariant](hashActual.asInstanceOf[cats.Hash[Int]])
     }.asInstanceOf[F[UserPortNumber]] // scalafix:ok DisableSyntax.asInstanceOf
   }
   private[types] trait UserPortNumberTypeClassInstance2 extends OrphanCats, OrphanCatsKernel {
     @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
-    inline given derivedUserPortNumberShow[F[*]: CatsShow, G[*]: CatsShow](using showActual: G[Int]): F[UserPortNumber] = {
+    given derivedUserPortNumberShow[F[*]: CatsShow, G[*]: CatsShow](using showActual: G[Int]): F[UserPortNumber] = {
       internalDef.contraCoercible[cats.Show, UserPortNumber, Int, cats.Contravariant](showActual.asInstanceOf[cats.Show[Int]])
     }.asInstanceOf[F[UserPortNumber]] // scalafix:ok DisableSyntax.asInstanceOf
   }
@@ -226,19 +226,19 @@ object network {
   }
   private[types] trait DynamicPortNumberTypeClassInstances extends DynamicPortNumberTypeClassInstance1 {
     @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
-    inline given derivedDynamicPortNumberEq[F[*]: CatsEq, G[*]: CatsEq](using eqActual: G[Int]): F[DynamicPortNumber] = {
+    given derivedDynamicPortNumberEq[F[*]: CatsEq, G[*]: CatsEq](using eqActual: G[Int]): F[DynamicPortNumber] = {
       internalDef.contraCoercible[cats.Eq, DynamicPortNumber, Int, cats.Contravariant](eqActual.asInstanceOf[cats.Eq[Int]])
     }.asInstanceOf[F[DynamicPortNumber]] // scalafix:ok DisableSyntax.asInstanceOf
   }
   private[types] trait DynamicPortNumberTypeClassInstance1 extends DynamicPortNumberTypeClassInstance2 {
     @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
-    inline given derivedDynamicPortNumberHash[F[*]: CatsHash, G[*]: CatsHash](using hashActual: G[Int]): F[DynamicPortNumber] = {
+    given derivedDynamicPortNumberHash[F[*]: CatsHash, G[*]: CatsHash](using hashActual: G[Int]): F[DynamicPortNumber] = {
       internalDef.contraCoercible[cats.Hash, DynamicPortNumber, Int, cats.Contravariant](hashActual.asInstanceOf[cats.Hash[Int]])
     }.asInstanceOf[F[DynamicPortNumber]] // scalafix:ok DisableSyntax.asInstanceOf
   }
   private[types] trait DynamicPortNumberTypeClassInstance2 extends OrphanCats, OrphanCatsKernel {
     @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
-    inline given derivedDynamicPortNumberShow[F[*]: CatsShow, G[*]: CatsShow](using showActual: G[Int]): F[DynamicPortNumber] = {
+    given derivedDynamicPortNumberShow[F[*]: CatsShow, G[*]: CatsShow](using showActual: G[Int]): F[DynamicPortNumber] = {
       internalDef.contraCoercible[cats.Show, DynamicPortNumber, Int, cats.Contravariant](showActual.asInstanceOf[cats.Show[Int]])
     }.asInstanceOf[F[DynamicPortNumber]] // scalafix:ok DisableSyntax.asInstanceOf
 

--- a/modules/refined4s-core/shared/src/main/scala/refined4s/types/numeric.scala
+++ b/modules/refined4s-core/shared/src/main/scala/refined4s/types/numeric.scala
@@ -145,19 +145,19 @@ object numeric {
   }
   private[types] trait NegIntTypeClassInstances extends NegIntTypeClassInstance1 {
     @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
-    inline given derivedNegIntEq[F[*]: CatsEq, G[*]: CatsEq](using eqActual: G[Int]): F[NegInt] = {
+    given derivedNegIntEq[F[*]: CatsEq, G[*]: CatsEq](using eqActual: G[Int]): F[NegInt] = {
       internalDef.contraCoercible[cats.Eq, NegInt, Int, cats.Contravariant](eqActual.asInstanceOf[cats.Eq[Int]])
     }.asInstanceOf[F[NegInt]] // scalafix:ok DisableSyntax.asInstanceOf
   }
   private[types] trait NegIntTypeClassInstance1 extends NegIntTypeClassInstance2 {
     @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
-    inline given derivedNegIntHash[F[*]: CatsHash, G[*]: CatsHash](using hashActual: G[Int]): F[NegInt] = {
+    given derivedNegIntHash[F[*]: CatsHash, G[*]: CatsHash](using hashActual: G[Int]): F[NegInt] = {
       internalDef.contraCoercible[cats.Hash, NegInt, Int, cats.Contravariant](hashActual.asInstanceOf[cats.Hash[Int]])
     }.asInstanceOf[F[NegInt]] // scalafix:ok DisableSyntax.asInstanceOf
   }
   private[types] trait NegIntTypeClassInstance2 extends OrphanCats, OrphanCatsKernel {
     @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
-    inline given derivedNegIntShow[F[*]: CatsShow, G[*]: CatsShow](using showActual: G[Int]): F[NegInt] = {
+    given derivedNegIntShow[F[*]: CatsShow, G[*]: CatsShow](using showActual: G[Int]): F[NegInt] = {
       internalDef.contraCoercible[cats.Show, NegInt, Int, cats.Contravariant](showActual.asInstanceOf[cats.Show[Int]])
     }.asInstanceOf[F[NegInt]] // scalafix:ok DisableSyntax.asInstanceOf
   }
@@ -174,19 +174,19 @@ object numeric {
   }
   private[types] trait NonNegIntTypeClassInstances extends NonNegIntTypeClassInstance1 {
     @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
-    inline given derivedNonNegIntEq[F[*]: CatsEq, G[*]: CatsEq](using eqActual: G[Int]): F[NonNegInt] = {
+    given derivedNonNegIntEq[F[*]: CatsEq, G[*]: CatsEq](using eqActual: G[Int]): F[NonNegInt] = {
       internalDef.contraCoercible[cats.Eq, NonNegInt, Int, cats.Contravariant](eqActual.asInstanceOf[cats.Eq[Int]])
     }.asInstanceOf[F[NonNegInt]] // scalafix:ok DisableSyntax.asInstanceOf
   }
   private[types] trait NonNegIntTypeClassInstance1 extends NonNegIntTypeClassInstance2 {
     @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
-    inline given derivedNonNegIntHash[F[*]: CatsHash, G[*]: CatsHash](using hashActual: G[Int]): F[NonNegInt] = {
+    given derivedNonNegIntHash[F[*]: CatsHash, G[*]: CatsHash](using hashActual: G[Int]): F[NonNegInt] = {
       internalDef.contraCoercible[cats.Hash, NonNegInt, Int, cats.Contravariant](hashActual.asInstanceOf[cats.Hash[Int]])
     }.asInstanceOf[F[NonNegInt]] // scalafix:ok DisableSyntax.asInstanceOf
   }
   private[types] trait NonNegIntTypeClassInstance2 extends OrphanCats, OrphanCatsKernel {
     @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
-    inline given derivedNonNegIntShow[F[*]: CatsShow, G[*]: CatsShow](using showActual: G[Int]): F[NonNegInt] = {
+    given derivedNonNegIntShow[F[*]: CatsShow, G[*]: CatsShow](using showActual: G[Int]): F[NonNegInt] = {
       internalDef.contraCoercible[cats.Show, NonNegInt, Int, cats.Contravariant](showActual.asInstanceOf[cats.Show[Int]])
     }.asInstanceOf[F[NonNegInt]] // scalafix:ok DisableSyntax.asInstanceOf
   }
@@ -203,19 +203,19 @@ object numeric {
   }
   private[types] trait PosIntTypeClassInstances extends PosIntTypeClassInstance1 {
     @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
-    inline given derivedPosIntEq[F[*]: CatsEq, G[*]: CatsEq](using eqActual: G[Int]): F[PosInt] = {
+    given derivedPosIntEq[F[*]: CatsEq, G[*]: CatsEq](using eqActual: G[Int]): F[PosInt] = {
       internalDef.contraCoercible[cats.Eq, PosInt, Int, cats.Contravariant](eqActual.asInstanceOf[cats.Eq[Int]])
     }.asInstanceOf[F[PosInt]] // scalafix:ok DisableSyntax.asInstanceOf
   }
   private[types] trait PosIntTypeClassInstance1 extends PosIntTypeClassInstance2 {
     @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
-    inline given derivedPosIntHash[F[*]: CatsHash, G[*]: CatsHash](using hashActual: G[Int]): F[PosInt] = {
+    given derivedPosIntHash[F[*]: CatsHash, G[*]: CatsHash](using hashActual: G[Int]): F[PosInt] = {
       internalDef.contraCoercible[cats.Hash, PosInt, Int, cats.Contravariant](hashActual.asInstanceOf[cats.Hash[Int]])
     }.asInstanceOf[F[PosInt]] // scalafix:ok DisableSyntax.asInstanceOf
   }
   private[types] trait PosIntTypeClassInstance2 extends OrphanCats, OrphanCatsKernel {
     @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
-    inline given derivedPosIntShow[F[*]: CatsShow, G[*]: CatsShow](using showActual: G[Int]): F[PosInt] = {
+    given derivedPosIntShow[F[*]: CatsShow, G[*]: CatsShow](using showActual: G[Int]): F[PosInt] = {
       internalDef.contraCoercible[cats.Show, PosInt, Int, cats.Contravariant](showActual.asInstanceOf[cats.Show[Int]])
     }.asInstanceOf[F[PosInt]] // scalafix:ok DisableSyntax.asInstanceOf
   }
@@ -232,19 +232,19 @@ object numeric {
   }
   private[types] trait NonPosIntTypeClassInstances extends NonPosIntTypeClassInstance1 {
     @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
-    inline given derivedNonPosIntEq[F[*]: CatsEq, G[*]: CatsEq](using eqActual: G[Int]): F[NonPosInt] = {
+    given derivedNonPosIntEq[F[*]: CatsEq, G[*]: CatsEq](using eqActual: G[Int]): F[NonPosInt] = {
       internalDef.contraCoercible[cats.Eq, NonPosInt, Int, cats.Contravariant](eqActual.asInstanceOf[cats.Eq[Int]])
     }.asInstanceOf[F[NonPosInt]] // scalafix:ok DisableSyntax.asInstanceOf
   }
   private[types] trait NonPosIntTypeClassInstance1 extends NonPosIntTypeClassInstance2 {
     @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
-    inline given derivedNonPosIntHash[F[*]: CatsHash, G[*]: CatsHash](using hashActual: G[Int]): F[NonPosInt] = {
+    given derivedNonPosIntHash[F[*]: CatsHash, G[*]: CatsHash](using hashActual: G[Int]): F[NonPosInt] = {
       internalDef.contraCoercible[cats.Hash, NonPosInt, Int, cats.Contravariant](hashActual.asInstanceOf[cats.Hash[Int]])
     }.asInstanceOf[F[NonPosInt]] // scalafix:ok DisableSyntax.asInstanceOf
   }
   private[types] trait NonPosIntTypeClassInstance2 extends OrphanCats, OrphanCatsKernel {
     @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
-    inline given derivedNonPosIntShow[F[*]: CatsShow, G[*]: CatsShow](using showActual: G[Int]): F[NonPosInt] = {
+    given derivedNonPosIntShow[F[*]: CatsShow, G[*]: CatsShow](using showActual: G[Int]): F[NonPosInt] = {
       internalDef.contraCoercible[cats.Show, NonPosInt, Int, cats.Contravariant](showActual.asInstanceOf[cats.Show[Int]])
     }.asInstanceOf[F[NonPosInt]] // scalafix:ok DisableSyntax.asInstanceOf
   }
@@ -261,19 +261,19 @@ object numeric {
   }
   private[types] trait NegLongTypeClassInstances extends NegLongTypeClassInstance1 {
     @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
-    inline given derivedNegLongEq[F[*]: CatsEq, G[*]: CatsEq](using eqActual: G[Long]): F[NegLong] = {
+    given derivedNegLongEq[F[*]: CatsEq, G[*]: CatsEq](using eqActual: G[Long]): F[NegLong] = {
       internalDef.contraCoercible[cats.Eq, NegLong, Long, cats.Contravariant](eqActual.asInstanceOf[cats.Eq[Long]])
     }.asInstanceOf[F[NegLong]] // scalafix:ok DisableSyntax.asInstanceOf
   }
   private[types] trait NegLongTypeClassInstance1 extends NegLongTypeClassInstance2 {
     @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
-    inline given derivedNegLongHash[F[*]: CatsHash, G[*]: CatsHash](using hashActual: G[Long]): F[NegLong] = {
+    given derivedNegLongHash[F[*]: CatsHash, G[*]: CatsHash](using hashActual: G[Long]): F[NegLong] = {
       internalDef.contraCoercible[cats.Hash, NegLong, Long, cats.Contravariant](hashActual.asInstanceOf[cats.Hash[Long]])
     }.asInstanceOf[F[NegLong]] // scalafix:ok DisableSyntax.asInstanceOf
   }
   private[types] trait NegLongTypeClassInstance2 extends OrphanCats, OrphanCatsKernel {
     @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
-    inline given derivedNegLongShow[F[*]: CatsShow, G[*]: CatsShow](using showActual: G[Long]): F[NegLong] = {
+    given derivedNegLongShow[F[*]: CatsShow, G[*]: CatsShow](using showActual: G[Long]): F[NegLong] = {
       internalDef.contraCoercible[cats.Show, NegLong, Long, cats.Contravariant](showActual.asInstanceOf[cats.Show[Long]])
     }.asInstanceOf[F[NegLong]] // scalafix:ok DisableSyntax.asInstanceOf
   }
@@ -290,19 +290,19 @@ object numeric {
   }
   private[types] trait NonNegLongTypeClassInstances extends NonNegLongTypeClassInstance1 {
     @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
-    inline given derivedNonNegLongEq[F[*]: CatsEq, G[*]: CatsEq](using eqActual: G[Long]): F[NonNegLong] = {
+    given derivedNonNegLongEq[F[*]: CatsEq, G[*]: CatsEq](using eqActual: G[Long]): F[NonNegLong] = {
       internalDef.contraCoercible[cats.Eq, NonNegLong, Long, cats.Contravariant](eqActual.asInstanceOf[cats.Eq[Long]])
     }.asInstanceOf[F[NonNegLong]] // scalafix:ok DisableSyntax.asInstanceOf
   }
   private[types] trait NonNegLongTypeClassInstance1 extends NonNegLongTypeClassInstance2 {
     @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
-    inline given derivedNonNegLongHash[F[*]: CatsHash, G[*]: CatsHash](using hashActual: G[Long]): F[NonNegLong] = {
+    given derivedNonNegLongHash[F[*]: CatsHash, G[*]: CatsHash](using hashActual: G[Long]): F[NonNegLong] = {
       internalDef.contraCoercible[cats.Hash, NonNegLong, Long, cats.Contravariant](hashActual.asInstanceOf[cats.Hash[Long]])
     }.asInstanceOf[F[NonNegLong]] // scalafix:ok DisableSyntax.asInstanceOf
   }
   private[types] trait NonNegLongTypeClassInstance2 extends OrphanCats, OrphanCatsKernel {
     @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
-    inline given derivedNonNegLongShow[F[*]: CatsShow, G[*]: CatsShow](using showActual: G[Long]): F[NonNegLong] = {
+    given derivedNonNegLongShow[F[*]: CatsShow, G[*]: CatsShow](using showActual: G[Long]): F[NonNegLong] = {
       internalDef.contraCoercible[cats.Show, NonNegLong, Long, cats.Contravariant](showActual.asInstanceOf[cats.Show[Long]])
     }.asInstanceOf[F[NonNegLong]] // scalafix:ok DisableSyntax.asInstanceOf
   }
@@ -319,19 +319,19 @@ object numeric {
   }
   private[types] trait PosLongTypeClassInstances extends PosLongTypeClassInstance1 {
     @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
-    inline given derivedPosLongEq[F[*]: CatsEq, G[*]: CatsEq](using eqActual: G[Long]): F[PosLong] = {
+    given derivedPosLongEq[F[*]: CatsEq, G[*]: CatsEq](using eqActual: G[Long]): F[PosLong] = {
       internalDef.contraCoercible[cats.Eq, PosLong, Long, cats.Contravariant](eqActual.asInstanceOf[cats.Eq[Long]])
     }.asInstanceOf[F[PosLong]] // scalafix:ok DisableSyntax.asInstanceOf
   }
   private[types] trait PosLongTypeClassInstance1 extends PosLongTypeClassInstance2 {
     @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
-    inline given derivedPosLongHash[F[*]: CatsHash, G[*]: CatsHash](using hashActual: G[Long]): F[PosLong] = {
+    given derivedPosLongHash[F[*]: CatsHash, G[*]: CatsHash](using hashActual: G[Long]): F[PosLong] = {
       internalDef.contraCoercible[cats.Hash, PosLong, Long, cats.Contravariant](hashActual.asInstanceOf[cats.Hash[Long]])
     }.asInstanceOf[F[PosLong]] // scalafix:ok DisableSyntax.asInstanceOf
   }
   private[types] trait PosLongTypeClassInstance2 extends OrphanCats, OrphanCatsKernel {
     @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
-    inline given derivedPosLongShow[F[*]: CatsShow, G[*]: CatsShow](using showActual: G[Long]): F[PosLong] = {
+    given derivedPosLongShow[F[*]: CatsShow, G[*]: CatsShow](using showActual: G[Long]): F[PosLong] = {
       internalDef.contraCoercible[cats.Show, PosLong, Long, cats.Contravariant](showActual.asInstanceOf[cats.Show[Long]])
     }.asInstanceOf[F[PosLong]] // scalafix:ok DisableSyntax.asInstanceOf
   }
@@ -348,19 +348,19 @@ object numeric {
   }
   private[types] trait NonPosLongTypeClassInstances extends NonPosLongTypeClassInstance1 {
     @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
-    inline given derivedNonPosLongEq[F[*]: CatsEq, G[*]: CatsEq](using eqActual: G[Long]): F[NonPosLong] = {
+    given derivedNonPosLongEq[F[*]: CatsEq, G[*]: CatsEq](using eqActual: G[Long]): F[NonPosLong] = {
       internalDef.contraCoercible[cats.Eq, NonPosLong, Long, cats.Contravariant](eqActual.asInstanceOf[cats.Eq[Long]])
     }.asInstanceOf[F[NonPosLong]] // scalafix:ok DisableSyntax.asInstanceOf
   }
   private[types] trait NonPosLongTypeClassInstance1 extends NonPosLongTypeClassInstance2 {
     @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
-    inline given derivedNonPosLongHash[F[*]: CatsHash, G[*]: CatsHash](using hashActual: G[Long]): F[NonPosLong] = {
+    given derivedNonPosLongHash[F[*]: CatsHash, G[*]: CatsHash](using hashActual: G[Long]): F[NonPosLong] = {
       internalDef.contraCoercible[cats.Hash, NonPosLong, Long, cats.Contravariant](hashActual.asInstanceOf[cats.Hash[Long]])
     }.asInstanceOf[F[NonPosLong]] // scalafix:ok DisableSyntax.asInstanceOf
   }
   private[types] trait NonPosLongTypeClassInstance2 extends OrphanCats, OrphanCatsKernel {
     @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
-    inline given derivedNonPosLongShow[F[*]: CatsShow, G[*]: CatsShow](using showActual: G[Long]): F[NonPosLong] = {
+    given derivedNonPosLongShow[F[*]: CatsShow, G[*]: CatsShow](using showActual: G[Long]): F[NonPosLong] = {
       internalDef.contraCoercible[cats.Show, NonPosLong, Long, cats.Contravariant](showActual.asInstanceOf[cats.Show[Long]])
     }.asInstanceOf[F[NonPosLong]] // scalafix:ok DisableSyntax.asInstanceOf
   }
@@ -377,19 +377,19 @@ object numeric {
   }
   private[types] trait NegShortTypeClassInstances extends NegShortTypeClassInstance1 {
     @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
-    inline given derivedNegShortEq[F[*]: CatsEq, G[*]: CatsEq](using eqActual: G[Short]): F[NegShort] = {
+    given derivedNegShortEq[F[*]: CatsEq, G[*]: CatsEq](using eqActual: G[Short]): F[NegShort] = {
       internalDef.contraCoercible[cats.Eq, NegShort, Short, cats.Contravariant](eqActual.asInstanceOf[cats.Eq[Short]])
     }.asInstanceOf[F[NegShort]] // scalafix:ok DisableSyntax.asInstanceOf
   }
   private[types] trait NegShortTypeClassInstance1 extends NegShortTypeClassInstance2 {
     @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
-    inline given derivedNegShortHash[F[*]: CatsHash, G[*]: CatsHash](using hashActual: G[Short]): F[NegShort] = {
+    given derivedNegShortHash[F[*]: CatsHash, G[*]: CatsHash](using hashActual: G[Short]): F[NegShort] = {
       internalDef.contraCoercible[cats.Hash, NegShort, Short, cats.Contravariant](hashActual.asInstanceOf[cats.Hash[Short]])
     }.asInstanceOf[F[NegShort]] // scalafix:ok DisableSyntax.asInstanceOf
   }
   private[types] trait NegShortTypeClassInstance2 extends OrphanCats, OrphanCatsKernel {
     @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
-    inline given derivedNegShortShow[F[*]: CatsShow, G[*]: CatsShow](using showActual: G[Short]): F[NegShort] = {
+    given derivedNegShortShow[F[*]: CatsShow, G[*]: CatsShow](using showActual: G[Short]): F[NegShort] = {
       internalDef.contraCoercible[cats.Show, NegShort, Short, cats.Contravariant](showActual.asInstanceOf[cats.Show[Short]])
     }.asInstanceOf[F[NegShort]] // scalafix:ok DisableSyntax.asInstanceOf
   }
@@ -406,19 +406,19 @@ object numeric {
   }
   private[types] trait NonNegShortTypeClassInstances extends NonNegShortTypeClassInstance1 {
     @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
-    inline given derivedNonNegShortEq[F[*]: CatsEq, G[*]: CatsEq](using eqActual: G[Short]): F[NonNegShort] = {
+    given derivedNonNegShortEq[F[*]: CatsEq, G[*]: CatsEq](using eqActual: G[Short]): F[NonNegShort] = {
       internalDef.contraCoercible[cats.Eq, NonNegShort, Short, cats.Contravariant](eqActual.asInstanceOf[cats.Eq[Short]])
     }.asInstanceOf[F[NonNegShort]] // scalafix:ok DisableSyntax.asInstanceOf
   }
   private[types] trait NonNegShortTypeClassInstance1 extends NonNegShortTypeClassInstance2 {
     @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
-    inline given derivedNonNegShortHash[F[*]: CatsHash, G[*]: CatsHash](using hashActual: G[Short]): F[NonNegShort] = {
+    given derivedNonNegShortHash[F[*]: CatsHash, G[*]: CatsHash](using hashActual: G[Short]): F[NonNegShort] = {
       internalDef.contraCoercible[cats.Hash, NonNegShort, Short, cats.Contravariant](hashActual.asInstanceOf[cats.Hash[Short]])
     }.asInstanceOf[F[NonNegShort]] // scalafix:ok DisableSyntax.asInstanceOf
   }
   private[types] trait NonNegShortTypeClassInstance2 extends OrphanCats, OrphanCatsKernel {
     @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
-    inline given derivedNonNegShortShow[F[*]: CatsShow, G[*]: CatsShow](using showActual: G[Short]): F[NonNegShort] = {
+    given derivedNonNegShortShow[F[*]: CatsShow, G[*]: CatsShow](using showActual: G[Short]): F[NonNegShort] = {
       internalDef.contraCoercible[cats.Show, NonNegShort, Short, cats.Contravariant](showActual.asInstanceOf[cats.Show[Short]])
     }.asInstanceOf[F[NonNegShort]] // scalafix:ok DisableSyntax.asInstanceOf
   }
@@ -435,19 +435,19 @@ object numeric {
   }
   private[types] trait PosShortTypeClassInstances extends PosShortTypeClassInstance1 {
     @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
-    inline given derivedPosShortEq[F[*]: CatsEq, G[*]: CatsEq](using eqActual: G[Short]): F[PosShort] = {
+    given derivedPosShortEq[F[*]: CatsEq, G[*]: CatsEq](using eqActual: G[Short]): F[PosShort] = {
       internalDef.contraCoercible[cats.Eq, PosShort, Short, cats.Contravariant](eqActual.asInstanceOf[cats.Eq[Short]])
     }.asInstanceOf[F[PosShort]] // scalafix:ok DisableSyntax.asInstanceOf
   }
   private[types] trait PosShortTypeClassInstance1 extends PosShortTypeClassInstance2 {
     @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
-    inline given derivedPosShortHash[F[*]: CatsHash, G[*]: CatsHash](using hashActual: G[Short]): F[PosShort] = {
+    given derivedPosShortHash[F[*]: CatsHash, G[*]: CatsHash](using hashActual: G[Short]): F[PosShort] = {
       internalDef.contraCoercible[cats.Hash, PosShort, Short, cats.Contravariant](hashActual.asInstanceOf[cats.Hash[Short]])
     }.asInstanceOf[F[PosShort]] // scalafix:ok DisableSyntax.asInstanceOf
   }
   private[types] trait PosShortTypeClassInstance2 extends OrphanCats, OrphanCatsKernel {
     @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
-    inline given derivedPosShortShow[F[*]: CatsShow, G[*]: CatsShow](using showActual: G[Short]): F[PosShort] = {
+    given derivedPosShortShow[F[*]: CatsShow, G[*]: CatsShow](using showActual: G[Short]): F[PosShort] = {
       internalDef.contraCoercible[cats.Show, PosShort, Short, cats.Contravariant](showActual.asInstanceOf[cats.Show[Short]])
     }.asInstanceOf[F[PosShort]] // scalafix:ok DisableSyntax.asInstanceOf
   }
@@ -464,19 +464,19 @@ object numeric {
   }
   private[types] trait NonPosShortTypeClassInstances extends NonPosShortTypeClassInstance1 {
     @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
-    inline given derivedNonPosShortEq[F[*]: CatsEq, G[*]: CatsEq](using eqActual: G[Short]): F[NonPosShort] = {
+    given derivedNonPosShortEq[F[*]: CatsEq, G[*]: CatsEq](using eqActual: G[Short]): F[NonPosShort] = {
       internalDef.contraCoercible[cats.Eq, NonPosShort, Short, cats.Contravariant](eqActual.asInstanceOf[cats.Eq[Short]])
     }.asInstanceOf[F[NonPosShort]] // scalafix:ok DisableSyntax.asInstanceOf
   }
   private[types] trait NonPosShortTypeClassInstance1 extends NonPosShortTypeClassInstance2 {
     @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
-    inline given derivedNonPosShortHash[F[*]: CatsHash, G[*]: CatsHash](using hashActual: G[Short]): F[NonPosShort] = {
+    given derivedNonPosShortHash[F[*]: CatsHash, G[*]: CatsHash](using hashActual: G[Short]): F[NonPosShort] = {
       internalDef.contraCoercible[cats.Hash, NonPosShort, Short, cats.Contravariant](hashActual.asInstanceOf[cats.Hash[Short]])
     }.asInstanceOf[F[NonPosShort]] // scalafix:ok DisableSyntax.asInstanceOf
   }
   private[types] trait NonPosShortTypeClassInstance2 extends OrphanCats, OrphanCatsKernel {
     @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
-    inline given derivedNonPosShortShow[F[*]: CatsShow, G[*]: CatsShow](using showActual: G[Short]): F[NonPosShort] = {
+    given derivedNonPosShortShow[F[*]: CatsShow, G[*]: CatsShow](using showActual: G[Short]): F[NonPosShort] = {
       internalDef.contraCoercible[cats.Show, NonPosShort, Short, cats.Contravariant](showActual.asInstanceOf[cats.Show[Short]])
     }.asInstanceOf[F[NonPosShort]] // scalafix:ok DisableSyntax.asInstanceOf
   }
@@ -493,19 +493,19 @@ object numeric {
   }
   private[types] trait NegByteTypeClassInstances extends NegByteTypeClassInstance1 {
     @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
-    inline given derivedNegByteEq[F[*]: CatsEq, G[*]: CatsEq](using eqActual: G[Byte]): F[NegByte] = {
+    given derivedNegByteEq[F[*]: CatsEq, G[*]: CatsEq](using eqActual: G[Byte]): F[NegByte] = {
       internalDef.contraCoercible[cats.Eq, NegByte, Byte, cats.Contravariant](eqActual.asInstanceOf[cats.Eq[Byte]])
     }.asInstanceOf[F[NegByte]] // scalafix:ok DisableSyntax.asInstanceOf
   }
   private[types] trait NegByteTypeClassInstance1 extends NegByteTypeClassInstance2 {
     @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
-    inline given derivedNegByteHash[F[*]: CatsHash, G[*]: CatsHash](using hashActual: G[Byte]): F[NegByte] = {
+    given derivedNegByteHash[F[*]: CatsHash, G[*]: CatsHash](using hashActual: G[Byte]): F[NegByte] = {
       internalDef.contraCoercible[cats.Hash, NegByte, Byte, cats.Contravariant](hashActual.asInstanceOf[cats.Hash[Byte]])
     }.asInstanceOf[F[NegByte]] // scalafix:ok DisableSyntax.asInstanceOf
   }
   private[types] trait NegByteTypeClassInstance2 extends OrphanCats, OrphanCatsKernel {
     @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
-    inline given derivedNegByteShow[F[*]: CatsShow, G[*]: CatsShow](using showActual: G[Byte]): F[NegByte] = {
+    given derivedNegByteShow[F[*]: CatsShow, G[*]: CatsShow](using showActual: G[Byte]): F[NegByte] = {
       internalDef.contraCoercible[cats.Show, NegByte, Byte, cats.Contravariant](showActual.asInstanceOf[cats.Show[Byte]])
     }.asInstanceOf[F[NegByte]] // scalafix:ok DisableSyntax.asInstanceOf
   }
@@ -522,19 +522,19 @@ object numeric {
   }
   private[types] trait NonNegByteTypeClassInstances extends NonNegByteTypeClassInstance1 {
     @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
-    inline given derivedNonNegByteEq[F[*]: CatsEq, G[*]: CatsEq](using eqActual: G[Byte]): F[NonNegByte] = {
+    given derivedNonNegByteEq[F[*]: CatsEq, G[*]: CatsEq](using eqActual: G[Byte]): F[NonNegByte] = {
       internalDef.contraCoercible[cats.Eq, NonNegByte, Byte, cats.Contravariant](eqActual.asInstanceOf[cats.Eq[Byte]])
     }.asInstanceOf[F[NonNegByte]] // scalafix:ok DisableSyntax.asInstanceOf
   }
   private[types] trait NonNegByteTypeClassInstance1 extends NonNegByteTypeClassInstance2 {
     @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
-    inline given derivedNonNegByteHash[F[*]: CatsHash, G[*]: CatsHash](using hashActual: G[Byte]): F[NonNegByte] = {
+    given derivedNonNegByteHash[F[*]: CatsHash, G[*]: CatsHash](using hashActual: G[Byte]): F[NonNegByte] = {
       internalDef.contraCoercible[cats.Hash, NonNegByte, Byte, cats.Contravariant](hashActual.asInstanceOf[cats.Hash[Byte]])
     }.asInstanceOf[F[NonNegByte]] // scalafix:ok DisableSyntax.asInstanceOf
   }
   private[types] trait NonNegByteTypeClassInstance2 extends OrphanCats, OrphanCatsKernel {
     @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
-    inline given derivedNonNegByteShow[F[*]: CatsShow, G[*]: CatsShow](using showActual: G[Byte]): F[NonNegByte] = {
+    given derivedNonNegByteShow[F[*]: CatsShow, G[*]: CatsShow](using showActual: G[Byte]): F[NonNegByte] = {
       internalDef.contraCoercible[cats.Show, NonNegByte, Byte, cats.Contravariant](showActual.asInstanceOf[cats.Show[Byte]])
     }.asInstanceOf[F[NonNegByte]] // scalafix:ok DisableSyntax.asInstanceOf
   }
@@ -551,19 +551,19 @@ object numeric {
   }
   private[types] trait PosByteTypeClassInstances extends PosByteTypeClassInstance1 {
     @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
-    inline given derivedPosByteEq[F[*]: CatsEq, G[*]: CatsEq](using eqActual: G[Byte]): F[PosByte] = {
+    given derivedPosByteEq[F[*]: CatsEq, G[*]: CatsEq](using eqActual: G[Byte]): F[PosByte] = {
       internalDef.contraCoercible[cats.Eq, PosByte, Byte, cats.Contravariant](eqActual.asInstanceOf[cats.Eq[Byte]])
     }.asInstanceOf[F[PosByte]] // scalafix:ok DisableSyntax.asInstanceOf
   }
   private[types] trait PosByteTypeClassInstance1 extends PosByteTypeClassInstance2 {
     @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
-    inline given derivedPosByteHash[F[*]: CatsHash, G[*]: CatsHash](using hashActual: G[Byte]): F[PosByte] = {
+    given derivedPosByteHash[F[*]: CatsHash, G[*]: CatsHash](using hashActual: G[Byte]): F[PosByte] = {
       internalDef.contraCoercible[cats.Hash, PosByte, Byte, cats.Contravariant](hashActual.asInstanceOf[cats.Hash[Byte]])
     }.asInstanceOf[F[PosByte]] // scalafix:ok DisableSyntax.asInstanceOf
   }
   private[types] trait PosByteTypeClassInstance2 extends OrphanCats, OrphanCatsKernel {
     @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
-    inline given derivedPosByteShow[F[*]: CatsShow, G[*]: CatsShow](using showActual: G[Byte]): F[PosByte] = {
+    given derivedPosByteShow[F[*]: CatsShow, G[*]: CatsShow](using showActual: G[Byte]): F[PosByte] = {
       internalDef.contraCoercible[cats.Show, PosByte, Byte, cats.Contravariant](showActual.asInstanceOf[cats.Show[Byte]])
     }.asInstanceOf[F[PosByte]] // scalafix:ok DisableSyntax.asInstanceOf
   }
@@ -580,19 +580,19 @@ object numeric {
   }
   private[types] trait NonPosByteTypeClassInstances extends NonPosByteTypeClassInstance1 {
     @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
-    inline given derivedNonPosByteEq[F[*]: CatsEq, G[*]: CatsEq](using eqActual: G[Byte]): F[NonPosByte] = {
+    given derivedNonPosByteEq[F[*]: CatsEq, G[*]: CatsEq](using eqActual: G[Byte]): F[NonPosByte] = {
       internalDef.contraCoercible[cats.Eq, NonPosByte, Byte, cats.Contravariant](eqActual.asInstanceOf[cats.Eq[Byte]])
     }.asInstanceOf[F[NonPosByte]] // scalafix:ok DisableSyntax.asInstanceOf
   }
   private[types] trait NonPosByteTypeClassInstance1 extends NonPosByteTypeClassInstance2 {
     @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
-    inline given derivedNonPosByteHash[F[*]: CatsHash, G[*]: CatsHash](using hashActual: G[Byte]): F[NonPosByte] = {
+    given derivedNonPosByteHash[F[*]: CatsHash, G[*]: CatsHash](using hashActual: G[Byte]): F[NonPosByte] = {
       internalDef.contraCoercible[cats.Hash, NonPosByte, Byte, cats.Contravariant](hashActual.asInstanceOf[cats.Hash[Byte]])
     }.asInstanceOf[F[NonPosByte]] // scalafix:ok DisableSyntax.asInstanceOf
   }
   private[types] trait NonPosByteTypeClassInstance2 extends OrphanCats, OrphanCatsKernel {
     @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
-    inline given derivedNonPosByteShow[F[*]: CatsShow, G[*]: CatsShow](using showActual: G[Byte]): F[NonPosByte] = {
+    given derivedNonPosByteShow[F[*]: CatsShow, G[*]: CatsShow](using showActual: G[Byte]): F[NonPosByte] = {
       internalDef.contraCoercible[cats.Show, NonPosByte, Byte, cats.Contravariant](showActual.asInstanceOf[cats.Show[Byte]])
     }.asInstanceOf[F[NonPosByte]] // scalafix:ok DisableSyntax.asInstanceOf
   }
@@ -609,19 +609,19 @@ object numeric {
   }
   private[types] trait NegFloatTypeClassInstances extends NegFloatTypeClassInstance1 {
     @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
-    inline given derivedNegFloatEq[F[*]: CatsEq, G[*]: CatsEq](using eqActual: G[Float]): F[NegFloat] = {
+    given derivedNegFloatEq[F[*]: CatsEq, G[*]: CatsEq](using eqActual: G[Float]): F[NegFloat] = {
       internalDef.contraCoercible[cats.Eq, NegFloat, Float, cats.Contravariant](eqActual.asInstanceOf[cats.Eq[Float]])
     }.asInstanceOf[F[NegFloat]] // scalafix:ok DisableSyntax.asInstanceOf
   }
   private[types] trait NegFloatTypeClassInstance1 extends NegFloatTypeClassInstance2 {
     @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
-    inline given derivedNegFloatHash[F[*]: CatsHash, G[*]: CatsHash](using hashActual: G[Float]): F[NegFloat] = {
+    given derivedNegFloatHash[F[*]: CatsHash, G[*]: CatsHash](using hashActual: G[Float]): F[NegFloat] = {
       internalDef.contraCoercible[cats.Hash, NegFloat, Float, cats.Contravariant](hashActual.asInstanceOf[cats.Hash[Float]])
     }.asInstanceOf[F[NegFloat]] // scalafix:ok DisableSyntax.asInstanceOf
   }
   private[types] trait NegFloatTypeClassInstance2 extends OrphanCats, OrphanCatsKernel {
     @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
-    inline given derivedNegFloatShow[F[*]: CatsShow, G[*]: CatsShow](using showActual: G[Float]): F[NegFloat] = {
+    given derivedNegFloatShow[F[*]: CatsShow, G[*]: CatsShow](using showActual: G[Float]): F[NegFloat] = {
       internalDef.contraCoercible[cats.Show, NegFloat, Float, cats.Contravariant](showActual.asInstanceOf[cats.Show[Float]])
     }.asInstanceOf[F[NegFloat]] // scalafix:ok DisableSyntax.asInstanceOf
   }
@@ -638,19 +638,19 @@ object numeric {
   }
   private[types] trait NonNegFloatTypeClassInstances extends NonNegFloatTypeClassInstance1 {
     @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
-    inline given derivedNonNegFloatEq[F[*]: CatsEq, G[*]: CatsEq](using eqActual: G[Float]): F[NonNegFloat] = {
+    given derivedNonNegFloatEq[F[*]: CatsEq, G[*]: CatsEq](using eqActual: G[Float]): F[NonNegFloat] = {
       internalDef.contraCoercible[cats.Eq, NonNegFloat, Float, cats.Contravariant](eqActual.asInstanceOf[cats.Eq[Float]])
     }.asInstanceOf[F[NonNegFloat]] // scalafix:ok DisableSyntax.asInstanceOf
   }
   private[types] trait NonNegFloatTypeClassInstance1 extends NonNegFloatTypeClassInstance2 {
     @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
-    inline given derivedNonNegFloatHash[F[*]: CatsHash, G[*]: CatsHash](using hashActual: G[Float]): F[NonNegFloat] = {
+    given derivedNonNegFloatHash[F[*]: CatsHash, G[*]: CatsHash](using hashActual: G[Float]): F[NonNegFloat] = {
       internalDef.contraCoercible[cats.Hash, NonNegFloat, Float, cats.Contravariant](hashActual.asInstanceOf[cats.Hash[Float]])
     }.asInstanceOf[F[NonNegFloat]] // scalafix:ok DisableSyntax.asInstanceOf
   }
   private[types] trait NonNegFloatTypeClassInstance2 extends OrphanCats, OrphanCatsKernel {
     @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
-    inline given derivedNonNegFloatShow[F[*]: CatsShow, G[*]: CatsShow](using showActual: G[Float]): F[NonNegFloat] = {
+    given derivedNonNegFloatShow[F[*]: CatsShow, G[*]: CatsShow](using showActual: G[Float]): F[NonNegFloat] = {
       internalDef.contraCoercible[cats.Show, NonNegFloat, Float, cats.Contravariant](showActual.asInstanceOf[cats.Show[Float]])
     }.asInstanceOf[F[NonNegFloat]] // scalafix:ok DisableSyntax.asInstanceOf
   }
@@ -667,19 +667,19 @@ object numeric {
   }
   private[types] trait PosFloatTypeClassInstances extends PosFloatTypeClassInstance1 {
     @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
-    inline given derivedPosFloatEq[F[*]: CatsEq, G[*]: CatsEq](using eqActual: G[Float]): F[PosFloat] = {
+    given derivedPosFloatEq[F[*]: CatsEq, G[*]: CatsEq](using eqActual: G[Float]): F[PosFloat] = {
       internalDef.contraCoercible[cats.Eq, PosFloat, Float, cats.Contravariant](eqActual.asInstanceOf[cats.Eq[Float]])
     }.asInstanceOf[F[PosFloat]] // scalafix:ok DisableSyntax.asInstanceOf
   }
   private[types] trait PosFloatTypeClassInstance1 extends PosFloatTypeClassInstance2 {
     @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
-    inline given derivedPosFloatHash[F[*]: CatsHash, G[*]: CatsHash](using hashActual: G[Float]): F[PosFloat] = {
+    given derivedPosFloatHash[F[*]: CatsHash, G[*]: CatsHash](using hashActual: G[Float]): F[PosFloat] = {
       internalDef.contraCoercible[cats.Hash, PosFloat, Float, cats.Contravariant](hashActual.asInstanceOf[cats.Hash[Float]])
     }.asInstanceOf[F[PosFloat]] // scalafix:ok DisableSyntax.asInstanceOf
   }
   private[types] trait PosFloatTypeClassInstance2 extends OrphanCats, OrphanCatsKernel {
     @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
-    inline given derivedPosFloatShow[F[*]: CatsShow, G[*]: CatsShow](using showActual: G[Float]): F[PosFloat] = {
+    given derivedPosFloatShow[F[*]: CatsShow, G[*]: CatsShow](using showActual: G[Float]): F[PosFloat] = {
       internalDef.contraCoercible[cats.Show, PosFloat, Float, cats.Contravariant](showActual.asInstanceOf[cats.Show[Float]])
     }.asInstanceOf[F[PosFloat]] // scalafix:ok DisableSyntax.asInstanceOf
   }
@@ -696,19 +696,19 @@ object numeric {
   }
   private[types] trait NonPosFloatTypeClassInstances extends NonPosFloatTypeClassInstance1 {
     @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
-    inline given derivedNonPosFloatEq[F[*]: CatsEq, G[*]: CatsEq](using eqActual: G[Float]): F[NonPosFloat] = {
+    given derivedNonPosFloatEq[F[*]: CatsEq, G[*]: CatsEq](using eqActual: G[Float]): F[NonPosFloat] = {
       internalDef.contraCoercible[cats.Eq, NonPosFloat, Float, cats.Contravariant](eqActual.asInstanceOf[cats.Eq[Float]])
     }.asInstanceOf[F[NonPosFloat]] // scalafix:ok DisableSyntax.asInstanceOf
   }
   private[types] trait NonPosFloatTypeClassInstance1 extends NonPosFloatTypeClassInstance2 {
     @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
-    inline given derivedNonPosFloatHash[F[*]: CatsHash, G[*]: CatsHash](using hashActual: G[Float]): F[NonPosFloat] = {
+    given derivedNonPosFloatHash[F[*]: CatsHash, G[*]: CatsHash](using hashActual: G[Float]): F[NonPosFloat] = {
       internalDef.contraCoercible[cats.Hash, NonPosFloat, Float, cats.Contravariant](hashActual.asInstanceOf[cats.Hash[Float]])
     }.asInstanceOf[F[NonPosFloat]] // scalafix:ok DisableSyntax.asInstanceOf
   }
   private[types] trait NonPosFloatTypeClassInstance2 extends OrphanCats, OrphanCatsKernel {
     @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
-    inline given derivedNonPosFloatShow[F[*]: CatsShow, G[*]: CatsShow](using showActual: G[Float]): F[NonPosFloat] = {
+    given derivedNonPosFloatShow[F[*]: CatsShow, G[*]: CatsShow](using showActual: G[Float]): F[NonPosFloat] = {
       internalDef.contraCoercible[cats.Show, NonPosFloat, Float, cats.Contravariant](showActual.asInstanceOf[cats.Show[Float]])
     }.asInstanceOf[F[NonPosFloat]] // scalafix:ok DisableSyntax.asInstanceOf
   }
@@ -725,19 +725,19 @@ object numeric {
   }
   private[types] trait NegDoubleTypeClassInstances extends NegDoubleTypeClassInstance1 {
     @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
-    inline given derivedNegDoubleEq[F[*]: CatsEq, G[*]: CatsEq](using eqActual: G[Double]): F[NegDouble] = {
+    given derivedNegDoubleEq[F[*]: CatsEq, G[*]: CatsEq](using eqActual: G[Double]): F[NegDouble] = {
       internalDef.contraCoercible[cats.Eq, NegDouble, Double, cats.Contravariant](eqActual.asInstanceOf[cats.Eq[Double]])
     }.asInstanceOf[F[NegDouble]] // scalafix:ok DisableSyntax.asInstanceOf
   }
   private[types] trait NegDoubleTypeClassInstance1 extends NegDoubleTypeClassInstance2 {
     @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
-    inline given derivedNegDoubleHash[F[*]: CatsHash, G[*]: CatsHash](using hashActual: G[Double]): F[NegDouble] = {
+    given derivedNegDoubleHash[F[*]: CatsHash, G[*]: CatsHash](using hashActual: G[Double]): F[NegDouble] = {
       internalDef.contraCoercible[cats.Hash, NegDouble, Double, cats.Contravariant](hashActual.asInstanceOf[cats.Hash[Double]])
     }.asInstanceOf[F[NegDouble]] // scalafix:ok DisableSyntax.asInstanceOf
   }
   private[types] trait NegDoubleTypeClassInstance2 extends OrphanCats, OrphanCatsKernel {
     @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
-    inline given derivedNegDoubleShow[F[*]: CatsShow, G[*]: CatsShow](using showActual: G[Double]): F[NegDouble] = {
+    given derivedNegDoubleShow[F[*]: CatsShow, G[*]: CatsShow](using showActual: G[Double]): F[NegDouble] = {
       internalDef.contraCoercible[cats.Show, NegDouble, Double, cats.Contravariant](showActual.asInstanceOf[cats.Show[Double]])
     }.asInstanceOf[F[NegDouble]] // scalafix:ok DisableSyntax.asInstanceOf
   }
@@ -754,19 +754,19 @@ object numeric {
   }
   private[types] trait NonNegDoubleTypeClassInstances extends NonNegDoubleTypeClassInstance1 {
     @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
-    inline given derivedNonNegDoubleEq[F[*]: CatsEq, G[*]: CatsEq](using eqActual: G[Double]): F[NonNegDouble] = {
+    given derivedNonNegDoubleEq[F[*]: CatsEq, G[*]: CatsEq](using eqActual: G[Double]): F[NonNegDouble] = {
       internalDef.contraCoercible[cats.Eq, NonNegDouble, Double, cats.Contravariant](eqActual.asInstanceOf[cats.Eq[Double]])
     }.asInstanceOf[F[NonNegDouble]] // scalafix:ok DisableSyntax.asInstanceOf
   }
   private[types] trait NonNegDoubleTypeClassInstance1 extends NonNegDoubleTypeClassInstance2 {
     @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
-    inline given derivedNonNegDoubleHash[F[*]: CatsHash, G[*]: CatsHash](using hashActual: G[Double]): F[NonNegDouble] = {
+    given derivedNonNegDoubleHash[F[*]: CatsHash, G[*]: CatsHash](using hashActual: G[Double]): F[NonNegDouble] = {
       internalDef.contraCoercible[cats.Hash, NonNegDouble, Double, cats.Contravariant](hashActual.asInstanceOf[cats.Hash[Double]])
     }.asInstanceOf[F[NonNegDouble]] // scalafix:ok DisableSyntax.asInstanceOf
   }
   private[types] trait NonNegDoubleTypeClassInstance2 extends OrphanCats, OrphanCatsKernel {
     @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
-    inline given derivedNonNegDoubleShow[F[*]: CatsShow, G[*]: CatsShow](using showActual: G[Double]): F[NonNegDouble] = {
+    given derivedNonNegDoubleShow[F[*]: CatsShow, G[*]: CatsShow](using showActual: G[Double]): F[NonNegDouble] = {
       internalDef.contraCoercible[cats.Show, NonNegDouble, Double, cats.Contravariant](showActual.asInstanceOf[cats.Show[Double]])
     }.asInstanceOf[F[NonNegDouble]] // scalafix:ok DisableSyntax.asInstanceOf
   }
@@ -783,19 +783,19 @@ object numeric {
   }
   private[types] trait PosDoubleTypeClassInstances extends PosDoubleTypeClassInstance1 {
     @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
-    inline given derivedPosDoubleEq[F[*]: CatsEq, G[*]: CatsEq](using eqActual: G[Double]): F[PosDouble] = {
+    given derivedPosDoubleEq[F[*]: CatsEq, G[*]: CatsEq](using eqActual: G[Double]): F[PosDouble] = {
       internalDef.contraCoercible[cats.Eq, PosDouble, Double, cats.Contravariant](eqActual.asInstanceOf[cats.Eq[Double]])
     }.asInstanceOf[F[PosDouble]] // scalafix:ok DisableSyntax.asInstanceOf
   }
   private[types] trait PosDoubleTypeClassInstance1 extends PosDoubleTypeClassInstance2 {
     @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
-    inline given derivedPosDoubleHash[F[*]: CatsHash, G[*]: CatsHash](using hashActual: G[Double]): F[PosDouble] = {
+    given derivedPosDoubleHash[F[*]: CatsHash, G[*]: CatsHash](using hashActual: G[Double]): F[PosDouble] = {
       internalDef.contraCoercible[cats.Hash, PosDouble, Double, cats.Contravariant](hashActual.asInstanceOf[cats.Hash[Double]])
     }.asInstanceOf[F[PosDouble]] // scalafix:ok DisableSyntax.asInstanceOf
   }
   private[types] trait PosDoubleTypeClassInstance2 extends OrphanCats, OrphanCatsKernel {
     @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
-    inline given derivedPosDoubleShow[F[*]: CatsShow, G[*]: CatsShow](using showActual: G[Double]): F[PosDouble] = {
+    given derivedPosDoubleShow[F[*]: CatsShow, G[*]: CatsShow](using showActual: G[Double]): F[PosDouble] = {
       internalDef.contraCoercible[cats.Show, PosDouble, Double, cats.Contravariant](showActual.asInstanceOf[cats.Show[Double]])
     }.asInstanceOf[F[PosDouble]] // scalafix:ok DisableSyntax.asInstanceOf
   }
@@ -812,19 +812,19 @@ object numeric {
   }
   private[types] trait NonPosDoubleTypeClassInstances extends NonPosDoubleTypeClassInstance1 {
     @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
-    inline given derivedNonPosDoubleEq[F[*]: CatsEq, G[*]: CatsEq](using eqActual: G[Double]): F[NonPosDouble] = {
+    given derivedNonPosDoubleEq[F[*]: CatsEq, G[*]: CatsEq](using eqActual: G[Double]): F[NonPosDouble] = {
       internalDef.contraCoercible[cats.Eq, NonPosDouble, Double, cats.Contravariant](eqActual.asInstanceOf[cats.Eq[Double]])
     }.asInstanceOf[F[NonPosDouble]] // scalafix:ok DisableSyntax.asInstanceOf
   }
   private[types] trait NonPosDoubleTypeClassInstance1 extends NonPosDoubleTypeClassInstance2 {
     @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
-    inline given derivedNonPosDoubleHash[F[*]: CatsHash, G[*]: CatsHash](using hashActual: G[Double]): F[NonPosDouble] = {
+    given derivedNonPosDoubleHash[F[*]: CatsHash, G[*]: CatsHash](using hashActual: G[Double]): F[NonPosDouble] = {
       internalDef.contraCoercible[cats.Hash, NonPosDouble, Double, cats.Contravariant](hashActual.asInstanceOf[cats.Hash[Double]])
     }.asInstanceOf[F[NonPosDouble]] // scalafix:ok DisableSyntax.asInstanceOf
   }
   private[types] trait NonPosDoubleTypeClassInstance2 extends OrphanCats, OrphanCatsKernel {
     @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
-    inline given derivedNonPosDoubleShow[F[*]: CatsShow, G[*]: CatsShow](using showActual: G[Double]): F[NonPosDouble] = {
+    given derivedNonPosDoubleShow[F[*]: CatsShow, G[*]: CatsShow](using showActual: G[Double]): F[NonPosDouble] = {
       internalDef.contraCoercible[cats.Show, NonPosDouble, Double, cats.Contravariant](showActual.asInstanceOf[cats.Show[Double]])
     }.asInstanceOf[F[NonPosDouble]] // scalafix:ok DisableSyntax.asInstanceOf
   }
@@ -855,19 +855,19 @@ object numeric {
   }
   private[types] trait NegBigIntTypeClassInstances extends NegBigIntTypeClassInstance1 {
     @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
-    inline given derivedNegBigIntEq[F[*]: CatsEq, G[*]: CatsEq](using eqActual: G[BigInt]): F[NegBigInt] = {
+    given derivedNegBigIntEq[F[*]: CatsEq, G[*]: CatsEq](using eqActual: G[BigInt]): F[NegBigInt] = {
       internalDef.contraCoercible[cats.Eq, NegBigInt, BigInt, cats.Contravariant](eqActual.asInstanceOf[cats.Eq[BigInt]])
     }.asInstanceOf[F[NegBigInt]] // scalafix:ok DisableSyntax.asInstanceOf
   }
   private[types] trait NegBigIntTypeClassInstance1 extends NegBigIntTypeClassInstance2 {
     @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
-    inline given derivedNegBigIntHash[F[*]: CatsHash, G[*]: CatsHash](using hashActual: G[BigInt]): F[NegBigInt] = {
+    given derivedNegBigIntHash[F[*]: CatsHash, G[*]: CatsHash](using hashActual: G[BigInt]): F[NegBigInt] = {
       internalDef.contraCoercible[cats.Hash, NegBigInt, BigInt, cats.Contravariant](hashActual.asInstanceOf[cats.Hash[BigInt]])
     }.asInstanceOf[F[NegBigInt]] // scalafix:ok DisableSyntax.asInstanceOf
   }
   private[types] trait NegBigIntTypeClassInstance2 extends OrphanCats, OrphanCatsKernel {
     @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
-    inline given derivedNegBigIntShow[F[*]: CatsShow, G[*]: CatsShow](using showActual: G[BigInt]): F[NegBigInt] = {
+    given derivedNegBigIntShow[F[*]: CatsShow, G[*]: CatsShow](using showActual: G[BigInt]): F[NegBigInt] = {
       internalDef.contraCoercible[cats.Show, NegBigInt, BigInt, cats.Contravariant](showActual.asInstanceOf[cats.Show[BigInt]])
     }.asInstanceOf[F[NegBigInt]] // scalafix:ok DisableSyntax.asInstanceOf
   }
@@ -892,19 +892,19 @@ object numeric {
   }
   private[types] trait NonNegBigIntTypeClassInstances extends NonNegBigIntTypeClassInstance1 {
     @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
-    inline given derivedNonNegBigIntEq[F[*]: CatsEq, G[*]: CatsEq](using eqActual: G[BigInt]): F[NonNegBigInt] = {
+    given derivedNonNegBigIntEq[F[*]: CatsEq, G[*]: CatsEq](using eqActual: G[BigInt]): F[NonNegBigInt] = {
       internalDef.contraCoercible[cats.Eq, NonNegBigInt, BigInt, cats.Contravariant](eqActual.asInstanceOf[cats.Eq[BigInt]])
     }.asInstanceOf[F[NonNegBigInt]] // scalafix:ok DisableSyntax.asInstanceOf
   }
   private[types] trait NonNegBigIntTypeClassInstance1 extends NonNegBigIntTypeClassInstance2 {
     @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
-    inline given derivedNonNegBigIntHash[F[*]: CatsHash, G[*]: CatsHash](using hashActual: G[BigInt]): F[NonNegBigInt] = {
+    given derivedNonNegBigIntHash[F[*]: CatsHash, G[*]: CatsHash](using hashActual: G[BigInt]): F[NonNegBigInt] = {
       internalDef.contraCoercible[cats.Hash, NonNegBigInt, BigInt, cats.Contravariant](hashActual.asInstanceOf[cats.Hash[BigInt]])
     }.asInstanceOf[F[NonNegBigInt]] // scalafix:ok DisableSyntax.asInstanceOf
   }
   private[types] trait NonNegBigIntTypeClassInstance2 extends OrphanCats, OrphanCatsKernel {
     @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
-    inline given derivedNonNegBigIntShow[F[*]: CatsShow, G[*]: CatsShow](using showActual: G[BigInt]): F[NonNegBigInt] = {
+    given derivedNonNegBigIntShow[F[*]: CatsShow, G[*]: CatsShow](using showActual: G[BigInt]): F[NonNegBigInt] = {
       internalDef.contraCoercible[cats.Show, NonNegBigInt, BigInt, cats.Contravariant](showActual.asInstanceOf[cats.Show[BigInt]])
     }.asInstanceOf[F[NonNegBigInt]] // scalafix:ok DisableSyntax.asInstanceOf
   }
@@ -929,19 +929,19 @@ object numeric {
   }
   private[types] trait PosBigIntTypeClassInstances extends PosBigIntTypeClassInstance1 {
     @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
-    inline given derivedPosBigIntEq[F[*]: CatsEq, G[*]: CatsEq](using eqActual: G[BigInt]): F[PosBigInt] = {
+    given derivedPosBigIntEq[F[*]: CatsEq, G[*]: CatsEq](using eqActual: G[BigInt]): F[PosBigInt] = {
       internalDef.contraCoercible[cats.Eq, PosBigInt, BigInt, cats.Contravariant](eqActual.asInstanceOf[cats.Eq[BigInt]])
     }.asInstanceOf[F[PosBigInt]] // scalafix:ok DisableSyntax.asInstanceOf
   }
   private[types] trait PosBigIntTypeClassInstance1 extends PosBigIntTypeClassInstance2 {
     @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
-    inline given derivedPosBigIntHash[F[*]: CatsHash, G[*]: CatsHash](using hashActual: G[BigInt]): F[PosBigInt] = {
+    given derivedPosBigIntHash[F[*]: CatsHash, G[*]: CatsHash](using hashActual: G[BigInt]): F[PosBigInt] = {
       internalDef.contraCoercible[cats.Hash, PosBigInt, BigInt, cats.Contravariant](hashActual.asInstanceOf[cats.Hash[BigInt]])
     }.asInstanceOf[F[PosBigInt]] // scalafix:ok DisableSyntax.asInstanceOf
   }
   private[types] trait PosBigIntTypeClassInstance2 extends OrphanCats, OrphanCatsKernel {
     @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
-    inline given derivedPosBigIntShow[F[*]: CatsShow, G[*]: CatsShow](using showActual: G[BigInt]): F[PosBigInt] = {
+    given derivedPosBigIntShow[F[*]: CatsShow, G[*]: CatsShow](using showActual: G[BigInt]): F[PosBigInt] = {
       internalDef.contraCoercible[cats.Show, PosBigInt, BigInt, cats.Contravariant](showActual.asInstanceOf[cats.Show[BigInt]])
     }.asInstanceOf[F[PosBigInt]] // scalafix:ok DisableSyntax.asInstanceOf
   }
@@ -966,19 +966,19 @@ object numeric {
   }
   private[types] trait NonPosBigIntTypeClassInstances extends NonPosBigIntTypeClassInstance1 {
     @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
-    inline given derivedNonPosBigIntEq[F[*]: CatsEq, G[*]: CatsEq](using eqActual: G[BigInt]): F[NonPosBigInt] = {
+    given derivedNonPosBigIntEq[F[*]: CatsEq, G[*]: CatsEq](using eqActual: G[BigInt]): F[NonPosBigInt] = {
       internalDef.contraCoercible[cats.Eq, NonPosBigInt, BigInt, cats.Contravariant](eqActual.asInstanceOf[cats.Eq[BigInt]])
     }.asInstanceOf[F[NonPosBigInt]] // scalafix:ok DisableSyntax.asInstanceOf
   }
   private[types] trait NonPosBigIntTypeClassInstance1 extends NonPosBigIntTypeClassInstance2 {
     @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
-    inline given derivedNonPosBigIntHash[F[*]: CatsHash, G[*]: CatsHash](using hashActual: G[BigInt]): F[NonPosBigInt] = {
+    given derivedNonPosBigIntHash[F[*]: CatsHash, G[*]: CatsHash](using hashActual: G[BigInt]): F[NonPosBigInt] = {
       internalDef.contraCoercible[cats.Hash, NonPosBigInt, BigInt, cats.Contravariant](hashActual.asInstanceOf[cats.Hash[BigInt]])
     }.asInstanceOf[F[NonPosBigInt]] // scalafix:ok DisableSyntax.asInstanceOf
   }
   private[types] trait NonPosBigIntTypeClassInstance2 extends OrphanCats, OrphanCatsKernel {
     @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
-    inline given derivedNonPosBigIntShow[F[*]: CatsShow, G[*]: CatsShow](using showActual: G[BigInt]): F[NonPosBigInt] = {
+    given derivedNonPosBigIntShow[F[*]: CatsShow, G[*]: CatsShow](using showActual: G[BigInt]): F[NonPosBigInt] = {
       internalDef.contraCoercible[cats.Show, NonPosBigInt, BigInt, cats.Contravariant](showActual.asInstanceOf[cats.Show[BigInt]])
     }.asInstanceOf[F[NonPosBigInt]] // scalafix:ok DisableSyntax.asInstanceOf
   }
@@ -1007,19 +1007,19 @@ object numeric {
   }
   private[types] trait NegBigDecimalTypeClassInstances extends NegBigDecimalTypeClassInstance1 {
     @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
-    inline given derivedNegBigDecimalEq[F[*]: CatsEq, G[*]: CatsEq](using eqActual: G[BigDecimal]): F[NegBigDecimal] = {
+    given derivedNegBigDecimalEq[F[*]: CatsEq, G[*]: CatsEq](using eqActual: G[BigDecimal]): F[NegBigDecimal] = {
       internalDef.contraCoercible[cats.Eq, NegBigDecimal, BigDecimal, cats.Contravariant](eqActual.asInstanceOf[cats.Eq[BigDecimal]])
     }.asInstanceOf[F[NegBigDecimal]] // scalafix:ok DisableSyntax.asInstanceOf
   }
   private[types] trait NegBigDecimalTypeClassInstance1 extends NegBigDecimalTypeClassInstance2 {
     @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
-    inline given derivedNegBigDecimalHash[F[*]: CatsHash, G[*]: CatsHash](using hashActual: G[BigDecimal]): F[NegBigDecimal] = {
+    given derivedNegBigDecimalHash[F[*]: CatsHash, G[*]: CatsHash](using hashActual: G[BigDecimal]): F[NegBigDecimal] = {
       internalDef.contraCoercible[cats.Hash, NegBigDecimal, BigDecimal, cats.Contravariant](hashActual.asInstanceOf[cats.Hash[BigDecimal]])
     }.asInstanceOf[F[NegBigDecimal]] // scalafix:ok DisableSyntax.asInstanceOf
   }
   private[types] trait NegBigDecimalTypeClassInstance2 extends OrphanCats, OrphanCatsKernel {
     @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
-    inline given derivedNegBigDecimalShow[F[*]: CatsShow, G[*]: CatsShow](using showActual: G[BigDecimal]): F[NegBigDecimal] = {
+    given derivedNegBigDecimalShow[F[*]: CatsShow, G[*]: CatsShow](using showActual: G[BigDecimal]): F[NegBigDecimal] = {
       internalDef.contraCoercible[cats.Show, NegBigDecimal, BigDecimal, cats.Contravariant](showActual.asInstanceOf[cats.Show[BigDecimal]])
     }.asInstanceOf[F[NegBigDecimal]] // scalafix:ok DisableSyntax.asInstanceOf
   }
@@ -1048,13 +1048,13 @@ object numeric {
   }
   private[types] trait NonNegBigDecimalTypeClassInstances extends NonNegBigDecimalTypeClassInstance1 {
     @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
-    inline given derivedNonNegBigDecimalEq[F[*]: CatsEq, G[*]: CatsEq](using eqActual: G[BigDecimal]): F[NonNegBigDecimal] = {
+    given derivedNonNegBigDecimalEq[F[*]: CatsEq, G[*]: CatsEq](using eqActual: G[BigDecimal]): F[NonNegBigDecimal] = {
       internalDef.contraCoercible[cats.Eq, NonNegBigDecimal, BigDecimal, cats.Contravariant](eqActual.asInstanceOf[cats.Eq[BigDecimal]])
     }.asInstanceOf[F[NonNegBigDecimal]] // scalafix:ok DisableSyntax.asInstanceOf
   }
   private[types] trait NonNegBigDecimalTypeClassInstance1 extends NonNegBigDecimalTypeClassInstance2 {
     @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
-    inline given derivedNonNegBigDecimalHash[F[*]: CatsHash, G[*]: CatsHash](using hashActual: G[BigDecimal]): F[NonNegBigDecimal] = {
+    given derivedNonNegBigDecimalHash[F[*]: CatsHash, G[*]: CatsHash](using hashActual: G[BigDecimal]): F[NonNegBigDecimal] = {
       internalDef.contraCoercible[cats.Hash, NonNegBigDecimal, BigDecimal, cats.Contravariant](
         hashActual.asInstanceOf[cats.Hash[BigDecimal]]
       )
@@ -1062,7 +1062,7 @@ object numeric {
   }
   private[types] trait NonNegBigDecimalTypeClassInstance2 extends OrphanCats, OrphanCatsKernel {
     @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
-    inline given derivedNonNegBigDecimalShow[F[*]: CatsShow, G[*]: CatsShow](using showActual: G[BigDecimal]): F[NonNegBigDecimal] = {
+    given derivedNonNegBigDecimalShow[F[*]: CatsShow, G[*]: CatsShow](using showActual: G[BigDecimal]): F[NonNegBigDecimal] = {
       internalDef.contraCoercible[cats.Show, NonNegBigDecimal, BigDecimal, cats.Contravariant](
         showActual.asInstanceOf[cats.Show[BigDecimal]]
       )
@@ -1093,19 +1093,19 @@ object numeric {
   }
   private[types] trait PosBigDecimalTypeClassInstances extends PosBigDecimalTypeClassInstance1 {
     @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
-    inline given derivedPosBigDecimalEq[F[*]: CatsEq, G[*]: CatsEq](using eqActual: G[BigDecimal]): F[PosBigDecimal] = {
+    given derivedPosBigDecimalEq[F[*]: CatsEq, G[*]: CatsEq](using eqActual: G[BigDecimal]): F[PosBigDecimal] = {
       internalDef.contraCoercible[cats.Eq, PosBigDecimal, BigDecimal, cats.Contravariant](eqActual.asInstanceOf[cats.Eq[BigDecimal]])
     }.asInstanceOf[F[PosBigDecimal]] // scalafix:ok DisableSyntax.asInstanceOf
   }
   private[types] trait PosBigDecimalTypeClassInstance1 extends PosBigDecimalTypeClassInstance2 {
     @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
-    inline given derivedPosBigDecimalHash[F[*]: CatsHash, G[*]: CatsHash](using hashActual: G[BigDecimal]): F[PosBigDecimal] = {
+    given derivedPosBigDecimalHash[F[*]: CatsHash, G[*]: CatsHash](using hashActual: G[BigDecimal]): F[PosBigDecimal] = {
       internalDef.contraCoercible[cats.Hash, PosBigDecimal, BigDecimal, cats.Contravariant](hashActual.asInstanceOf[cats.Hash[BigDecimal]])
     }.asInstanceOf[F[PosBigDecimal]] // scalafix:ok DisableSyntax.asInstanceOf
   }
   private[types] trait PosBigDecimalTypeClassInstance2 extends OrphanCats, OrphanCatsKernel {
     @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
-    inline given derivedPosBigDecimalShow[F[*]: CatsShow, G[*]: CatsShow](using showActual: G[BigDecimal]): F[PosBigDecimal] = {
+    given derivedPosBigDecimalShow[F[*]: CatsShow, G[*]: CatsShow](using showActual: G[BigDecimal]): F[PosBigDecimal] = {
       internalDef.contraCoercible[cats.Show, PosBigDecimal, BigDecimal, cats.Contravariant](showActual.asInstanceOf[cats.Show[BigDecimal]])
     }.asInstanceOf[F[PosBigDecimal]] // scalafix:ok DisableSyntax.asInstanceOf
   }
@@ -1134,13 +1134,13 @@ object numeric {
   }
   private[types] trait NonPosBigDecimalTypeClassInstances extends NonPosBigDecimalTypeClassInstance1 {
     @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
-    inline given derivedNonPosBigDecimalEq[F[*]: CatsEq, G[*]: CatsEq](using eqActual: G[BigDecimal]): F[NonPosBigDecimal] = {
+    given derivedNonPosBigDecimalEq[F[*]: CatsEq, G[*]: CatsEq](using eqActual: G[BigDecimal]): F[NonPosBigDecimal] = {
       internalDef.contraCoercible[cats.Eq, NonPosBigDecimal, BigDecimal, cats.Contravariant](eqActual.asInstanceOf[cats.Eq[BigDecimal]])
     }.asInstanceOf[F[NonPosBigDecimal]] // scalafix:ok DisableSyntax.asInstanceOf
   }
   private[types] trait NonPosBigDecimalTypeClassInstance1 extends NonPosBigDecimalTypeClassInstance2 {
     @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
-    inline given derivedNonPosBigDecimalHash[F[*]: CatsHash, G[*]: CatsHash](using hashActual: G[BigDecimal]): F[NonPosBigDecimal] = {
+    given derivedNonPosBigDecimalHash[F[*]: CatsHash, G[*]: CatsHash](using hashActual: G[BigDecimal]): F[NonPosBigDecimal] = {
       internalDef.contraCoercible[cats.Hash, NonPosBigDecimal, BigDecimal, cats.Contravariant](
         hashActual.asInstanceOf[cats.Hash[BigDecimal]]
       )
@@ -1148,7 +1148,7 @@ object numeric {
   }
   private[types] trait NonPosBigDecimalTypeClassInstance2 extends OrphanCats, OrphanCatsKernel {
     @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
-    inline given derivedNonPosBigDecimalShow[F[*]: CatsShow, G[*]: CatsShow](using showActual: G[BigDecimal]): F[NonPosBigDecimal] = {
+    given derivedNonPosBigDecimalShow[F[*]: CatsShow, G[*]: CatsShow](using showActual: G[BigDecimal]): F[NonPosBigDecimal] = {
       internalDef.contraCoercible[cats.Show, NonPosBigDecimal, BigDecimal, cats.Contravariant](
         showActual.asInstanceOf[cats.Show[BigDecimal]]
       )

--- a/modules/refined4s-core/shared/src/main/scala/refined4s/types/strings.scala
+++ b/modules/refined4s-core/shared/src/main/scala/refined4s/types/strings.scala
@@ -112,19 +112,19 @@ object strings {
   }
   private[types] trait NonBlankStringInstances extends NonBlankStringInstance2 {
     @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
-    inline given derivedNonBlankStringEq[F[*]: CatsEq, G[*]: CatsEq](using eqActual: G[String]): F[NonBlankString] = {
+    given derivedNonBlankStringEq[F[*]: CatsEq, G[*]: CatsEq](using eqActual: G[String]): F[NonBlankString] = {
       internalDef.contraCoercible[cats.Eq, NonBlankString, String, cats.Contravariant](eqActual.asInstanceOf[cats.Eq[String]])
     }.asInstanceOf[F[NonBlankString]] // scalafix:ok DisableSyntax.asInstanceOf
   }
   private[types] trait NonBlankStringInstance2 extends NonBlankStringInstance1 {
     @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
-    inline given derivedNonBlankStringHash[F[*]: CatsHash, G[*]: CatsHash](using hashActual: G[String]): F[NonBlankString] = {
+    given derivedNonBlankStringHash[F[*]: CatsHash, G[*]: CatsHash](using hashActual: G[String]): F[NonBlankString] = {
       internalDef.contraCoercible[cats.Hash, NonBlankString, String, cats.Contravariant](hashActual.asInstanceOf[cats.Hash[String]])
     }.asInstanceOf[F[NonBlankString]] // scalafix:ok DisableSyntax.asInstanceOf
   }
   private[types] trait NonBlankStringInstance1 extends OrphanCats, OrphanCatsKernel {
     @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
-    inline given derivedNonBlankStringShow[F[*]: CatsShow, G[*]: CatsShow](using showActual: G[String]): F[NonBlankString] = {
+    given derivedNonBlankStringShow[F[*]: CatsShow, G[*]: CatsShow](using showActual: G[String]): F[NonBlankString] = {
       internalDef.contraCoercible[cats.Show, NonBlankString, String, cats.Contravariant](showActual.asInstanceOf[cats.Show[String]])
     }.asInstanceOf[F[NonBlankString]] // scalafix:ok DisableSyntax.asInstanceOf
   }
@@ -155,21 +155,21 @@ object strings {
   }
   private[types] trait UuidInstances extends UuidInstance2 {
     @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
-    inline given derivedUuidEq[F[*]: CatsEq, G[*]: CatsEq](using eqActual: G[String]): F[Uuid] = {
+    given derivedUuidEq[F[*]: CatsEq, G[*]: CatsEq](using eqActual: G[String]): F[Uuid] = {
       internalDef.contraCoercible[cats.Eq, Uuid, String, cats.Contravariant](eqActual.asInstanceOf[cats.Eq[String]])
     }.asInstanceOf[F[Uuid]] // scalafix:ok DisableSyntax.asInstanceOf
   }
 
   private[types] trait UuidInstance2 extends UuidInstance1 {
     @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
-    inline given derivedUuidHash[F[*]: CatsHash, G[*]: CatsHash](using hashActual: G[String]): F[Uuid] = {
+    given derivedUuidHash[F[*]: CatsHash, G[*]: CatsHash](using hashActual: G[String]): F[Uuid] = {
       internalDef.contraCoercible[cats.Hash, Uuid, String, cats.Contravariant](hashActual.asInstanceOf[cats.Hash[String]])
     }.asInstanceOf[F[Uuid]] // scalafix:ok DisableSyntax.asInstanceOf
   }
 
   private[types] trait UuidInstance1 extends OrphanCats, OrphanCatsKernel {
     @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
-    inline given derivedUuidShow[F[*]: CatsShow, G[*]: CatsShow](using showActual: G[String]): F[Uuid] = {
+    given derivedUuidShow[F[*]: CatsShow, G[*]: CatsShow](using showActual: G[String]): F[Uuid] = {
       internalDef.contraCoercible[cats.Show, Uuid, String, cats.Contravariant](showActual.asInstanceOf[cats.Show[String]])
     }.asInstanceOf[F[Uuid]] // scalafix:ok DisableSyntax.asInstanceOf
   }

--- a/modules/refined4s-core/shared/src/main/scala/refined4s/types/time.scala
+++ b/modules/refined4s-core/shared/src/main/scala/refined4s/types/time.scala
@@ -46,19 +46,19 @@ object time {
   }
   private[types] trait MonthTypeClassInstances extends MonthTypeClassInstance1 {
     @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
-    inline given derivedMonthEq[F[*]: CatsEq, G[*]: CatsEq](using eqActual: G[Int]): F[Month] = {
+    given derivedMonthEq[F[*]: CatsEq, G[*]: CatsEq](using eqActual: G[Int]): F[Month] = {
       internalDef.contraCoercible[cats.Eq, Month, Int, cats.Contravariant](eqActual.asInstanceOf[cats.Eq[Int]])
     }.asInstanceOf[F[Month]] // scalafix:ok DisableSyntax.asInstanceOf
   }
   private[types] trait MonthTypeClassInstance1 extends MonthTypeClassInstance2 {
     @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
-    inline given derivedMonthHash[F[*]: CatsHash, G[*]: CatsHash](using hashActual: G[Int]): F[Month] = {
+    given derivedMonthHash[F[*]: CatsHash, G[*]: CatsHash](using hashActual: G[Int]): F[Month] = {
       internalDef.contraCoercible[cats.Hash, Month, Int, cats.Contravariant](hashActual.asInstanceOf[cats.Hash[Int]])
     }.asInstanceOf[F[Month]] // scalafix:ok DisableSyntax.asInstanceOf
   }
   private[types] trait MonthTypeClassInstance2 extends OrphanCats, OrphanCatsKernel {
     @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
-    inline given derivedMonthShow[F[*]: CatsShow, G[*]: CatsShow](using showActual: G[Int]): F[Month] = {
+    given derivedMonthShow[F[*]: CatsShow, G[*]: CatsShow](using showActual: G[Int]): F[Month] = {
       internalDef.contraCoercible[cats.Show, Month, Int, cats.Contravariant](showActual.asInstanceOf[cats.Show[Int]])
     }.asInstanceOf[F[Month]] // scalafix:ok DisableSyntax.asInstanceOf
   }
@@ -81,19 +81,19 @@ object time {
   }
   private[types] trait DayTypeClassInstances extends DayTypeClassInstance1 {
     @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
-    inline given derivedDayEq[F[*]: CatsEq, G[*]: CatsEq](using eqActual: G[Int]): F[Day] = {
+    given derivedDayEq[F[*]: CatsEq, G[*]: CatsEq](using eqActual: G[Int]): F[Day] = {
       internalDef.contraCoercible[cats.Eq, Day, Int, cats.Contravariant](eqActual.asInstanceOf[cats.Eq[Int]])
     }.asInstanceOf[F[Day]] // scalafix:ok DisableSyntax.asInstanceOf
   }
   private[types] trait DayTypeClassInstance1 extends DayTypeClassInstance2 {
     @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
-    inline given derivedDayHash[F[*]: CatsHash, G[*]: CatsHash](using hashActual: G[Int]): F[Day] = {
+    given derivedDayHash[F[*]: CatsHash, G[*]: CatsHash](using hashActual: G[Int]): F[Day] = {
       internalDef.contraCoercible[cats.Hash, Day, Int, cats.Contravariant](hashActual.asInstanceOf[cats.Hash[Int]])
     }.asInstanceOf[F[Day]] // scalafix:ok DisableSyntax.asInstanceOf
   }
   private[types] trait DayTypeClassInstance2 extends OrphanCats, OrphanCatsKernel {
     @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
-    inline given derivedDayShow[F[*]: CatsShow, G[*]: CatsShow](using showActual: G[Int]): F[Day] = {
+    given derivedDayShow[F[*]: CatsShow, G[*]: CatsShow](using showActual: G[Int]): F[Day] = {
       internalDef.contraCoercible[cats.Show, Day, Int, cats.Contravariant](showActual.asInstanceOf[cats.Show[Int]])
     }.asInstanceOf[F[Day]] // scalafix:ok DisableSyntax.asInstanceOf
   }
@@ -116,19 +116,19 @@ object time {
   }
   private[types] trait HourTypeClassInstances extends HourTypeClassInstance1 {
     @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
-    inline given derivedHourEq[F[*]: CatsEq, G[*]: CatsEq](using eqActual: G[Int]): F[Hour] = {
+    given derivedHourEq[F[*]: CatsEq, G[*]: CatsEq](using eqActual: G[Int]): F[Hour] = {
       internalDef.contraCoercible[cats.Eq, Hour, Int, cats.Contravariant](eqActual.asInstanceOf[cats.Eq[Int]])
     }.asInstanceOf[F[Hour]] // scalafix:ok DisableSyntax.asInstanceOf
   }
   private[types] trait HourTypeClassInstance1 extends HourTypeClassInstance2 {
     @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
-    inline given derivedHourHash[F[*]: CatsHash, G[*]: CatsHash](using hashActual: G[Int]): F[Hour] = {
+    given derivedHourHash[F[*]: CatsHash, G[*]: CatsHash](using hashActual: G[Int]): F[Hour] = {
       internalDef.contraCoercible[cats.Hash, Hour, Int, cats.Contravariant](hashActual.asInstanceOf[cats.Hash[Int]])
     }.asInstanceOf[F[Hour]] // scalafix:ok DisableSyntax.asInstanceOf
   }
   private[types] trait HourTypeClassInstance2 extends OrphanCats, OrphanCatsKernel {
     @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
-    inline given derivedHourShow[F[*]: CatsShow, G[*]: CatsShow](using showActual: G[Int]): F[Hour] = {
+    given derivedHourShow[F[*]: CatsShow, G[*]: CatsShow](using showActual: G[Int]): F[Hour] = {
       internalDef.contraCoercible[cats.Show, Hour, Int, cats.Contravariant](showActual.asInstanceOf[cats.Show[Int]])
     }.asInstanceOf[F[Hour]] // scalafix:ok DisableSyntax.asInstanceOf
   }
@@ -151,19 +151,19 @@ object time {
   }
   private[types] trait MinuteTypeClassInstances extends MinuteTypeClassInstance1 {
     @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
-    inline given derivedMinuteEq[F[*]: CatsEq, G[*]: CatsEq](using eqActual: G[Int]): F[Minute] = {
+    given derivedMinuteEq[F[*]: CatsEq, G[*]: CatsEq](using eqActual: G[Int]): F[Minute] = {
       internalDef.contraCoercible[cats.Eq, Minute, Int, cats.Contravariant](eqActual.asInstanceOf[cats.Eq[Int]])
     }.asInstanceOf[F[Minute]] // scalafix:ok DisableSyntax.asInstanceOf
   }
   private[types] trait MinuteTypeClassInstance1 extends MinuteTypeClassInstance2 {
     @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
-    inline given derivedMinuteHash[F[*]: CatsHash, G[*]: CatsHash](using hashActual: G[Int]): F[Minute] = {
+    given derivedMinuteHash[F[*]: CatsHash, G[*]: CatsHash](using hashActual: G[Int]): F[Minute] = {
       internalDef.contraCoercible[cats.Hash, Minute, Int, cats.Contravariant](hashActual.asInstanceOf[cats.Hash[Int]])
     }.asInstanceOf[F[Minute]] // scalafix:ok DisableSyntax.asInstanceOf
   }
   private[types] trait MinuteTypeClassInstance2 extends OrphanCats, OrphanCatsKernel {
     @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
-    inline given derivedMinuteShow[F[*]: CatsShow, G[*]: CatsShow](using showActual: G[Int]): F[Minute] = {
+    given derivedMinuteShow[F[*]: CatsShow, G[*]: CatsShow](using showActual: G[Int]): F[Minute] = {
       internalDef.contraCoercible[cats.Show, Minute, Int, cats.Contravariant](showActual.asInstanceOf[cats.Show[Int]])
     }.asInstanceOf[F[Minute]] // scalafix:ok DisableSyntax.asInstanceOf
   }
@@ -186,19 +186,19 @@ object time {
   }
   private[types] trait SecondTypeClassInstances extends SecondTypeClassInstance1 {
     @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
-    inline given derivedSecondEq[F[*]: CatsEq, G[*]: CatsEq](using eqActual: G[Int]): F[Second] = {
+    given derivedSecondEq[F[*]: CatsEq, G[*]: CatsEq](using eqActual: G[Int]): F[Second] = {
       internalDef.contraCoercible[cats.Eq, Second, Int, cats.Contravariant](eqActual.asInstanceOf[cats.Eq[Int]])
     }.asInstanceOf[F[Second]] // scalafix:ok DisableSyntax.asInstanceOf
   }
   private[types] trait SecondTypeClassInstance1 extends SecondTypeClassInstance2 {
     @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
-    inline given derivedSecondHash[F[*]: CatsHash, G[*]: CatsHash](using hashActual: G[Int]): F[Second] = {
+    given derivedSecondHash[F[*]: CatsHash, G[*]: CatsHash](using hashActual: G[Int]): F[Second] = {
       internalDef.contraCoercible[cats.Hash, Second, Int, cats.Contravariant](hashActual.asInstanceOf[cats.Hash[Int]])
     }.asInstanceOf[F[Second]] // scalafix:ok DisableSyntax.asInstanceOf
   }
   private[types] trait SecondTypeClassInstance2 extends OrphanCats, OrphanCatsKernel {
     @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
-    inline given derivedSecondShow[F[*]: CatsShow, G[*]: CatsShow](using showActual: G[Int]): F[Second] = {
+    given derivedSecondShow[F[*]: CatsShow, G[*]: CatsShow](using showActual: G[Int]): F[Second] = {
       internalDef.contraCoercible[cats.Show, Second, Int, cats.Contravariant](showActual.asInstanceOf[cats.Show[Int]])
     }.asInstanceOf[F[Second]] // scalafix:ok DisableSyntax.asInstanceOf
   }
@@ -221,19 +221,19 @@ object time {
   }
   private[types] trait MillisTypeClassInstances extends MillisTypeClassInstance1 {
     @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
-    inline given derivedMillisEq[F[*]: CatsEq, G[*]: CatsEq](using eqActual: G[Int]): F[Millis] = {
+    given derivedMillisEq[F[*]: CatsEq, G[*]: CatsEq](using eqActual: G[Int]): F[Millis] = {
       internalDef.contraCoercible[cats.Eq, Millis, Int, cats.Contravariant](eqActual.asInstanceOf[cats.Eq[Int]])
     }.asInstanceOf[F[Millis]] // scalafix:ok DisableSyntax.asInstanceOf
   }
   private[types] trait MillisTypeClassInstance1 extends MillisTypeClassInstance2 {
     @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
-    inline given derivedMillisHash[F[*]: CatsHash, G[*]: CatsHash](using hashActual: G[Int]): F[Millis] = {
+    given derivedMillisHash[F[*]: CatsHash, G[*]: CatsHash](using hashActual: G[Int]): F[Millis] = {
       internalDef.contraCoercible[cats.Hash, Millis, Int, cats.Contravariant](hashActual.asInstanceOf[cats.Hash[Int]])
     }.asInstanceOf[F[Millis]] // scalafix:ok DisableSyntax.asInstanceOf
   }
   private[types] trait MillisTypeClassInstance2 extends OrphanCats, OrphanCatsKernel {
     @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
-    inline given derivedMillisShow[F[*]: CatsShow, G[*]: CatsShow](using showActual: G[Int]): F[Millis] = {
+    given derivedMillisShow[F[*]: CatsShow, G[*]: CatsShow](using showActual: G[Int]): F[Millis] = {
       internalDef.contraCoercible[cats.Show, Millis, Int, cats.Contravariant](showActual.asInstanceOf[cats.Show[Int]])
     }.asInstanceOf[F[Millis]] // scalafix:ok DisableSyntax.asInstanceOf
   }

--- a/modules/refined4s-core/shared/src/test/scala/refined4s/CoercibleSpec.scala
+++ b/modules/refined4s-core/shared/src/test/scala/refined4s/CoercibleSpec.scala
@@ -63,7 +63,7 @@ object CoercibleSpec extends Properties {
   trait TestNewtype[A] {
     type Type
 
-    inline given unwrap: Coercible[Type, A] = Coercible.instance
+    given unwrap: Coercible[Type, A] = Coercible.instance
   }
   type TestType = TestType.Type
   object TestType extends TestNewtype[String] {

--- a/modules/refined4s-doobie-ce2/shared/src/main/scala/refined4s/modules/doobie/derivation/generic/auto.scala
+++ b/modules/refined4s-doobie-ce2/shared/src/main/scala/refined4s/modules/doobie/derivation/generic/auto.scala
@@ -9,13 +9,13 @@ import refined4s.{Coercible, RefinedCtor}
   */
 trait auto {
 
-  inline given derivedPut[A, B](using coercible: Coercible[A, B], put: Put[B]): Put[A] =
+  given derivedPut[A, B](using coercible: Coercible[A, B], put: Put[B]): Put[A] =
     put.contramap(coercible(_))
 
-  inline given derivedRefinedGet[A, B](using refinedCtor: RefinedCtor[B, A], getA: Get[A], showA: Show[A]): Get[B] =
+  given derivedRefinedGet[A, B](using refinedCtor: RefinedCtor[B, A], getA: Get[A], showA: Show[A]): Get[B] =
     getA.temap(refinedCtor.create)
 
-  inline given derivedNewtypeGet[A, B](using coercible: Coercible[A, B], getA: Get[A]): Get[B] =
+  given derivedNewtypeGet[A, B](using coercible: Coercible[A, B], getA: Get[A]): Get[B] =
     getA.map(coercible(_))
 
 }

--- a/modules/refined4s-doobie-ce2/shared/src/main/scala/refined4s/modules/doobie/derivation/types/network.scala
+++ b/modules/refined4s-doobie-ce2/shared/src/main/scala/refined4s/modules/doobie/derivation/types/network.scala
@@ -9,26 +9,26 @@ import refined4s.types.network.*
   */
 trait network {
 
-  inline given derivedUriGet: Get[Uri] = network.derivedUriGet
-  inline given derivedUriPut: Put[Uri] = network.derivedUriPut
+  given derivedUriGet: Get[Uri] = network.derivedUriGet
+  given derivedUriPut: Put[Uri] = network.derivedUriPut
 
-  inline given derivedUrlGet: Get[Url] = network.derivedUrlGet
-  inline given derivedUrlPut: Put[Url] = network.derivedUrlPut
+  given derivedUrlGet: Get[Url] = network.derivedUrlGet
+  given derivedUrlPut: Put[Url] = network.derivedUrlPut
 
-  inline given derivedPortNumberGet: Get[PortNumber] = network.derivedPortNumberGet
-  inline given derivedPortNumberPut: Put[PortNumber] = network.derivedPortNumberPut
+  given derivedPortNumberGet: Get[PortNumber] = network.derivedPortNumberGet
+  given derivedPortNumberPut: Put[PortNumber] = network.derivedPortNumberPut
 
-  inline given derivedSystemPortNumberGet: Get[SystemPortNumber] = network.derivedSystemPortNumberGet
-  inline given derivedSystemPortNumberPut: Put[SystemPortNumber] = network.derivedSystemPortNumberPut
+  given derivedSystemPortNumberGet: Get[SystemPortNumber] = network.derivedSystemPortNumberGet
+  given derivedSystemPortNumberPut: Put[SystemPortNumber] = network.derivedSystemPortNumberPut
 
-  inline given derivedNonSystemPortNumberGet: Get[NonSystemPortNumber] = network.derivedNonSystemPortNumberGet
-  inline given derivedNonSystemPortNumberPut: Put[NonSystemPortNumber] = network.derivedNonSystemPortNumberPut
+  given derivedNonSystemPortNumberGet: Get[NonSystemPortNumber] = network.derivedNonSystemPortNumberGet
+  given derivedNonSystemPortNumberPut: Put[NonSystemPortNumber] = network.derivedNonSystemPortNumberPut
 
-  inline given derivedUserPortNumberGet: Get[UserPortNumber] = network.derivedUserPortNumberGet
-  inline given derivedUserPortNumberPut: Put[UserPortNumber] = network.derivedUserPortNumberPut
+  given derivedUserPortNumberGet: Get[UserPortNumber] = network.derivedUserPortNumberGet
+  given derivedUserPortNumberPut: Put[UserPortNumber] = network.derivedUserPortNumberPut
 
-  inline given derivedDynamicPortNumberGet: Get[DynamicPortNumber] = network.derivedDynamicPortNumberGet
-  inline given derivedDynamicPortNumberPut: Put[DynamicPortNumber] = network.derivedDynamicPortNumberPut
+  given derivedDynamicPortNumberGet: Get[DynamicPortNumber] = network.derivedDynamicPortNumberGet
+  given derivedDynamicPortNumberPut: Put[DynamicPortNumber] = network.derivedDynamicPortNumberPut
 
 }
 object network {

--- a/modules/refined4s-doobie-ce2/shared/src/main/scala/refined4s/modules/doobie/derivation/types/numeric.scala
+++ b/modules/refined4s-doobie-ce2/shared/src/main/scala/refined4s/modules/doobie/derivation/types/numeric.scala
@@ -9,101 +9,101 @@ import refined4s.types.numeric.*
   */
 trait numeric {
 
-  inline given derivedNegIntGet: Get[NegInt] = numeric.derivedNegIntGet
-  inline given derivedNegIntPut: Put[NegInt] = numeric.derivedNegIntPut
+  given derivedNegIntGet: Get[NegInt] = numeric.derivedNegIntGet
+  given derivedNegIntPut: Put[NegInt] = numeric.derivedNegIntPut
 
-  inline given derivedNonNegIntGet: Get[NonNegInt] = numeric.derivedNonNegIntGet
-  inline given derivedNonNegIntPut: Put[NonNegInt] = numeric.derivedNonNegIntPut
+  given derivedNonNegIntGet: Get[NonNegInt] = numeric.derivedNonNegIntGet
+  given derivedNonNegIntPut: Put[NonNegInt] = numeric.derivedNonNegIntPut
 
-  inline given derivedPosIntGet: Get[PosInt] = numeric.derivedPosIntGet
-  inline given derivedPosIntPut: Put[PosInt] = numeric.derivedPosIntPut
+  given derivedPosIntGet: Get[PosInt] = numeric.derivedPosIntGet
+  given derivedPosIntPut: Put[PosInt] = numeric.derivedPosIntPut
 
-  inline given derivedNonPosIntGet: Get[NonPosInt] = numeric.derivedNonPosIntGet
-  inline given derivedNonPosIntPut: Put[NonPosInt] = numeric.derivedNonPosIntPut
+  given derivedNonPosIntGet: Get[NonPosInt] = numeric.derivedNonPosIntGet
+  given derivedNonPosIntPut: Put[NonPosInt] = numeric.derivedNonPosIntPut
 
-  inline given derivedNegLongGet: Get[NegLong] = numeric.derivedNegLongGet
-  inline given derivedNegLongPut: Put[NegLong] = numeric.derivedNegLongPut
+  given derivedNegLongGet: Get[NegLong] = numeric.derivedNegLongGet
+  given derivedNegLongPut: Put[NegLong] = numeric.derivedNegLongPut
 
-  inline given derivedNonNegLongGet: Get[NonNegLong] = numeric.derivedNonNegLongGet
-  inline given derivedNonNegLongPut: Put[NonNegLong] = numeric.derivedNonNegLongPut
+  given derivedNonNegLongGet: Get[NonNegLong] = numeric.derivedNonNegLongGet
+  given derivedNonNegLongPut: Put[NonNegLong] = numeric.derivedNonNegLongPut
 
-  inline given derivedPosLongGet: Get[PosLong] = numeric.derivedPosLongGet
-  inline given derivedPosLongPut: Put[PosLong] = numeric.derivedPosLongPut
+  given derivedPosLongGet: Get[PosLong] = numeric.derivedPosLongGet
+  given derivedPosLongPut: Put[PosLong] = numeric.derivedPosLongPut
 
-  inline given derivedNonPosLongGet: Get[NonPosLong] = numeric.derivedNonPosLongGet
-  inline given derivedNonPosLongPut: Put[NonPosLong] = numeric.derivedNonPosLongPut
+  given derivedNonPosLongGet: Get[NonPosLong] = numeric.derivedNonPosLongGet
+  given derivedNonPosLongPut: Put[NonPosLong] = numeric.derivedNonPosLongPut
 
-  inline given derivedNegShortGet: Get[NegShort] = numeric.derivedNegShortGet
-  inline given derivedNegShortPut: Put[NegShort] = numeric.derivedNegShortPut
+  given derivedNegShortGet: Get[NegShort] = numeric.derivedNegShortGet
+  given derivedNegShortPut: Put[NegShort] = numeric.derivedNegShortPut
 
-  inline given derivedNonNegShortGet: Get[NonNegShort] = numeric.derivedNonNegShortGet
-  inline given derivedNonNegShortPut: Put[NonNegShort] = numeric.derivedNonNegShortPut
+  given derivedNonNegShortGet: Get[NonNegShort] = numeric.derivedNonNegShortGet
+  given derivedNonNegShortPut: Put[NonNegShort] = numeric.derivedNonNegShortPut
 
-  inline given derivedPosShortGet: Get[PosShort] = numeric.derivedPosShortGet
-  inline given derivedPosShortPut: Put[PosShort] = numeric.derivedPosShortPut
+  given derivedPosShortGet: Get[PosShort] = numeric.derivedPosShortGet
+  given derivedPosShortPut: Put[PosShort] = numeric.derivedPosShortPut
 
-  inline given derivedNonPosShortGet: Get[NonPosShort] = numeric.derivedNonPosShortGet
-  inline given derivedNonPosShortPut: Put[NonPosShort] = numeric.derivedNonPosShortPut
+  given derivedNonPosShortGet: Get[NonPosShort] = numeric.derivedNonPosShortGet
+  given derivedNonPosShortPut: Put[NonPosShort] = numeric.derivedNonPosShortPut
 
-  inline given derivedNegByteGet: Get[NegByte] = numeric.derivedNegByteGet
-  inline given derivedNegBytePut: Put[NegByte] = numeric.derivedNegBytePut
+  given derivedNegByteGet: Get[NegByte] = numeric.derivedNegByteGet
+  given derivedNegBytePut: Put[NegByte] = numeric.derivedNegBytePut
 
-  inline given derivedNonNegByteGet: Get[NonNegByte] = numeric.derivedNonNegByteGet
-  inline given derivedNonNegBytePut: Put[NonNegByte] = numeric.derivedNonNegBytePut
+  given derivedNonNegByteGet: Get[NonNegByte] = numeric.derivedNonNegByteGet
+  given derivedNonNegBytePut: Put[NonNegByte] = numeric.derivedNonNegBytePut
 
-  inline given derivedPosByteGet: Get[PosByte] = numeric.derivedPosByteGet
-  inline given derivedPosBytePut: Put[PosByte] = numeric.derivedPosBytePut
+  given derivedPosByteGet: Get[PosByte] = numeric.derivedPosByteGet
+  given derivedPosBytePut: Put[PosByte] = numeric.derivedPosBytePut
 
-  inline given derivedNonPosByteGet: Get[NonPosByte] = numeric.derivedNonPosByteGet
-  inline given derivedNonPosBytePut: Put[NonPosByte] = numeric.derivedNonPosBytePut
+  given derivedNonPosByteGet: Get[NonPosByte] = numeric.derivedNonPosByteGet
+  given derivedNonPosBytePut: Put[NonPosByte] = numeric.derivedNonPosBytePut
 
-  inline given derivedNegFloatGet: Get[NegFloat] = numeric.derivedNegFloatGet
-  inline given derivedNegFloatPut: Put[NegFloat] = numeric.derivedNegFloatPut
+  given derivedNegFloatGet: Get[NegFloat] = numeric.derivedNegFloatGet
+  given derivedNegFloatPut: Put[NegFloat] = numeric.derivedNegFloatPut
 
-  inline given derivedNonNegFloatGet: Get[NonNegFloat] = numeric.derivedNonNegFloatGet
-  inline given derivedNonNegFloatPut: Put[NonNegFloat] = numeric.derivedNonNegFloatPut
+  given derivedNonNegFloatGet: Get[NonNegFloat] = numeric.derivedNonNegFloatGet
+  given derivedNonNegFloatPut: Put[NonNegFloat] = numeric.derivedNonNegFloatPut
 
-  inline given derivedPosFloatGet: Get[PosFloat] = numeric.derivedPosFloatGet
-  inline given derivedPosFloatPut: Put[PosFloat] = numeric.derivedPosFloatPut
+  given derivedPosFloatGet: Get[PosFloat] = numeric.derivedPosFloatGet
+  given derivedPosFloatPut: Put[PosFloat] = numeric.derivedPosFloatPut
 
-  inline given derivedNonPosFloatGet: Get[NonPosFloat] = numeric.derivedNonPosFloatGet
-  inline given derivedNonPosFloatPut: Put[NonPosFloat] = numeric.derivedNonPosFloatPut
+  given derivedNonPosFloatGet: Get[NonPosFloat] = numeric.derivedNonPosFloatGet
+  given derivedNonPosFloatPut: Put[NonPosFloat] = numeric.derivedNonPosFloatPut
 
-  inline given derivedNegDoubleGet: Get[NegDouble] = numeric.derivedNegDoubleGet
-  inline given derivedNegDoublePut: Put[NegDouble] = numeric.derivedNegDoublePut
+  given derivedNegDoubleGet: Get[NegDouble] = numeric.derivedNegDoubleGet
+  given derivedNegDoublePut: Put[NegDouble] = numeric.derivedNegDoublePut
 
-  inline given derivedNonNegDoubleGet: Get[NonNegDouble] = numeric.derivedNonNegDoubleGet
-  inline given derivedNonNegDoublePut: Put[NonNegDouble] = numeric.derivedNonNegDoublePut
+  given derivedNonNegDoubleGet: Get[NonNegDouble] = numeric.derivedNonNegDoubleGet
+  given derivedNonNegDoublePut: Put[NonNegDouble] = numeric.derivedNonNegDoublePut
 
-  inline given derivedPosDoubleGet: Get[PosDouble] = numeric.derivedPosDoubleGet
-  inline given derivedPosDoublePut: Put[PosDouble] = numeric.derivedPosDoublePut
+  given derivedPosDoubleGet: Get[PosDouble] = numeric.derivedPosDoubleGet
+  given derivedPosDoublePut: Put[PosDouble] = numeric.derivedPosDoublePut
 
-  inline given derivedNonPosDoubleGet: Get[NonPosDouble] = numeric.derivedNonPosDoubleGet
-  inline given derivedNonPosDoublePut: Put[NonPosDouble] = numeric.derivedNonPosDoublePut
+  given derivedNonPosDoubleGet: Get[NonPosDouble] = numeric.derivedNonPosDoubleGet
+  given derivedNonPosDoublePut: Put[NonPosDouble] = numeric.derivedNonPosDoublePut
 
-  inline given derivedNegBigIntGet: Get[NegBigInt] = numeric.derivedNegBigIntGet
-  inline given derivedNegBigIntPut: Put[NegBigInt] = numeric.derivedNegBigIntPut
+  given derivedNegBigIntGet: Get[NegBigInt] = numeric.derivedNegBigIntGet
+  given derivedNegBigIntPut: Put[NegBigInt] = numeric.derivedNegBigIntPut
 
-  inline given derivedNonNegBigIntGet: Get[NonNegBigInt] = numeric.derivedNonNegBigIntGet
-  inline given derivedNonNegBigIntPut: Put[NonNegBigInt] = numeric.derivedNonNegBigIntPut
+  given derivedNonNegBigIntGet: Get[NonNegBigInt] = numeric.derivedNonNegBigIntGet
+  given derivedNonNegBigIntPut: Put[NonNegBigInt] = numeric.derivedNonNegBigIntPut
 
-  inline given derivedPosBigIntGet: Get[PosBigInt] = numeric.derivedPosBigIntGet
-  inline given derivedPosBigIntPut: Put[PosBigInt] = numeric.derivedPosBigIntPut
+  given derivedPosBigIntGet: Get[PosBigInt] = numeric.derivedPosBigIntGet
+  given derivedPosBigIntPut: Put[PosBigInt] = numeric.derivedPosBigIntPut
 
-  inline given derivedNonPosBigIntGet: Get[NonPosBigInt] = numeric.derivedNonPosBigIntGet
-  inline given derivedNonPosBigIntPut: Put[NonPosBigInt] = numeric.derivedNonPosBigIntPut
+  given derivedNonPosBigIntGet: Get[NonPosBigInt] = numeric.derivedNonPosBigIntGet
+  given derivedNonPosBigIntPut: Put[NonPosBigInt] = numeric.derivedNonPosBigIntPut
 
-  inline given derivedNegBigDecimalGet: Get[NegBigDecimal] = numeric.derivedNegBigDecimalGet
-  inline given derivedNegBigDecimalPut: Put[NegBigDecimal] = numeric.derivedNegBigDecimalPut
+  given derivedNegBigDecimalGet: Get[NegBigDecimal] = numeric.derivedNegBigDecimalGet
+  given derivedNegBigDecimalPut: Put[NegBigDecimal] = numeric.derivedNegBigDecimalPut
 
-  inline given derivedNonNegBigDecimalGet: Get[NonNegBigDecimal] = numeric.derivedNonNegBigDecimalGet
-  inline given derivedNonNegBigDecimalPut: Put[NonNegBigDecimal] = numeric.derivedNonNegBigDecimalPut
+  given derivedNonNegBigDecimalGet: Get[NonNegBigDecimal] = numeric.derivedNonNegBigDecimalGet
+  given derivedNonNegBigDecimalPut: Put[NonNegBigDecimal] = numeric.derivedNonNegBigDecimalPut
 
-  inline given derivedPosBigDecimalGet: Get[PosBigDecimal] = numeric.derivedPosBigDecimalGet
-  inline given derivedPosBigDecimalPut: Put[PosBigDecimal] = numeric.derivedPosBigDecimalPut
+  given derivedPosBigDecimalGet: Get[PosBigDecimal] = numeric.derivedPosBigDecimalGet
+  given derivedPosBigDecimalPut: Put[PosBigDecimal] = numeric.derivedPosBigDecimalPut
 
-  inline given derivedNonPosBigDecimalGet: Get[NonPosBigDecimal] = numeric.derivedNonPosBigDecimalGet
-  inline given derivedNonPosBigDecimalPut: Put[NonPosBigDecimal] = numeric.derivedNonPosBigDecimalPut
+  given derivedNonPosBigDecimalGet: Get[NonPosBigDecimal] = numeric.derivedNonPosBigDecimalGet
+  given derivedNonPosBigDecimalPut: Put[NonPosBigDecimal] = numeric.derivedNonPosBigDecimalPut
 
 }
 object numeric {

--- a/modules/refined4s-doobie-ce2/shared/src/main/scala/refined4s/modules/doobie/derivation/types/strings.scala
+++ b/modules/refined4s-doobie-ce2/shared/src/main/scala/refined4s/modules/doobie/derivation/types/strings.scala
@@ -9,14 +9,14 @@ import refined4s.types.strings.*
   */
 trait strings {
 
-  inline given derivedNonEmptyStringGet: Get[NonEmptyString] = strings.derivedNonEmptyStringGet
-  inline given derivedNonEmptyStringPut: Put[NonEmptyString] = strings.derivedNonEmptyStringPut
+  given derivedNonEmptyStringGet: Get[NonEmptyString] = strings.derivedNonEmptyStringGet
+  given derivedNonEmptyStringPut: Put[NonEmptyString] = strings.derivedNonEmptyStringPut
 
-  inline given derivedNonBlankStringGet: Get[NonBlankString] = strings.derivedNonBlankStringGet
-  inline given derivedNonBlankStringPut: Put[NonBlankString] = strings.derivedNonBlankStringPut
+  given derivedNonBlankStringGet: Get[NonBlankString] = strings.derivedNonBlankStringGet
+  given derivedNonBlankStringPut: Put[NonBlankString] = strings.derivedNonBlankStringPut
 
-  inline given derivedUuidGet: Get[Uuid] = strings.derivedUuidGet
-  inline given derivedUuidPut: Put[Uuid] = strings.derivedUuidPut
+  given derivedUuidGet: Get[Uuid] = strings.derivedUuidGet
+  given derivedUuidPut: Put[Uuid] = strings.derivedUuidPut
 
 }
 object strings {

--- a/modules/refined4s-doobie-ce2/shared/src/main/scala/refined4s/modules/doobie/derivation/types/time.scala
+++ b/modules/refined4s-doobie-ce2/shared/src/main/scala/refined4s/modules/doobie/derivation/types/time.scala
@@ -9,23 +9,23 @@ import refined4s.types.time.*
   */
 trait time {
 
-  inline given derivedMonthGet: Get[Month] = time.derivedMonthGet
-  inline given derivedMonthPut: Put[Month] = time.derivedMonthPut
+  given derivedMonthGet: Get[Month] = time.derivedMonthGet
+  given derivedMonthPut: Put[Month] = time.derivedMonthPut
 
-  inline given derivedDayGet: Get[Day] = time.derivedDayGet
-  inline given derivedDayPut: Put[Day] = time.derivedDayPut
+  given derivedDayGet: Get[Day] = time.derivedDayGet
+  given derivedDayPut: Put[Day] = time.derivedDayPut
 
-  inline given derivedHourGet: Get[Hour] = time.derivedHourGet
-  inline given derivedHourPut: Put[Hour] = time.derivedHourPut
+  given derivedHourGet: Get[Hour] = time.derivedHourGet
+  given derivedHourPut: Put[Hour] = time.derivedHourPut
 
-  inline given derivedMinuteGet: Get[Minute] = time.derivedMinuteGet
-  inline given derivedMinutePut: Put[Minute] = time.derivedMinutePut
+  given derivedMinuteGet: Get[Minute] = time.derivedMinuteGet
+  given derivedMinutePut: Put[Minute] = time.derivedMinutePut
 
-  inline given derivedSecondGet: Get[Second] = time.derivedSecondGet
-  inline given derivedSecondPut: Put[Second] = time.derivedSecondPut
+  given derivedSecondGet: Get[Second] = time.derivedSecondGet
+  given derivedSecondPut: Put[Second] = time.derivedSecondPut
 
-  inline given derivedMillisGet: Get[Millis] = time.derivedMillisGet
-  inline given derivedMillisPut: Put[Millis] = time.derivedMillisPut
+  given derivedMillisGet: Get[Millis] = time.derivedMillisGet
+  given derivedMillisPut: Put[Millis] = time.derivedMillisPut
 
 }
 object time {

--- a/modules/refined4s-doobie-ce2/shared/src/test/scala/refined4s/modules/doobie/derivation/types/numericSpec.scala
+++ b/modules/refined4s-doobie-ce2/shared/src/test/scala/refined4s/modules/doobie/derivation/types/numericSpec.scala
@@ -3,7 +3,6 @@ package refined4s.modules.doobie.derivation.types
 import cats.effect.ContextShift
 import cats.syntax.all.*
 import doobie.syntax.all.*
-import doobie.{Get, Put}
 import extras.doobie.RunWithDb
 import extras.doobie.ce2.DbTools
 import extras.runner.ce2.RunSyncCe2

--- a/modules/refined4s-doobie-ce2/shared/src/test/scala/refined4s/modules/doobie/derivation/types/stringsSpec.scala
+++ b/modules/refined4s-doobie-ce2/shared/src/test/scala/refined4s/modules/doobie/derivation/types/stringsSpec.scala
@@ -3,7 +3,6 @@ package refined4s.modules.doobie.derivation.types
 import cats.effect.ContextShift
 import cats.syntax.all.*
 import doobie.syntax.all.*
-import doobie.{Get, Put}
 import extras.core.syntax.all.*
 import extras.doobie.RunWithDb
 import extras.doobie.ce2.DbTools

--- a/modules/refined4s-doobie-ce3/shared/src/main/scala/refined4s/modules/doobie/derivation/generic/auto.scala
+++ b/modules/refined4s-doobie-ce3/shared/src/main/scala/refined4s/modules/doobie/derivation/generic/auto.scala
@@ -9,13 +9,13 @@ import refined4s.{Coercible, RefinedCtor}
   */
 trait auto {
 
-  inline given derivedPut[A, B](using coercible: Coercible[A, B], put: Put[B]): Put[A] =
+  given derivedPut[A, B](using coercible: Coercible[A, B], put: Put[B]): Put[A] =
     put.contramap(coercible(_))
 
-  inline given derivedRefinedGet[A, B](using refinedCtor: RefinedCtor[B, A], getA: Get[A], showA: Show[A]): Get[B] =
+  given derivedRefinedGet[A, B](using refinedCtor: RefinedCtor[B, A], getA: Get[A], showA: Show[A]): Get[B] =
     getA.temap(refinedCtor.create)
 
-  inline given derivedNewtypeGet[A, B](using coercible: Coercible[A, B], getA: Get[A]): Get[B] =
+  given derivedNewtypeGet[A, B](using coercible: Coercible[A, B], getA: Get[A]): Get[B] =
     getA.map(coercible(_))
 
 }

--- a/modules/refined4s-doobie-ce3/shared/src/main/scala/refined4s/modules/doobie/derivation/types/network.scala
+++ b/modules/refined4s-doobie-ce3/shared/src/main/scala/refined4s/modules/doobie/derivation/types/network.scala
@@ -9,26 +9,26 @@ import refined4s.types.network.*
   */
 trait network {
 
-  inline given derivedUriGet: Get[Uri] = network.derivedUriGet
-  inline given derivedUriPut: Put[Uri] = network.derivedUriPut
+  given derivedUriGet: Get[Uri] = network.derivedUriGet
+  given derivedUriPut: Put[Uri] = network.derivedUriPut
 
-  inline given derivedUrlGet: Get[Url] = network.derivedUrlGet
-  inline given derivedUrlPut: Put[Url] = network.derivedUrlPut
+  given derivedUrlGet: Get[Url] = network.derivedUrlGet
+  given derivedUrlPut: Put[Url] = network.derivedUrlPut
 
-  inline given derivedPortNumberGet: Get[PortNumber] = network.derivedPortNumberGet
-  inline given derivedPortNumberPut: Put[PortNumber] = network.derivedPortNumberPut
+  given derivedPortNumberGet: Get[PortNumber] = network.derivedPortNumberGet
+  given derivedPortNumberPut: Put[PortNumber] = network.derivedPortNumberPut
 
-  inline given derivedSystemPortNumberGet: Get[SystemPortNumber] = network.derivedSystemPortNumberGet
-  inline given derivedSystemPortNumberPut: Put[SystemPortNumber] = network.derivedSystemPortNumberPut
+  given derivedSystemPortNumberGet: Get[SystemPortNumber] = network.derivedSystemPortNumberGet
+  given derivedSystemPortNumberPut: Put[SystemPortNumber] = network.derivedSystemPortNumberPut
 
-  inline given derivedNonSystemPortNumberGet: Get[NonSystemPortNumber] = network.derivedNonSystemPortNumberGet
-  inline given derivedNonSystemPortNumberPut: Put[NonSystemPortNumber] = network.derivedNonSystemPortNumberPut
+  given derivedNonSystemPortNumberGet: Get[NonSystemPortNumber] = network.derivedNonSystemPortNumberGet
+  given derivedNonSystemPortNumberPut: Put[NonSystemPortNumber] = network.derivedNonSystemPortNumberPut
 
-  inline given derivedUserPortNumberGet: Get[UserPortNumber] = network.derivedUserPortNumberGet
-  inline given derivedUserPortNumberPut: Put[UserPortNumber] = network.derivedUserPortNumberPut
+  given derivedUserPortNumberGet: Get[UserPortNumber] = network.derivedUserPortNumberGet
+  given derivedUserPortNumberPut: Put[UserPortNumber] = network.derivedUserPortNumberPut
 
-  inline given derivedDynamicPortNumberGet: Get[DynamicPortNumber] = network.derivedDynamicPortNumberGet
-  inline given derivedDynamicPortNumberPut: Put[DynamicPortNumber] = network.derivedDynamicPortNumberPut
+  given derivedDynamicPortNumberGet: Get[DynamicPortNumber] = network.derivedDynamicPortNumberGet
+  given derivedDynamicPortNumberPut: Put[DynamicPortNumber] = network.derivedDynamicPortNumberPut
 
 }
 object network {

--- a/modules/refined4s-doobie-ce3/shared/src/main/scala/refined4s/modules/doobie/derivation/types/numeric.scala
+++ b/modules/refined4s-doobie-ce3/shared/src/main/scala/refined4s/modules/doobie/derivation/types/numeric.scala
@@ -9,101 +9,101 @@ import refined4s.types.numeric.*
   */
 trait numeric {
 
-  inline given derivedNegIntGet: Get[NegInt] = numeric.derivedNegIntGet
-  inline given derivedNegIntPut: Put[NegInt] = numeric.derivedNegIntPut
+  given derivedNegIntGet: Get[NegInt] = numeric.derivedNegIntGet
+  given derivedNegIntPut: Put[NegInt] = numeric.derivedNegIntPut
 
-  inline given derivedNonNegIntGet: Get[NonNegInt] = numeric.derivedNonNegIntGet
-  inline given derivedNonNegIntPut: Put[NonNegInt] = numeric.derivedNonNegIntPut
+  given derivedNonNegIntGet: Get[NonNegInt] = numeric.derivedNonNegIntGet
+  given derivedNonNegIntPut: Put[NonNegInt] = numeric.derivedNonNegIntPut
 
-  inline given derivedPosIntGet: Get[PosInt] = numeric.derivedPosIntGet
-  inline given derivedPosIntPut: Put[PosInt] = numeric.derivedPosIntPut
+  given derivedPosIntGet: Get[PosInt] = numeric.derivedPosIntGet
+  given derivedPosIntPut: Put[PosInt] = numeric.derivedPosIntPut
 
-  inline given derivedNonPosIntGet: Get[NonPosInt] = numeric.derivedNonPosIntGet
-  inline given derivedNonPosIntPut: Put[NonPosInt] = numeric.derivedNonPosIntPut
+  given derivedNonPosIntGet: Get[NonPosInt] = numeric.derivedNonPosIntGet
+  given derivedNonPosIntPut: Put[NonPosInt] = numeric.derivedNonPosIntPut
 
-  inline given derivedNegLongGet: Get[NegLong] = numeric.derivedNegLongGet
-  inline given derivedNegLongPut: Put[NegLong] = numeric.derivedNegLongPut
+  given derivedNegLongGet: Get[NegLong] = numeric.derivedNegLongGet
+  given derivedNegLongPut: Put[NegLong] = numeric.derivedNegLongPut
 
-  inline given derivedNonNegLongGet: Get[NonNegLong] = numeric.derivedNonNegLongGet
-  inline given derivedNonNegLongPut: Put[NonNegLong] = numeric.derivedNonNegLongPut
+  given derivedNonNegLongGet: Get[NonNegLong] = numeric.derivedNonNegLongGet
+  given derivedNonNegLongPut: Put[NonNegLong] = numeric.derivedNonNegLongPut
 
-  inline given derivedPosLongGet: Get[PosLong] = numeric.derivedPosLongGet
-  inline given derivedPosLongPut: Put[PosLong] = numeric.derivedPosLongPut
+  given derivedPosLongGet: Get[PosLong] = numeric.derivedPosLongGet
+  given derivedPosLongPut: Put[PosLong] = numeric.derivedPosLongPut
 
-  inline given derivedNonPosLongGet: Get[NonPosLong] = numeric.derivedNonPosLongGet
-  inline given derivedNonPosLongPut: Put[NonPosLong] = numeric.derivedNonPosLongPut
+  given derivedNonPosLongGet: Get[NonPosLong] = numeric.derivedNonPosLongGet
+  given derivedNonPosLongPut: Put[NonPosLong] = numeric.derivedNonPosLongPut
 
-  inline given derivedNegShortGet: Get[NegShort] = numeric.derivedNegShortGet
-  inline given derivedNegShortPut: Put[NegShort] = numeric.derivedNegShortPut
+  given derivedNegShortGet: Get[NegShort] = numeric.derivedNegShortGet
+  given derivedNegShortPut: Put[NegShort] = numeric.derivedNegShortPut
 
-  inline given derivedNonNegShortGet: Get[NonNegShort] = numeric.derivedNonNegShortGet
-  inline given derivedNonNegShortPut: Put[NonNegShort] = numeric.derivedNonNegShortPut
+  given derivedNonNegShortGet: Get[NonNegShort] = numeric.derivedNonNegShortGet
+  given derivedNonNegShortPut: Put[NonNegShort] = numeric.derivedNonNegShortPut
 
-  inline given derivedPosShortGet: Get[PosShort] = numeric.derivedPosShortGet
-  inline given derivedPosShortPut: Put[PosShort] = numeric.derivedPosShortPut
+  given derivedPosShortGet: Get[PosShort] = numeric.derivedPosShortGet
+  given derivedPosShortPut: Put[PosShort] = numeric.derivedPosShortPut
 
-  inline given derivedNonPosShortGet: Get[NonPosShort] = numeric.derivedNonPosShortGet
-  inline given derivedNonPosShortPut: Put[NonPosShort] = numeric.derivedNonPosShortPut
+  given derivedNonPosShortGet: Get[NonPosShort] = numeric.derivedNonPosShortGet
+  given derivedNonPosShortPut: Put[NonPosShort] = numeric.derivedNonPosShortPut
 
-  inline given derivedNegByteGet: Get[NegByte] = numeric.derivedNegByteGet
-  inline given derivedNegBytePut: Put[NegByte] = numeric.derivedNegBytePut
+  given derivedNegByteGet: Get[NegByte] = numeric.derivedNegByteGet
+  given derivedNegBytePut: Put[NegByte] = numeric.derivedNegBytePut
 
-  inline given derivedNonNegByteGet: Get[NonNegByte] = numeric.derivedNonNegByteGet
-  inline given derivedNonNegBytePut: Put[NonNegByte] = numeric.derivedNonNegBytePut
+  given derivedNonNegByteGet: Get[NonNegByte] = numeric.derivedNonNegByteGet
+  given derivedNonNegBytePut: Put[NonNegByte] = numeric.derivedNonNegBytePut
 
-  inline given derivedPosByteGet: Get[PosByte] = numeric.derivedPosByteGet
-  inline given derivedPosBytePut: Put[PosByte] = numeric.derivedPosBytePut
+  given derivedPosByteGet: Get[PosByte] = numeric.derivedPosByteGet
+  given derivedPosBytePut: Put[PosByte] = numeric.derivedPosBytePut
 
-  inline given derivedNonPosByteGet: Get[NonPosByte] = numeric.derivedNonPosByteGet
-  inline given derivedNonPosBytePut: Put[NonPosByte] = numeric.derivedNonPosBytePut
+  given derivedNonPosByteGet: Get[NonPosByte] = numeric.derivedNonPosByteGet
+  given derivedNonPosBytePut: Put[NonPosByte] = numeric.derivedNonPosBytePut
 
-  inline given derivedNegFloatGet: Get[NegFloat] = numeric.derivedNegFloatGet
-  inline given derivedNegFloatPut: Put[NegFloat] = numeric.derivedNegFloatPut
+  given derivedNegFloatGet: Get[NegFloat] = numeric.derivedNegFloatGet
+  given derivedNegFloatPut: Put[NegFloat] = numeric.derivedNegFloatPut
 
-  inline given derivedNonNegFloatGet: Get[NonNegFloat] = numeric.derivedNonNegFloatGet
-  inline given derivedNonNegFloatPut: Put[NonNegFloat] = numeric.derivedNonNegFloatPut
+  given derivedNonNegFloatGet: Get[NonNegFloat] = numeric.derivedNonNegFloatGet
+  given derivedNonNegFloatPut: Put[NonNegFloat] = numeric.derivedNonNegFloatPut
 
-  inline given derivedPosFloatGet: Get[PosFloat] = numeric.derivedPosFloatGet
-  inline given derivedPosFloatPut: Put[PosFloat] = numeric.derivedPosFloatPut
+  given derivedPosFloatGet: Get[PosFloat] = numeric.derivedPosFloatGet
+  given derivedPosFloatPut: Put[PosFloat] = numeric.derivedPosFloatPut
 
-  inline given derivedNonPosFloatGet: Get[NonPosFloat] = numeric.derivedNonPosFloatGet
-  inline given derivedNonPosFloatPut: Put[NonPosFloat] = numeric.derivedNonPosFloatPut
+  given derivedNonPosFloatGet: Get[NonPosFloat] = numeric.derivedNonPosFloatGet
+  given derivedNonPosFloatPut: Put[NonPosFloat] = numeric.derivedNonPosFloatPut
 
-  inline given derivedNegDoubleGet: Get[NegDouble] = numeric.derivedNegDoubleGet
-  inline given derivedNegDoublePut: Put[NegDouble] = numeric.derivedNegDoublePut
+  given derivedNegDoubleGet: Get[NegDouble] = numeric.derivedNegDoubleGet
+  given derivedNegDoublePut: Put[NegDouble] = numeric.derivedNegDoublePut
 
-  inline given derivedNonNegDoubleGet: Get[NonNegDouble] = numeric.derivedNonNegDoubleGet
-  inline given derivedNonNegDoublePut: Put[NonNegDouble] = numeric.derivedNonNegDoublePut
+  given derivedNonNegDoubleGet: Get[NonNegDouble] = numeric.derivedNonNegDoubleGet
+  given derivedNonNegDoublePut: Put[NonNegDouble] = numeric.derivedNonNegDoublePut
 
-  inline given derivedPosDoubleGet: Get[PosDouble] = numeric.derivedPosDoubleGet
-  inline given derivedPosDoublePut: Put[PosDouble] = numeric.derivedPosDoublePut
+  given derivedPosDoubleGet: Get[PosDouble] = numeric.derivedPosDoubleGet
+  given derivedPosDoublePut: Put[PosDouble] = numeric.derivedPosDoublePut
 
-  inline given derivedNonPosDoubleGet: Get[NonPosDouble] = numeric.derivedNonPosDoubleGet
-  inline given derivedNonPosDoublePut: Put[NonPosDouble] = numeric.derivedNonPosDoublePut
+  given derivedNonPosDoubleGet: Get[NonPosDouble] = numeric.derivedNonPosDoubleGet
+  given derivedNonPosDoublePut: Put[NonPosDouble] = numeric.derivedNonPosDoublePut
 
-  inline given derivedNegBigIntGet: Get[NegBigInt] = numeric.derivedNegBigIntGet
-  inline given derivedNegBigIntPut: Put[NegBigInt] = numeric.derivedNegBigIntPut
+  given derivedNegBigIntGet: Get[NegBigInt] = numeric.derivedNegBigIntGet
+  given derivedNegBigIntPut: Put[NegBigInt] = numeric.derivedNegBigIntPut
 
-  inline given derivedNonNegBigIntGet: Get[NonNegBigInt] = numeric.derivedNonNegBigIntGet
-  inline given derivedNonNegBigIntPut: Put[NonNegBigInt] = numeric.derivedNonNegBigIntPut
+  given derivedNonNegBigIntGet: Get[NonNegBigInt] = numeric.derivedNonNegBigIntGet
+  given derivedNonNegBigIntPut: Put[NonNegBigInt] = numeric.derivedNonNegBigIntPut
 
-  inline given derivedPosBigIntGet: Get[PosBigInt] = numeric.derivedPosBigIntGet
-  inline given derivedPosBigIntPut: Put[PosBigInt] = numeric.derivedPosBigIntPut
+  given derivedPosBigIntGet: Get[PosBigInt] = numeric.derivedPosBigIntGet
+  given derivedPosBigIntPut: Put[PosBigInt] = numeric.derivedPosBigIntPut
 
-  inline given derivedNonPosBigIntGet: Get[NonPosBigInt] = numeric.derivedNonPosBigIntGet
-  inline given derivedNonPosBigIntPut: Put[NonPosBigInt] = numeric.derivedNonPosBigIntPut
+  given derivedNonPosBigIntGet: Get[NonPosBigInt] = numeric.derivedNonPosBigIntGet
+  given derivedNonPosBigIntPut: Put[NonPosBigInt] = numeric.derivedNonPosBigIntPut
 
-  inline given derivedNegBigDecimalGet: Get[NegBigDecimal] = numeric.derivedNegBigDecimalGet
-  inline given derivedNegBigDecimalPut: Put[NegBigDecimal] = numeric.derivedNegBigDecimalPut
+  given derivedNegBigDecimalGet: Get[NegBigDecimal] = numeric.derivedNegBigDecimalGet
+  given derivedNegBigDecimalPut: Put[NegBigDecimal] = numeric.derivedNegBigDecimalPut
 
-  inline given derivedNonNegBigDecimalGet: Get[NonNegBigDecimal] = numeric.derivedNonNegBigDecimalGet
-  inline given derivedNonNegBigDecimalPut: Put[NonNegBigDecimal] = numeric.derivedNonNegBigDecimalPut
+  given derivedNonNegBigDecimalGet: Get[NonNegBigDecimal] = numeric.derivedNonNegBigDecimalGet
+  given derivedNonNegBigDecimalPut: Put[NonNegBigDecimal] = numeric.derivedNonNegBigDecimalPut
 
-  inline given derivedPosBigDecimalGet: Get[PosBigDecimal] = numeric.derivedPosBigDecimalGet
-  inline given derivedPosBigDecimalPut: Put[PosBigDecimal] = numeric.derivedPosBigDecimalPut
+  given derivedPosBigDecimalGet: Get[PosBigDecimal] = numeric.derivedPosBigDecimalGet
+  given derivedPosBigDecimalPut: Put[PosBigDecimal] = numeric.derivedPosBigDecimalPut
 
-  inline given derivedNonPosBigDecimalGet: Get[NonPosBigDecimal] = numeric.derivedNonPosBigDecimalGet
-  inline given derivedNonPosBigDecimalPut: Put[NonPosBigDecimal] = numeric.derivedNonPosBigDecimalPut
+  given derivedNonPosBigDecimalGet: Get[NonPosBigDecimal] = numeric.derivedNonPosBigDecimalGet
+  given derivedNonPosBigDecimalPut: Put[NonPosBigDecimal] = numeric.derivedNonPosBigDecimalPut
 
 }
 object numeric {

--- a/modules/refined4s-doobie-ce3/shared/src/main/scala/refined4s/modules/doobie/derivation/types/strings.scala
+++ b/modules/refined4s-doobie-ce3/shared/src/main/scala/refined4s/modules/doobie/derivation/types/strings.scala
@@ -9,14 +9,14 @@ import refined4s.types.strings.*
   */
 trait strings {
 
-  inline given derivedNonEmptyStringGet: Get[NonEmptyString] = strings.derivedNonEmptyStringGet
-  inline given derivedNonEmptyStringPut: Put[NonEmptyString] = strings.derivedNonEmptyStringPut
+  given derivedNonEmptyStringGet: Get[NonEmptyString] = strings.derivedNonEmptyStringGet
+  given derivedNonEmptyStringPut: Put[NonEmptyString] = strings.derivedNonEmptyStringPut
 
-  inline given derivedNonBlankStringGet: Get[NonBlankString] = strings.derivedNonBlankStringGet
-  inline given derivedNonBlankStringPut: Put[NonBlankString] = strings.derivedNonBlankStringPut
+  given derivedNonBlankStringGet: Get[NonBlankString] = strings.derivedNonBlankStringGet
+  given derivedNonBlankStringPut: Put[NonBlankString] = strings.derivedNonBlankStringPut
 
-  inline given derivedUuidGet: Get[Uuid] = strings.derivedUuidGet
-  inline given derivedUuidPut: Put[Uuid] = strings.derivedUuidPut
+  given derivedUuidGet: Get[Uuid] = strings.derivedUuidGet
+  given derivedUuidPut: Put[Uuid] = strings.derivedUuidPut
 
 }
 object strings {

--- a/modules/refined4s-doobie-ce3/shared/src/main/scala/refined4s/modules/doobie/derivation/types/time.scala
+++ b/modules/refined4s-doobie-ce3/shared/src/main/scala/refined4s/modules/doobie/derivation/types/time.scala
@@ -9,23 +9,23 @@ import refined4s.types.time.*
   */
 trait time {
 
-  inline given derivedMonthGet: Get[Month] = time.derivedMonthGet
-  inline given derivedMonthPut: Put[Month] = time.derivedMonthPut
+  given derivedMonthGet: Get[Month] = time.derivedMonthGet
+  given derivedMonthPut: Put[Month] = time.derivedMonthPut
 
-  inline given derivedDayGet: Get[Day] = time.derivedDayGet
-  inline given derivedDayPut: Put[Day] = time.derivedDayPut
+  given derivedDayGet: Get[Day] = time.derivedDayGet
+  given derivedDayPut: Put[Day] = time.derivedDayPut
 
-  inline given derivedHourGet: Get[Hour] = time.derivedHourGet
-  inline given derivedHourPut: Put[Hour] = time.derivedHourPut
+  given derivedHourGet: Get[Hour] = time.derivedHourGet
+  given derivedHourPut: Put[Hour] = time.derivedHourPut
 
-  inline given derivedMinuteGet: Get[Minute] = time.derivedMinuteGet
-  inline given derivedMinutePut: Put[Minute] = time.derivedMinutePut
+  given derivedMinuteGet: Get[Minute] = time.derivedMinuteGet
+  given derivedMinutePut: Put[Minute] = time.derivedMinutePut
 
-  inline given derivedSecondGet: Get[Second] = time.derivedSecondGet
-  inline given derivedSecondPut: Put[Second] = time.derivedSecondPut
+  given derivedSecondGet: Get[Second] = time.derivedSecondGet
+  given derivedSecondPut: Put[Second] = time.derivedSecondPut
 
-  inline given derivedMillisGet: Get[Millis] = time.derivedMillisGet
-  inline given derivedMillisPut: Put[Millis] = time.derivedMillisPut
+  given derivedMillisGet: Get[Millis] = time.derivedMillisGet
+  given derivedMillisPut: Put[Millis] = time.derivedMillisPut
 
 }
 object time {

--- a/modules/refined4s-doobie-ce3/shared/src/test/scala/refined4s/modules/doobie/derivation/types/numericSpec.scala
+++ b/modules/refined4s-doobie-ce3/shared/src/test/scala/refined4s/modules/doobie/derivation/types/numericSpec.scala
@@ -3,7 +3,6 @@ package refined4s.modules.doobie.derivation.types
 import cats.effect.IO
 import cats.syntax.all.*
 import doobie.syntax.all.*
-import doobie.{Get, Put}
 import extras.doobie.RunWithDb
 import extras.doobie.ce3.DbTools
 import extras.hedgehog.ce3.CatsEffectRunner

--- a/modules/refined4s-doobie-ce3/shared/src/test/scala/refined4s/modules/doobie/derivation/types/stringsSpec.scala
+++ b/modules/refined4s-doobie-ce3/shared/src/test/scala/refined4s/modules/doobie/derivation/types/stringsSpec.scala
@@ -3,7 +3,6 @@ package refined4s.modules.doobie.derivation.types
 import cats.effect.IO
 import cats.syntax.all.*
 import doobie.syntax.all.*
-import doobie.{Get, Put}
 import extras.core.syntax.all.*
 import extras.doobie.RunWithDb
 import extras.doobie.ce3.DbTools

--- a/modules/refined4s-extras-render/shared/src/main/scala/refined4s/modules/extras/derivation/generic/auto.scala
+++ b/modules/refined4s-extras-render/shared/src/main/scala/refined4s/modules/extras/derivation/generic/auto.scala
@@ -11,7 +11,7 @@ trait auto {
   /** `Render` instance for Newtype, Refined and InlinedRefined types that delegates from the `Render`
     * instance of the base type.
     */
-  inline given derivedRender[A, B](using coercible: Coercible[A, B], renderB: Render[B]): Render[A] =
+  given derivedRender[A, B](using coercible: Coercible[A, B], renderB: Render[B]): Render[A] =
     renderB.contramap[A](coercible(_))
 
 }

--- a/modules/refined4s-extras-render/shared/src/main/scala/refined4s/modules/extras/derivation/types/network.scala
+++ b/modules/refined4s-extras-render/shared/src/main/scala/refined4s/modules/extras/derivation/types/network.scala
@@ -9,19 +9,19 @@ import refined4s.types.network.*
   */
 trait network {
 
-  inline given derivedUriRender: Render[Uri] = network.derivedUriRender
+  given derivedUriRender: Render[Uri] = network.derivedUriRender
 
-  inline given derivedUrlRender: Render[Url] = network.derivedUrlRender
+  given derivedUrlRender: Render[Url] = network.derivedUrlRender
 
-  inline given derivedPortNumberRender: Render[PortNumber] = network.derivedPortNumberRender
+  given derivedPortNumberRender: Render[PortNumber] = network.derivedPortNumberRender
 
-  inline given derivedSystemPortNumberRender: Render[SystemPortNumber] = network.derivedSystemPortNumberRender
+  given derivedSystemPortNumberRender: Render[SystemPortNumber] = network.derivedSystemPortNumberRender
 
-  inline given derivedNonSystemPortNumberRender: Render[NonSystemPortNumber] = network.derivedNonSystemPortNumberRender
+  given derivedNonSystemPortNumberRender: Render[NonSystemPortNumber] = network.derivedNonSystemPortNumberRender
 
-  inline given derivedUserPortNumberRender: Render[UserPortNumber] = network.derivedUserPortNumberRender
+  given derivedUserPortNumberRender: Render[UserPortNumber] = network.derivedUserPortNumberRender
 
-  inline given derivedDynamicPortNumberRender: Render[DynamicPortNumber] = network.derivedDynamicPortNumberRender
+  given derivedDynamicPortNumberRender: Render[DynamicPortNumber] = network.derivedDynamicPortNumberRender
 
 }
 object network {

--- a/modules/refined4s-extras-render/shared/src/main/scala/refined4s/modules/extras/derivation/types/numeric.scala
+++ b/modules/refined4s-extras-render/shared/src/main/scala/refined4s/modules/extras/derivation/types/numeric.scala
@@ -8,69 +8,69 @@ import refined4s.types.numeric.*
   */
 trait numeric {
 
-  inline given derivedNegIntRender: Render[NegInt] = numeric.derivedNegIntRender
+  given derivedNegIntRender: Render[NegInt] = numeric.derivedNegIntRender
 
-  inline given derivedNonNegIntRender: Render[NonNegInt] = numeric.derivedNonNegIntRender
+  given derivedNonNegIntRender: Render[NonNegInt] = numeric.derivedNonNegIntRender
 
-  inline given derivedPosIntRender: Render[PosInt] = numeric.derivedPosIntRender
+  given derivedPosIntRender: Render[PosInt] = numeric.derivedPosIntRender
 
-  inline given derivedNonPosIntRender: Render[NonPosInt] = numeric.derivedNonPosIntRender
+  given derivedNonPosIntRender: Render[NonPosInt] = numeric.derivedNonPosIntRender
 
-  inline given derivedNegLongRender: Render[NegLong] = numeric.derivedNegLongRender
+  given derivedNegLongRender: Render[NegLong] = numeric.derivedNegLongRender
 
-  inline given derivedNonNegLongRender: Render[NonNegLong] = numeric.derivedNonNegLongRender
+  given derivedNonNegLongRender: Render[NonNegLong] = numeric.derivedNonNegLongRender
 
-  inline given derivedPosLongRender: Render[PosLong] = numeric.derivedPosLongRender
+  given derivedPosLongRender: Render[PosLong] = numeric.derivedPosLongRender
 
-  inline given derivedNonPosLongRender: Render[NonPosLong] = numeric.derivedNonPosLongRender
+  given derivedNonPosLongRender: Render[NonPosLong] = numeric.derivedNonPosLongRender
 
-  inline given derivedNegShortRender: Render[NegShort] = numeric.derivedNegShortRender
+  given derivedNegShortRender: Render[NegShort] = numeric.derivedNegShortRender
 
-  inline given derivedNonNegShortRender: Render[NonNegShort] = numeric.derivedNonNegShortRender
+  given derivedNonNegShortRender: Render[NonNegShort] = numeric.derivedNonNegShortRender
 
-  inline given derivedPosShortRender: Render[PosShort] = numeric.derivedPosShortRender
+  given derivedPosShortRender: Render[PosShort] = numeric.derivedPosShortRender
 
-  inline given derivedNonPosShortRender: Render[NonPosShort] = numeric.derivedNonPosShortRender
+  given derivedNonPosShortRender: Render[NonPosShort] = numeric.derivedNonPosShortRender
 
-  inline given derivedNegByteRender: Render[NegByte] = numeric.derivedNegByteRender
+  given derivedNegByteRender: Render[NegByte] = numeric.derivedNegByteRender
 
-  inline given derivedNonNegByteRender: Render[NonNegByte] = numeric.derivedNonNegByteRender
+  given derivedNonNegByteRender: Render[NonNegByte] = numeric.derivedNonNegByteRender
 
-  inline given derivedPosByteRender: Render[PosByte] = numeric.derivedPosByteRender
+  given derivedPosByteRender: Render[PosByte] = numeric.derivedPosByteRender
 
-  inline given derivedNonPosByteRender: Render[NonPosByte] = numeric.derivedNonPosByteRender
+  given derivedNonPosByteRender: Render[NonPosByte] = numeric.derivedNonPosByteRender
 
-  inline given derivedNegFloatRender: Render[NegFloat] = numeric.derivedNegFloatRender
+  given derivedNegFloatRender: Render[NegFloat] = numeric.derivedNegFloatRender
 
-  inline given derivedNonNegFloatRender: Render[NonNegFloat] = numeric.derivedNonNegFloatRender
+  given derivedNonNegFloatRender: Render[NonNegFloat] = numeric.derivedNonNegFloatRender
 
-  inline given derivedPosFloatRender: Render[PosFloat] = numeric.derivedPosFloatRender
+  given derivedPosFloatRender: Render[PosFloat] = numeric.derivedPosFloatRender
 
-  inline given derivedNonPosFloatRender: Render[NonPosFloat] = numeric.derivedNonPosFloatRender
+  given derivedNonPosFloatRender: Render[NonPosFloat] = numeric.derivedNonPosFloatRender
 
-  inline given derivedNegDoubleRender: Render[NegDouble] = numeric.derivedNegDoubleRender
+  given derivedNegDoubleRender: Render[NegDouble] = numeric.derivedNegDoubleRender
 
-  inline given derivedNonNegDoubleRender: Render[NonNegDouble] = numeric.derivedNonNegDoubleRender
+  given derivedNonNegDoubleRender: Render[NonNegDouble] = numeric.derivedNonNegDoubleRender
 
-  inline given derivedPosDoubleRender: Render[PosDouble] = numeric.derivedPosDoubleRender
+  given derivedPosDoubleRender: Render[PosDouble] = numeric.derivedPosDoubleRender
 
-  inline given derivedNonPosDoubleRender: Render[NonPosDouble] = numeric.derivedNonPosDoubleRender
+  given derivedNonPosDoubleRender: Render[NonPosDouble] = numeric.derivedNonPosDoubleRender
 
-  inline given derivedNegBigIntRender: Render[NegBigInt] = numeric.derivedNegBigIntRender
+  given derivedNegBigIntRender: Render[NegBigInt] = numeric.derivedNegBigIntRender
 
-  inline given derivedNonNegBigIntRender: Render[NonNegBigInt] = numeric.derivedNonNegBigIntRender
+  given derivedNonNegBigIntRender: Render[NonNegBigInt] = numeric.derivedNonNegBigIntRender
 
-  inline given derivedPosBigIntRender: Render[PosBigInt] = numeric.derivedPosBigIntRender
+  given derivedPosBigIntRender: Render[PosBigInt] = numeric.derivedPosBigIntRender
 
-  inline given derivedNonPosBigIntRender: Render[NonPosBigInt] = numeric.derivedNonPosBigIntRender
+  given derivedNonPosBigIntRender: Render[NonPosBigInt] = numeric.derivedNonPosBigIntRender
 
-  inline given derivedNegBigDecimalRender: Render[NegBigDecimal] = numeric.derivedNegBigDecimalRender
+  given derivedNegBigDecimalRender: Render[NegBigDecimal] = numeric.derivedNegBigDecimalRender
 
-  inline given derivedNonNegBigDecimalRender: Render[NonNegBigDecimal] = numeric.derivedNonNegBigDecimalRender
+  given derivedNonNegBigDecimalRender: Render[NonNegBigDecimal] = numeric.derivedNonNegBigDecimalRender
 
-  inline given derivedPosBigDecimalRender: Render[PosBigDecimal] = numeric.derivedPosBigDecimalRender
+  given derivedPosBigDecimalRender: Render[PosBigDecimal] = numeric.derivedPosBigDecimalRender
 
-  inline given derivedNonPosBigDecimalRender: Render[NonPosBigDecimal] = numeric.derivedNonPosBigDecimalRender
+  given derivedNonPosBigDecimalRender: Render[NonPosBigDecimal] = numeric.derivedNonPosBigDecimalRender
 
 }
 object numeric {

--- a/modules/refined4s-extras-render/shared/src/main/scala/refined4s/modules/extras/derivation/types/strings.scala
+++ b/modules/refined4s-extras-render/shared/src/main/scala/refined4s/modules/extras/derivation/types/strings.scala
@@ -8,11 +8,11 @@ import refined4s.types.strings.*
   */
 trait strings {
 
-  inline given derivedNonEmptyStringRender: Render[NonEmptyString] = strings.derivedNonEmptyStringRender
+  given derivedNonEmptyStringRender: Render[NonEmptyString] = strings.derivedNonEmptyStringRender
 
-  inline given derivedNonBlankStringRender: Render[NonBlankString] = strings.derivedNonBlankStringRender
+  given derivedNonBlankStringRender: Render[NonBlankString] = strings.derivedNonBlankStringRender
 
-  inline given derivedUuidRender: Render[Uuid] = strings.derivedUuidRender
+  given derivedUuidRender: Render[Uuid] = strings.derivedUuidRender
 
 }
 object strings {

--- a/modules/refined4s-extras-render/shared/src/main/scala/refined4s/modules/extras/derivation/types/time.scala
+++ b/modules/refined4s-extras-render/shared/src/main/scala/refined4s/modules/extras/derivation/types/time.scala
@@ -7,28 +7,28 @@ import extras.render.Render
   * @since 2025-08-31
   */
 trait time {
-  inline given derivedMonthRender: Render[Month] = time.derivedMonthRender
+  given derivedMonthRender: Render[Month] = time.derivedMonthRender
 
-  inline given derivedDayRender: Render[Day] = time.derivedDayRender
+  given derivedDayRender: Render[Day] = time.derivedDayRender
 
-  inline given derivedHourRender: Render[Hour] = time.derivedHourRender
+  given derivedHourRender: Render[Hour] = time.derivedHourRender
 
-  inline given derivedMinuteRender: Render[Minute] = time.derivedMinuteRender
+  given derivedMinuteRender: Render[Minute] = time.derivedMinuteRender
 
-  inline given derivedSecondRender: Render[Second] = time.derivedSecondRender
+  given derivedSecondRender: Render[Second] = time.derivedSecondRender
 
-  inline given derivedMillisRender: Render[Millis] = time.derivedMillisRender
+  given derivedMillisRender: Render[Millis] = time.derivedMillisRender
 }
 object time {
-  inline given derivedMonthRender(using renderActual: Render[Int]): Render[Month] = renderActual.contramap(_.value)
+  given derivedMonthRender(using renderActual: Render[Int]): Render[Month] = renderActual.contramap(_.value)
 
-  inline given derivedDayRender(using renderActual: Render[Int]): Render[Day] = renderActual.contramap(_.value)
+  given derivedDayRender(using renderActual: Render[Int]): Render[Day] = renderActual.contramap(_.value)
 
-  inline given derivedHourRender(using renderActual: Render[Int]): Render[Hour] = renderActual.contramap(_.value)
+  given derivedHourRender(using renderActual: Render[Int]): Render[Hour] = renderActual.contramap(_.value)
 
-  inline given derivedMinuteRender(using renderActual: Render[Int]): Render[Minute] = renderActual.contramap(_.value)
+  given derivedMinuteRender(using renderActual: Render[Int]): Render[Minute] = renderActual.contramap(_.value)
 
-  inline given derivedSecondRender(using renderActual: Render[Int]): Render[Second] = renderActual.contramap(_.value)
+  given derivedSecondRender(using renderActual: Render[Int]): Render[Second] = renderActual.contramap(_.value)
 
-  inline given derivedMillisRender(using renderActual: Render[Int]): Render[Millis] = renderActual.contramap(_.value)
+  given derivedMillisRender(using renderActual: Render[Int]): Render[Millis] = renderActual.contramap(_.value)
 }

--- a/modules/refined4s-pureconfig/shared/src/main/scala/refined4s/modules/pureconfig/derivation/generic/auto.scala
+++ b/modules/refined4s-pureconfig/shared/src/main/scala/refined4s/modules/pureconfig/derivation/generic/auto.scala
@@ -26,7 +26,7 @@ trait auto {
       }
     }
 
-  inline given derivedConfigWriter[A, B](using coercible: Coercible[A, B], configWriter: ConfigWriter[B]): ConfigWriter[A] with {
+  given derivedConfigWriter[A, B](using coercible: Coercible[A, B], configWriter: ConfigWriter[B]): ConfigWriter[A] with {
     override inline def to(a: A): ConfigValue =
       configWriter.to(coercible(a))
   }

--- a/modules/refined4s-pureconfig/shared/src/main/scala/refined4s/modules/pureconfig/derivation/types/network.scala
+++ b/modules/refined4s-pureconfig/shared/src/main/scala/refined4s/modules/pureconfig/derivation/types/network.scala
@@ -10,26 +10,26 @@ import refined4s.types.network.*
   */
 trait network {
 
-  inline given derivedUriConfigReader: ConfigReader[Uri] = network.derivedUriConfigReader
-  inline given derivedUriConfigWriter: ConfigWriter[Uri] = network.derivedUriConfigWriter
+  given derivedUriConfigReader: ConfigReader[Uri] = network.derivedUriConfigReader
+  given derivedUriConfigWriter: ConfigWriter[Uri] = network.derivedUriConfigWriter
 
-  inline given derivedUrlConfigReader: ConfigReader[Url] = network.derivedUrlConfigReader
-  inline given derivedUrlConfigWriter: ConfigWriter[Url] = network.derivedUrlConfigWriter
+  given derivedUrlConfigReader: ConfigReader[Url] = network.derivedUrlConfigReader
+  given derivedUrlConfigWriter: ConfigWriter[Url] = network.derivedUrlConfigWriter
 
-  inline given derivedPortNumberConfigReader: ConfigReader[PortNumber] = network.derivedPortNumberConfigReader
-  inline given derivedPortNumberConfigWriter: ConfigWriter[PortNumber] = network.derivedPortNumberConfigWriter
+  given derivedPortNumberConfigReader: ConfigReader[PortNumber] = network.derivedPortNumberConfigReader
+  given derivedPortNumberConfigWriter: ConfigWriter[PortNumber] = network.derivedPortNumberConfigWriter
 
-  inline given derivedSystemPortNumberConfigReader: ConfigReader[SystemPortNumber] = network.derivedSystemPortNumberConfigReader
-  inline given derivedSystemPortNumberConfigWriter: ConfigWriter[SystemPortNumber] = network.derivedSystemPortNumberConfigWriter
+  given derivedSystemPortNumberConfigReader: ConfigReader[SystemPortNumber] = network.derivedSystemPortNumberConfigReader
+  given derivedSystemPortNumberConfigWriter: ConfigWriter[SystemPortNumber] = network.derivedSystemPortNumberConfigWriter
 
-  inline given derivedNonSystemPortNumberConfigReader: ConfigReader[NonSystemPortNumber] = network.derivedNonSystemPortNumberConfigReader
-  inline given derivedNonSystemPortNumberConfigWriter: ConfigWriter[NonSystemPortNumber] = network.derivedNonSystemPortNumberConfigWriter
+  given derivedNonSystemPortNumberConfigReader: ConfigReader[NonSystemPortNumber] = network.derivedNonSystemPortNumberConfigReader
+  given derivedNonSystemPortNumberConfigWriter: ConfigWriter[NonSystemPortNumber] = network.derivedNonSystemPortNumberConfigWriter
 
-  inline given derivedUserPortNumberConfigReader: ConfigReader[UserPortNumber] = network.derivedUserPortNumberConfigReader
-  inline given derivedUserPortNumberConfigWriter: ConfigWriter[UserPortNumber] = network.derivedUserPortNumberConfigWriter
+  given derivedUserPortNumberConfigReader: ConfigReader[UserPortNumber] = network.derivedUserPortNumberConfigReader
+  given derivedUserPortNumberConfigWriter: ConfigWriter[UserPortNumber] = network.derivedUserPortNumberConfigWriter
 
-  inline given derivedDynamicPortNumberConfigReader: ConfigReader[DynamicPortNumber] = network.derivedDynamicPortNumberConfigReader
-  inline given derivedDynamicPortNumberConfigWriter: ConfigWriter[DynamicPortNumber] = network.derivedDynamicPortNumberConfigWriter
+  given derivedDynamicPortNumberConfigReader: ConfigReader[DynamicPortNumber] = network.derivedDynamicPortNumberConfigReader
+  given derivedDynamicPortNumberConfigWriter: ConfigWriter[DynamicPortNumber] = network.derivedDynamicPortNumberConfigWriter
 
 }
 object network {

--- a/modules/refined4s-pureconfig/shared/src/main/scala/refined4s/modules/pureconfig/derivation/types/numeric.scala
+++ b/modules/refined4s-pureconfig/shared/src/main/scala/refined4s/modules/pureconfig/derivation/types/numeric.scala
@@ -10,101 +10,101 @@ import refined4s.types.numeric.*
   */
 trait numeric {
 
-  inline given derivedNegIntConfigReader: ConfigReader[NegInt] = numeric.derivedNegIntConfigReader
-  inline given derivedNegIntConfigWriter: ConfigWriter[NegInt] = numeric.derivedNegIntConfigWriter
+  given derivedNegIntConfigReader: ConfigReader[NegInt] = numeric.derivedNegIntConfigReader
+  given derivedNegIntConfigWriter: ConfigWriter[NegInt] = numeric.derivedNegIntConfigWriter
 
-  inline given derivedNonNegIntConfigReader: ConfigReader[NonNegInt] = numeric.derivedNonNegIntConfigReader
-  inline given derivedNonNegIntConfigWriter: ConfigWriter[NonNegInt] = numeric.derivedNonNegIntConfigWriter
+  given derivedNonNegIntConfigReader: ConfigReader[NonNegInt] = numeric.derivedNonNegIntConfigReader
+  given derivedNonNegIntConfigWriter: ConfigWriter[NonNegInt] = numeric.derivedNonNegIntConfigWriter
 
-  inline given derivedPosIntConfigReader: ConfigReader[PosInt] = numeric.derivedPosIntConfigReader
-  inline given derivedPosIntConfigWriter: ConfigWriter[PosInt] = numeric.derivedPosIntConfigWriter
+  given derivedPosIntConfigReader: ConfigReader[PosInt] = numeric.derivedPosIntConfigReader
+  given derivedPosIntConfigWriter: ConfigWriter[PosInt] = numeric.derivedPosIntConfigWriter
 
-  inline given derivedNonPosIntConfigReader: ConfigReader[NonPosInt] = numeric.derivedNonPosIntConfigReader
-  inline given derivedNonPosIntConfigWriter: ConfigWriter[NonPosInt] = numeric.derivedNonPosIntConfigWriter
+  given derivedNonPosIntConfigReader: ConfigReader[NonPosInt] = numeric.derivedNonPosIntConfigReader
+  given derivedNonPosIntConfigWriter: ConfigWriter[NonPosInt] = numeric.derivedNonPosIntConfigWriter
 
-  inline given derivedNegLongConfigReader: ConfigReader[NegLong] = numeric.derivedNegLongConfigReader
-  inline given derivedNegLongConfigWriter: ConfigWriter[NegLong] = numeric.derivedNegLongConfigWriter
+  given derivedNegLongConfigReader: ConfigReader[NegLong] = numeric.derivedNegLongConfigReader
+  given derivedNegLongConfigWriter: ConfigWriter[NegLong] = numeric.derivedNegLongConfigWriter
 
-  inline given derivedNonNegLongConfigReader: ConfigReader[NonNegLong] = numeric.derivedNonNegLongConfigReader
-  inline given derivedNonNegLongConfigWriter: ConfigWriter[NonNegLong] = numeric.derivedNonNegLongConfigWriter
+  given derivedNonNegLongConfigReader: ConfigReader[NonNegLong] = numeric.derivedNonNegLongConfigReader
+  given derivedNonNegLongConfigWriter: ConfigWriter[NonNegLong] = numeric.derivedNonNegLongConfigWriter
 
-  inline given derivedPosLongConfigReader: ConfigReader[PosLong] = numeric.derivedPosLongConfigReader
-  inline given derivedPosLongConfigWriter: ConfigWriter[PosLong] = numeric.derivedPosLongConfigWriter
+  given derivedPosLongConfigReader: ConfigReader[PosLong] = numeric.derivedPosLongConfigReader
+  given derivedPosLongConfigWriter: ConfigWriter[PosLong] = numeric.derivedPosLongConfigWriter
 
-  inline given derivedNonPosLongConfigReader: ConfigReader[NonPosLong] = numeric.derivedNonPosLongConfigReader
-  inline given derivedNonPosLongConfigWriter: ConfigWriter[NonPosLong] = numeric.derivedNonPosLongConfigWriter
+  given derivedNonPosLongConfigReader: ConfigReader[NonPosLong] = numeric.derivedNonPosLongConfigReader
+  given derivedNonPosLongConfigWriter: ConfigWriter[NonPosLong] = numeric.derivedNonPosLongConfigWriter
 
-  inline given derivedNegShortConfigReader: ConfigReader[NegShort] = numeric.derivedNegShortConfigReader
-  inline given derivedNegShortConfigWriter: ConfigWriter[NegShort] = numeric.derivedNegShortConfigWriter
+  given derivedNegShortConfigReader: ConfigReader[NegShort] = numeric.derivedNegShortConfigReader
+  given derivedNegShortConfigWriter: ConfigWriter[NegShort] = numeric.derivedNegShortConfigWriter
 
-  inline given derivedNonNegShortConfigReader: ConfigReader[NonNegShort] = numeric.derivedNonNegShortConfigReader
-  inline given derivedNonNegShortConfigWriter: ConfigWriter[NonNegShort] = numeric.derivedNonNegShortConfigWriter
+  given derivedNonNegShortConfigReader: ConfigReader[NonNegShort] = numeric.derivedNonNegShortConfigReader
+  given derivedNonNegShortConfigWriter: ConfigWriter[NonNegShort] = numeric.derivedNonNegShortConfigWriter
 
-  inline given derivedPosShortConfigReader: ConfigReader[PosShort] = numeric.derivedPosShortConfigReader
-  inline given derivedPosShortConfigWriter: ConfigWriter[PosShort] = numeric.derivedPosShortConfigWriter
+  given derivedPosShortConfigReader: ConfigReader[PosShort] = numeric.derivedPosShortConfigReader
+  given derivedPosShortConfigWriter: ConfigWriter[PosShort] = numeric.derivedPosShortConfigWriter
 
-  inline given derivedNonPosShortConfigReader: ConfigReader[NonPosShort] = numeric.derivedNonPosShortConfigReader
-  inline given derivedNonPosShortConfigWriter: ConfigWriter[NonPosShort] = numeric.derivedNonPosShortConfigWriter
+  given derivedNonPosShortConfigReader: ConfigReader[NonPosShort] = numeric.derivedNonPosShortConfigReader
+  given derivedNonPosShortConfigWriter: ConfigWriter[NonPosShort] = numeric.derivedNonPosShortConfigWriter
 
-  inline given derivedNegByteConfigReader: ConfigReader[NegByte] = numeric.derivedNegByteConfigReader
-  inline given derivedNegByteConfigWriter: ConfigWriter[NegByte] = numeric.derivedNegByteConfigWriter
+  given derivedNegByteConfigReader: ConfigReader[NegByte] = numeric.derivedNegByteConfigReader
+  given derivedNegByteConfigWriter: ConfigWriter[NegByte] = numeric.derivedNegByteConfigWriter
 
-  inline given derivedNonNegByteConfigReader: ConfigReader[NonNegByte] = numeric.derivedNonNegByteConfigReader
-  inline given derivedNonNegByteConfigWriter: ConfigWriter[NonNegByte] = numeric.derivedNonNegByteConfigWriter
+  given derivedNonNegByteConfigReader: ConfigReader[NonNegByte] = numeric.derivedNonNegByteConfigReader
+  given derivedNonNegByteConfigWriter: ConfigWriter[NonNegByte] = numeric.derivedNonNegByteConfigWriter
 
-  inline given derivedPosByteConfigReader: ConfigReader[PosByte] = numeric.derivedPosByteConfigReader
-  inline given derivedPosByteConfigWriter: ConfigWriter[PosByte] = numeric.derivedPosByteConfigWriter
+  given derivedPosByteConfigReader: ConfigReader[PosByte] = numeric.derivedPosByteConfigReader
+  given derivedPosByteConfigWriter: ConfigWriter[PosByte] = numeric.derivedPosByteConfigWriter
 
-  inline given derivedNonPosByteConfigReader: ConfigReader[NonPosByte] = numeric.derivedNonPosByteConfigReader
-  inline given derivedNonPosByteConfigWriter: ConfigWriter[NonPosByte] = numeric.derivedNonPosByteConfigWriter
+  given derivedNonPosByteConfigReader: ConfigReader[NonPosByte] = numeric.derivedNonPosByteConfigReader
+  given derivedNonPosByteConfigWriter: ConfigWriter[NonPosByte] = numeric.derivedNonPosByteConfigWriter
 
-  inline given derivedNegFloatConfigReader: ConfigReader[NegFloat] = numeric.derivedNegFloatConfigReader
-  inline given derivedNegFloatConfigWriter: ConfigWriter[NegFloat] = numeric.derivedNegFloatConfigWriter
+  given derivedNegFloatConfigReader: ConfigReader[NegFloat] = numeric.derivedNegFloatConfigReader
+  given derivedNegFloatConfigWriter: ConfigWriter[NegFloat] = numeric.derivedNegFloatConfigWriter
 
-  inline given derivedNonNegFloatConfigReader: ConfigReader[NonNegFloat] = numeric.derivedNonNegFloatConfigReader
-  inline given derivedNonNegFloatConfigWriter: ConfigWriter[NonNegFloat] = numeric.derivedNonNegFloatConfigWriter
+  given derivedNonNegFloatConfigReader: ConfigReader[NonNegFloat] = numeric.derivedNonNegFloatConfigReader
+  given derivedNonNegFloatConfigWriter: ConfigWriter[NonNegFloat] = numeric.derivedNonNegFloatConfigWriter
 
-  inline given derivedPosFloatConfigReader: ConfigReader[PosFloat] = numeric.derivedPosFloatConfigReader
-  inline given derivedPosFloatConfigWriter: ConfigWriter[PosFloat] = numeric.derivedPosFloatConfigWriter
+  given derivedPosFloatConfigReader: ConfigReader[PosFloat] = numeric.derivedPosFloatConfigReader
+  given derivedPosFloatConfigWriter: ConfigWriter[PosFloat] = numeric.derivedPosFloatConfigWriter
 
-  inline given derivedNonPosFloatConfigReader: ConfigReader[NonPosFloat] = numeric.derivedNonPosFloatConfigReader
-  inline given derivedNonPosFloatConfigWriter: ConfigWriter[NonPosFloat] = numeric.derivedNonPosFloatConfigWriter
+  given derivedNonPosFloatConfigReader: ConfigReader[NonPosFloat] = numeric.derivedNonPosFloatConfigReader
+  given derivedNonPosFloatConfigWriter: ConfigWriter[NonPosFloat] = numeric.derivedNonPosFloatConfigWriter
 
-  inline given derivedNegDoubleConfigReader: ConfigReader[NegDouble] = numeric.derivedNegDoubleConfigReader
-  inline given derivedNegDoubleConfigWriter: ConfigWriter[NegDouble] = numeric.derivedNegDoubleConfigWriter
+  given derivedNegDoubleConfigReader: ConfigReader[NegDouble] = numeric.derivedNegDoubleConfigReader
+  given derivedNegDoubleConfigWriter: ConfigWriter[NegDouble] = numeric.derivedNegDoubleConfigWriter
 
-  inline given derivedNonNegDoubleConfigReader: ConfigReader[NonNegDouble] = numeric.derivedNonNegDoubleConfigReader
-  inline given derivedNonNegDoubleConfigWriter: ConfigWriter[NonNegDouble] = numeric.derivedNonNegDoubleConfigWriter
+  given derivedNonNegDoubleConfigReader: ConfigReader[NonNegDouble] = numeric.derivedNonNegDoubleConfigReader
+  given derivedNonNegDoubleConfigWriter: ConfigWriter[NonNegDouble] = numeric.derivedNonNegDoubleConfigWriter
 
-  inline given derivedPosDoubleConfigReader: ConfigReader[PosDouble] = numeric.derivedPosDoubleConfigReader
-  inline given derivedPosDoubleConfigWriter: ConfigWriter[PosDouble] = numeric.derivedPosDoubleConfigWriter
+  given derivedPosDoubleConfigReader: ConfigReader[PosDouble] = numeric.derivedPosDoubleConfigReader
+  given derivedPosDoubleConfigWriter: ConfigWriter[PosDouble] = numeric.derivedPosDoubleConfigWriter
 
-  inline given derivedNonPosDoubleConfigReader: ConfigReader[NonPosDouble] = numeric.derivedNonPosDoubleConfigReader
-  inline given derivedNonPosDoubleConfigWriter: ConfigWriter[NonPosDouble] = numeric.derivedNonPosDoubleConfigWriter
+  given derivedNonPosDoubleConfigReader: ConfigReader[NonPosDouble] = numeric.derivedNonPosDoubleConfigReader
+  given derivedNonPosDoubleConfigWriter: ConfigWriter[NonPosDouble] = numeric.derivedNonPosDoubleConfigWriter
 
-  inline given derivedNegBigIntConfigReader: ConfigReader[NegBigInt] = numeric.derivedNegBigIntConfigReader
-  inline given derivedNegBigIntConfigWriter: ConfigWriter[NegBigInt] = numeric.derivedNegBigIntConfigWriter
+  given derivedNegBigIntConfigReader: ConfigReader[NegBigInt] = numeric.derivedNegBigIntConfigReader
+  given derivedNegBigIntConfigWriter: ConfigWriter[NegBigInt] = numeric.derivedNegBigIntConfigWriter
 
-  inline given derivedNonNegBigIntConfigReader: ConfigReader[NonNegBigInt] = numeric.derivedNonNegBigIntConfigReader
-  inline given derivedNonNegBigIntConfigWriter: ConfigWriter[NonNegBigInt] = numeric.derivedNonNegBigIntConfigWriter
+  given derivedNonNegBigIntConfigReader: ConfigReader[NonNegBigInt] = numeric.derivedNonNegBigIntConfigReader
+  given derivedNonNegBigIntConfigWriter: ConfigWriter[NonNegBigInt] = numeric.derivedNonNegBigIntConfigWriter
 
-  inline given derivedPosBigIntConfigReader: ConfigReader[PosBigInt] = numeric.derivedPosBigIntConfigReader
-  inline given derivedPosBigIntConfigWriter: ConfigWriter[PosBigInt] = numeric.derivedPosBigIntConfigWriter
+  given derivedPosBigIntConfigReader: ConfigReader[PosBigInt] = numeric.derivedPosBigIntConfigReader
+  given derivedPosBigIntConfigWriter: ConfigWriter[PosBigInt] = numeric.derivedPosBigIntConfigWriter
 
-  inline given derivedNonPosBigIntConfigReader: ConfigReader[NonPosBigInt] = numeric.derivedNonPosBigIntConfigReader
-  inline given derivedNonPosBigIntConfigWriter: ConfigWriter[NonPosBigInt] = numeric.derivedNonPosBigIntConfigWriter
+  given derivedNonPosBigIntConfigReader: ConfigReader[NonPosBigInt] = numeric.derivedNonPosBigIntConfigReader
+  given derivedNonPosBigIntConfigWriter: ConfigWriter[NonPosBigInt] = numeric.derivedNonPosBigIntConfigWriter
 
-  inline given derivedNegBigDecimalConfigReader: ConfigReader[NegBigDecimal] = numeric.derivedNegBigDecimalConfigReader
-  inline given derivedNegBigDecimalConfigWriter: ConfigWriter[NegBigDecimal] = numeric.derivedNegBigDecimalConfigWriter
+  given derivedNegBigDecimalConfigReader: ConfigReader[NegBigDecimal] = numeric.derivedNegBigDecimalConfigReader
+  given derivedNegBigDecimalConfigWriter: ConfigWriter[NegBigDecimal] = numeric.derivedNegBigDecimalConfigWriter
 
-  inline given derivedNonNegBigDecimalConfigReader: ConfigReader[NonNegBigDecimal] = numeric.derivedNonNegBigDecimalConfigReader
-  inline given derivedNonNegBigDecimalConfigWriter: ConfigWriter[NonNegBigDecimal] = numeric.derivedNonNegBigDecimalConfigWriter
+  given derivedNonNegBigDecimalConfigReader: ConfigReader[NonNegBigDecimal] = numeric.derivedNonNegBigDecimalConfigReader
+  given derivedNonNegBigDecimalConfigWriter: ConfigWriter[NonNegBigDecimal] = numeric.derivedNonNegBigDecimalConfigWriter
 
-  inline given derivedPosBigDecimalConfigReader: ConfigReader[PosBigDecimal] = numeric.derivedPosBigDecimalConfigReader
-  inline given derivedPosBigDecimalConfigWriter: ConfigWriter[PosBigDecimal] = numeric.derivedPosBigDecimalConfigWriter
+  given derivedPosBigDecimalConfigReader: ConfigReader[PosBigDecimal] = numeric.derivedPosBigDecimalConfigReader
+  given derivedPosBigDecimalConfigWriter: ConfigWriter[PosBigDecimal] = numeric.derivedPosBigDecimalConfigWriter
 
-  inline given derivedNonPosBigDecimalConfigReader: ConfigReader[NonPosBigDecimal] = numeric.derivedNonPosBigDecimalConfigReader
-  inline given derivedNonPosBigDecimalConfigWriter: ConfigWriter[NonPosBigDecimal] = numeric.derivedNonPosBigDecimalConfigWriter
+  given derivedNonPosBigDecimalConfigReader: ConfigReader[NonPosBigDecimal] = numeric.derivedNonPosBigDecimalConfigReader
+  given derivedNonPosBigDecimalConfigWriter: ConfigWriter[NonPosBigDecimal] = numeric.derivedNonPosBigDecimalConfigWriter
 
 }
 object numeric {

--- a/modules/refined4s-pureconfig/shared/src/main/scala/refined4s/modules/pureconfig/derivation/types/strings.scala
+++ b/modules/refined4s-pureconfig/shared/src/main/scala/refined4s/modules/pureconfig/derivation/types/strings.scala
@@ -10,14 +10,14 @@ import refined4s.types.strings.*
   */
 trait strings {
 
-  inline given derivedNonEmptyStringConfigReader: ConfigReader[NonEmptyString] = strings.derivedNonEmptyStringConfigReader
-  inline given derivedNonEmptyStringConfigWriter: ConfigWriter[NonEmptyString] = strings.derivedNonEmptyStringConfigWriter
+  given derivedNonEmptyStringConfigReader: ConfigReader[NonEmptyString] = strings.derivedNonEmptyStringConfigReader
+  given derivedNonEmptyStringConfigWriter: ConfigWriter[NonEmptyString] = strings.derivedNonEmptyStringConfigWriter
 
-  inline given derivedNonBlankStringConfigReader: ConfigReader[NonBlankString] = strings.derivedNonBlankStringConfigReader
-  inline given derivedNonBlankStringConfigWriter: ConfigWriter[NonBlankString] = strings.derivedNonBlankStringConfigWriter
+  given derivedNonBlankStringConfigReader: ConfigReader[NonBlankString] = strings.derivedNonBlankStringConfigReader
+  given derivedNonBlankStringConfigWriter: ConfigWriter[NonBlankString] = strings.derivedNonBlankStringConfigWriter
 
-  inline given derivedUuidConfigReader: ConfigReader[Uuid] = strings.derivedUuidConfigReader
-  inline given derivedUuidConfigWriter: ConfigWriter[Uuid] = strings.derivedUuidConfigWriter
+  given derivedUuidConfigReader: ConfigReader[Uuid] = strings.derivedUuidConfigReader
+  given derivedUuidConfigWriter: ConfigWriter[Uuid] = strings.derivedUuidConfigWriter
 
 }
 object strings {

--- a/modules/refined4s-pureconfig/shared/src/main/scala/refined4s/modules/pureconfig/derivation/types/time.scala
+++ b/modules/refined4s-pureconfig/shared/src/main/scala/refined4s/modules/pureconfig/derivation/types/time.scala
@@ -8,23 +8,23 @@ import refined4s.types.time.*
   */
 trait time {
 
-  inline given derivedMonthConfigReader: ConfigReader[Month] = time.derivedMonthConfigReader
-  inline given derivedMonthConfigWriter: ConfigWriter[Month] = time.derivedMonthConfigWriter
+  given derivedMonthConfigReader: ConfigReader[Month] = time.derivedMonthConfigReader
+  given derivedMonthConfigWriter: ConfigWriter[Month] = time.derivedMonthConfigWriter
 
-  inline given derivedDayConfigReader: ConfigReader[Day] = time.derivedDayConfigReader
-  inline given derivedDayConfigWriter: ConfigWriter[Day] = time.derivedDayConfigWriter
+  given derivedDayConfigReader: ConfigReader[Day] = time.derivedDayConfigReader
+  given derivedDayConfigWriter: ConfigWriter[Day] = time.derivedDayConfigWriter
 
-  inline given derivedHourConfigReader: ConfigReader[Hour] = time.derivedHourConfigReader
-  inline given derivedHourConfigWriter: ConfigWriter[Hour] = time.derivedHourConfigWriter
+  given derivedHourConfigReader: ConfigReader[Hour] = time.derivedHourConfigReader
+  given derivedHourConfigWriter: ConfigWriter[Hour] = time.derivedHourConfigWriter
 
-  inline given derivedMinuteConfigReader: ConfigReader[Minute] = time.derivedMinuteConfigReader
-  inline given derivedMinuteConfigWriter: ConfigWriter[Minute] = time.derivedMinuteConfigWriter
+  given derivedMinuteConfigReader: ConfigReader[Minute] = time.derivedMinuteConfigReader
+  given derivedMinuteConfigWriter: ConfigWriter[Minute] = time.derivedMinuteConfigWriter
 
-  inline given derivedSecondConfigReader: ConfigReader[Second] = time.derivedSecondConfigReader
-  inline given derivedSecondConfigWriter: ConfigWriter[Second] = time.derivedSecondConfigWriter
+  given derivedSecondConfigReader: ConfigReader[Second] = time.derivedSecondConfigReader
+  given derivedSecondConfigWriter: ConfigWriter[Second] = time.derivedSecondConfigWriter
 
-  inline given derivedMillisConfigReader: ConfigReader[Millis] = time.derivedMillisConfigReader
-  inline given derivedMillisConfigWriter: ConfigWriter[Millis] = time.derivedMillisConfigWriter
+  given derivedMillisConfigReader: ConfigReader[Millis] = time.derivedMillisConfigReader
+  given derivedMillisConfigWriter: ConfigWriter[Millis] = time.derivedMillisConfigWriter
 
 }
 object time {

--- a/modules/refined4s-tapir/shared/src/main/scala/refined4s/modules/tapir/derivation/generic/auto.scala
+++ b/modules/refined4s-tapir/shared/src/main/scala/refined4s/modules/tapir/derivation/generic/auto.scala
@@ -7,29 +7,15 @@ import sttp.tapir.Schema
   * @since 2024-04-03
   */
 trait auto {
-  inline given derivedNewtypeSchema[A, B](
-    using coercibleA2B: Coercible[A, B],
-    coercibleB2A: Coercible[B, A],
-    schemaB: Schema[B],
-  ): Schema[A] = auto.derivedNewtypeSchema
 
-  inline given derivedRefinedSchema[A, B](
-    using refinedCtor: RefinedCtor[A, B],
-    coercibleA2B: Coercible[A, B],
-    schemaB: Schema[B],
-  ): Schema[A] = auto.derivedRefinedSchema
-
-}
-object auto {
-
-  inline given derivedNewtypeSchema[A, B](
+  given derivedNewtypeSchema[A, B](
     using coercibleA2B: Coercible[A, B],
     coercibleB2A: Coercible[B, A],
     schemaB: Schema[B],
   ): Schema[A] =
     schemaB.map(b => Some(coercibleB2A(b)))(coercibleA2B(_))
 
-  inline given derivedRefinedSchema[A, B](
+  given derivedRefinedSchema[A, B](
     using refinedCtor: RefinedCtor[A, B],
     coercibleA2B: Coercible[A, B],
     schemaB: Schema[B],
@@ -37,3 +23,4 @@ object auto {
     schemaB.map(refinedCtor.create(_).toOption)(coercibleA2B(_))
 
 }
+object auto extends auto

--- a/modules/refined4s-tapir/shared/src/main/scala/refined4s/modules/tapir/derivation/types/network.scala
+++ b/modules/refined4s-tapir/shared/src/main/scala/refined4s/modules/tapir/derivation/types/network.scala
@@ -8,19 +8,19 @@ import sttp.tapir.Schema
   */
 trait network {
 
-  inline given schemaUri: Schema[Uri] = network.derivedUriSchema
+  given schemaUri: Schema[Uri] = network.derivedUriSchema
 
-  inline given schemaUrl: Schema[Url] = network.derivedUrlSchema
+  given schemaUrl: Schema[Url] = network.derivedUrlSchema
 
-  inline given schemaPortNumber: Schema[PortNumber] = network.derivedPortNumberSchema
+  given schemaPortNumber: Schema[PortNumber] = network.derivedPortNumberSchema
 
-  inline given schemaSystemPortNumber: Schema[SystemPortNumber] = network.derivedSystemPortNumberSchema
+  given schemaSystemPortNumber: Schema[SystemPortNumber] = network.derivedSystemPortNumberSchema
 
-  inline given schemaNonSystemPortNumber: Schema[NonSystemPortNumber] = network.derivedNonSystemPortNumberSchema
+  given schemaNonSystemPortNumber: Schema[NonSystemPortNumber] = network.derivedNonSystemPortNumberSchema
 
-  inline given schemaUserPortNumber: Schema[UserPortNumber] = network.derivedUserPortNumberSchema
+  given schemaUserPortNumber: Schema[UserPortNumber] = network.derivedUserPortNumberSchema
 
-  inline given schemaDynamicPortNumber: Schema[DynamicPortNumber] = network.derivedDynamicPortNumberSchema
+  given schemaDynamicPortNumber: Schema[DynamicPortNumber] = network.derivedDynamicPortNumberSchema
 
 }
 object network {

--- a/modules/refined4s-tapir/shared/src/main/scala/refined4s/modules/tapir/derivation/types/numeric.scala
+++ b/modules/refined4s-tapir/shared/src/main/scala/refined4s/modules/tapir/derivation/types/numeric.scala
@@ -8,69 +8,69 @@ import sttp.tapir.Schema
   */
 trait numeric {
 
-  inline given schemaNegInt: Schema[NegInt] = numeric.derivedNegIntSchema
+  given schemaNegInt: Schema[NegInt] = numeric.derivedNegIntSchema
 
-  inline given schemaNonNegInt: Schema[NonNegInt] = numeric.derivedNonNegIntSchema
+  given schemaNonNegInt: Schema[NonNegInt] = numeric.derivedNonNegIntSchema
 
-  inline given schemaPosInt: Schema[PosInt] = numeric.derivedPosIntSchema
+  given schemaPosInt: Schema[PosInt] = numeric.derivedPosIntSchema
 
-  inline given schemaNonPosInt: Schema[NonPosInt] = numeric.derivedNonPosIntSchema
+  given schemaNonPosInt: Schema[NonPosInt] = numeric.derivedNonPosIntSchema
 
-  inline given schemaNegLong: Schema[NegLong] = numeric.derivedNegLongSchema
+  given schemaNegLong: Schema[NegLong] = numeric.derivedNegLongSchema
 
-  inline given schemaNonNegLong: Schema[NonNegLong] = numeric.derivedNonNegLongSchema
+  given schemaNonNegLong: Schema[NonNegLong] = numeric.derivedNonNegLongSchema
 
-  inline given schemaPosLong: Schema[PosLong] = numeric.derivedPosLongSchema
+  given schemaPosLong: Schema[PosLong] = numeric.derivedPosLongSchema
 
-  inline given schemaNonPosLong: Schema[NonPosLong] = numeric.derivedNonPosLongSchema
+  given schemaNonPosLong: Schema[NonPosLong] = numeric.derivedNonPosLongSchema
 
-  inline given schemaNegShort: Schema[NegShort] = numeric.derivedNegShortSchema
+  given schemaNegShort: Schema[NegShort] = numeric.derivedNegShortSchema
 
-  inline given schemaNonNegShort: Schema[NonNegShort] = numeric.derivedNonNegShortSchema
+  given schemaNonNegShort: Schema[NonNegShort] = numeric.derivedNonNegShortSchema
 
-  inline given schemaPosShort: Schema[PosShort] = numeric.derivedPosShortSchema
+  given schemaPosShort: Schema[PosShort] = numeric.derivedPosShortSchema
 
-  inline given schemaNonPosShort: Schema[NonPosShort] = numeric.derivedNonPosShortSchema
+  given schemaNonPosShort: Schema[NonPosShort] = numeric.derivedNonPosShortSchema
 
-  inline given schemaNegByte: Schema[NegByte] = numeric.derivedNegByteSchema
+  given schemaNegByte: Schema[NegByte] = numeric.derivedNegByteSchema
 
-  inline given schemaNonNegByte: Schema[NonNegByte] = numeric.derivedNonNegByteSchema
+  given schemaNonNegByte: Schema[NonNegByte] = numeric.derivedNonNegByteSchema
 
-  inline given schemaPosByte: Schema[PosByte] = numeric.derivedPosByteSchema
+  given schemaPosByte: Schema[PosByte] = numeric.derivedPosByteSchema
 
-  inline given schemaNonPosByte: Schema[NonPosByte] = numeric.derivedNonPosByteSchema
+  given schemaNonPosByte: Schema[NonPosByte] = numeric.derivedNonPosByteSchema
 
-  inline given schemaNegFloat: Schema[NegFloat] = numeric.derivedNegFloatSchema
+  given schemaNegFloat: Schema[NegFloat] = numeric.derivedNegFloatSchema
 
-  inline given schemaNonNegFloat: Schema[NonNegFloat] = numeric.derivedNonNegFloatSchema
+  given schemaNonNegFloat: Schema[NonNegFloat] = numeric.derivedNonNegFloatSchema
 
-  inline given schemaPosFloat: Schema[PosFloat] = numeric.derivedPosFloatSchema
+  given schemaPosFloat: Schema[PosFloat] = numeric.derivedPosFloatSchema
 
-  inline given schemaNonPosFloat: Schema[NonPosFloat] = numeric.derivedNonPosFloatSchema
+  given schemaNonPosFloat: Schema[NonPosFloat] = numeric.derivedNonPosFloatSchema
 
-  inline given schemaNegDouble: Schema[NegDouble] = numeric.derivedNegDoubleSchema
+  given schemaNegDouble: Schema[NegDouble] = numeric.derivedNegDoubleSchema
 
-  inline given schemaNonNegDouble: Schema[NonNegDouble] = numeric.derivedNonNegDoubleSchema
+  given schemaNonNegDouble: Schema[NonNegDouble] = numeric.derivedNonNegDoubleSchema
 
-  inline given schemaPosDouble: Schema[PosDouble] = numeric.derivedPosDoubleSchema
+  given schemaPosDouble: Schema[PosDouble] = numeric.derivedPosDoubleSchema
 
-  inline given schemaNonPosDouble: Schema[NonPosDouble] = numeric.derivedNonPosDoubleSchema
+  given schemaNonPosDouble: Schema[NonPosDouble] = numeric.derivedNonPosDoubleSchema
 
-  inline given schemaNegBigInt: Schema[NegBigInt] = numeric.derivedNegBigIntSchema
+  given schemaNegBigInt: Schema[NegBigInt] = numeric.derivedNegBigIntSchema
 
-  inline given schemaNonNegBigInt: Schema[NonNegBigInt] = numeric.derivedNonNegBigIntSchema
+  given schemaNonNegBigInt: Schema[NonNegBigInt] = numeric.derivedNonNegBigIntSchema
 
-  inline given schemaPosBigInt: Schema[PosBigInt] = numeric.derivedPosBigIntSchema
+  given schemaPosBigInt: Schema[PosBigInt] = numeric.derivedPosBigIntSchema
 
-  inline given schemaNonPosBigInt: Schema[NonPosBigInt] = numeric.derivedNonPosBigIntSchema
+  given schemaNonPosBigInt: Schema[NonPosBigInt] = numeric.derivedNonPosBigIntSchema
 
-  inline given schemaNegBigDecimal: Schema[NegBigDecimal] = numeric.derivedNegBigDecimalSchema
+  given schemaNegBigDecimal: Schema[NegBigDecimal] = numeric.derivedNegBigDecimalSchema
 
-  inline given schemaNonNegBigDecimal: Schema[NonNegBigDecimal] = numeric.derivedNonNegBigDecimalSchema
+  given schemaNonNegBigDecimal: Schema[NonNegBigDecimal] = numeric.derivedNonNegBigDecimalSchema
 
-  inline given schemaPosBigDecimal: Schema[PosBigDecimal] = numeric.derivedPosBigDecimalSchema
+  given schemaPosBigDecimal: Schema[PosBigDecimal] = numeric.derivedPosBigDecimalSchema
 
-  inline given schemaNonPosBigDecimal: Schema[NonPosBigDecimal] = numeric.derivedNonPosBigDecimalSchema
+  given schemaNonPosBigDecimal: Schema[NonPosBigDecimal] = numeric.derivedNonPosBigDecimalSchema
 
 }
 object numeric {

--- a/modules/refined4s-tapir/shared/src/main/scala/refined4s/modules/tapir/derivation/types/strings.scala
+++ b/modules/refined4s-tapir/shared/src/main/scala/refined4s/modules/tapir/derivation/types/strings.scala
@@ -10,11 +10,11 @@ import java.util.UUID
   */
 trait strings {
 
-  inline given schemaNonEmptyString: Schema[NonEmptyString] = strings.derivedNonEmptyStringSchema
+  given schemaNonEmptyString: Schema[NonEmptyString] = strings.derivedNonEmptyStringSchema
 
-  inline given schemaNonBlankString: Schema[NonBlankString] = strings.derivedNonBlankStringSchema
+  given schemaNonBlankString: Schema[NonBlankString] = strings.derivedNonBlankStringSchema
 
-  inline given schemaUuid: Schema[Uuid] = strings.derivedUuidSchema
+  given schemaUuid: Schema[Uuid] = strings.derivedUuidSchema
 
 }
 object strings {

--- a/modules/refined4s-tapir/shared/src/main/scala/refined4s/modules/tapir/derivation/types/time.scala
+++ b/modules/refined4s-tapir/shared/src/main/scala/refined4s/modules/tapir/derivation/types/time.scala
@@ -8,17 +8,17 @@ import refined4s.types.time.*
   */
 trait time {
 
-  inline given derivedMonthSchema: Schema[Month] = time.derivedMonthSchema
+  given derivedMonthSchema: Schema[Month] = time.derivedMonthSchema
 
-  inline given derivedDaySchema: Schema[Day] = time.derivedDaySchema
+  given derivedDaySchema: Schema[Day] = time.derivedDaySchema
 
-  inline given derivedHourSchema: Schema[Hour] = time.derivedHourSchema
+  given derivedHourSchema: Schema[Hour] = time.derivedHourSchema
 
-  inline given derivedMinuteSchema: Schema[Minute] = time.derivedMinuteSchema
+  given derivedMinuteSchema: Schema[Minute] = time.derivedMinuteSchema
 
-  inline given derivedSecondSchema: Schema[Second] = time.derivedSecondSchema
+  given derivedSecondSchema: Schema[Second] = time.derivedSecondSchema
 
-  inline given derivedMillisSchema: Schema[Millis] = time.derivedMillisSchema
+  given derivedMillisSchema: Schema[Millis] = time.derivedMillisSchema
 
 }
 object time {


### PR DESCRIPTION
Fix #531: `inline given`s in `trait`s for type classes cause `unused import` warnings