### PR TITLE
refined4s v1.11.0

### DIFF
--- a/changelogs/1.11.0.md
+++ b/changelogs/1.11.0.md
@@ -1,0 +1,7 @@
+## [1.11.0](https://github.com/kevin-lee/refined4s/issues?q=is%3Aissue%20is%3Aclosed%20-label%3Ainvalid%20-label%3Awontfix%20milestone%3Am33) - 2025-09-29
+
+### Changes
+
+#### Use the `java.net.URL` constructor for `Url` again (#535)
+
+Existing projects using the older versions of `refined4s` might be broken due to [this change](https://github.com/kevin-lee/refined4s/commit/d500258dcbf067b64c73843cdf43351633457756) in [v1.9.0](https://github.com/kevin-lee/refined4s/releases/tag/v1.9.0). So, the previous change should be reverted.


### PR DESCRIPTION
# refined4s v1.11.0
## [1.11.0](https://github.com/kevin-lee/refined4s/issues?q=is%3Aissue%20is%3Aclosed%20-label%3Ainvalid%20-label%3Awontfix%20milestone%3Am33) - 2025-09-29

### Changes

#### Use the `java.net.URL` constructor for `Url` again (#535)

Existing projects using the older versions of `refined4s` might be broken due to [this change](https://github.com/kevin-lee/refined4s/commit/d500258dcbf067b64c73843cdf43351633457756) in [v1.9.0](https://github.com/kevin-lee/refined4s/releases/tag/v1.9.0). So, the previous change should be reverted.
