### PR TITLE
refined4s v1.10.1

### DIFF
--- a/changelogs/1.10.1.md
+++ b/changelogs/1.10.1.md
@@ -1,0 +1,38 @@
+## [1.10.1](https://github.com/kevin-lee/refined4s/issues?q=is%3Aissue%20is%3Aclosed%20-label%3Ainvalid%20-label%3Awontfix%20milestone%3Am32) - 2025-09-26
+
+### Bug Fixed
+
+* Fixed: `inline given`s in `trait`s for type classes cause `unused import` warnings (#531)
+
+  ```scala 3
+  trait MyTypeClass {
+    inline given someTypeClass[A]: SomeTypeClass[A] = MyTypeClass.someTypeClass
+  }
+  object MyTypeClass {
+    given someTypeClass[A]: MyTypeClass[A] = ...
+  }
+  
+  trait all extends MyTypeClass
+  trait all extends all
+  ```
+  Suppose the following code requires `SomeTypeClass[A]`, so it's required to import `MyTypeClass.given` or `all.given`.
+  ```scala 3
+  import all.given
+  
+  // Some code that requires an instance of SomeTypeClass[A]
+  ```
+  This causes
+  ```
+               import all.given
+  [warn]    |             ^^^^^
+  [warn]    |             unused import
+  ```
+  whereas
+  ```scala 3
+  import MyTypeClass.given
+  
+  // Some code that requires an instance of SomeTypeClass[A]
+  ```
+  just compiles.
+
+  The issue was fixed by removing `inline`s from `inline given`s. The ones removed were neither required nor beneficial.


### PR DESCRIPTION
# refined4s v1.10.1
## [1.10.1](https://github.com/kevin-lee/refined4s/issues?q=is%3Aissue%20is%3Aclosed%20-label%3Ainvalid%20-label%3Awontfix%20milestone%3Am32) - 2025-09-26

### Bug Fixed

* Fixed: `inline given`s in `trait`s for type classes cause `unused import` warnings (#531)

  ```scala 3
  trait MyTypeClass {
    inline given someTypeClass[A]: SomeTypeClass[A] = MyTypeClass.someTypeClass
  }
  object MyTypeClass {
    given someTypeClass[A]: MyTypeClass[A] = ...
  }
  
  trait all extends MyTypeClass
  trait all extends all
  ```
  Suppose the following code requires `SomeTypeClass[A]`, so it's required to import `MyTypeClass.given` or `all.given`.
  ```scala 3
  import all.given
  
  // Some code that requires an instance of SomeTypeClass[A]
  ```
  This causes
  ```
               import all.given
  [warn]    |             ^^^^^
  [warn]    |             unused import
  ```
  whereas
  ```scala 3
  import MyTypeClass.given
  
  // Some code that requires an instance of SomeTypeClass[A]
  ```
  just compiles.

  The issue was fixed by removing `inline`s from `inline given`s. The ones removed were neither required nor beneficial.
