### PR TITLE
Close #544: [refined4s-core] Add better error messages for Uri.from, Uri.unsafeFrom, Url.from and Url.unsafeFrom

### DIFF
--- a/modules/refined4s-core/js/src/main/scala/refined4s/types/networkCompat.scala
+++ b/modules/refined4s-core/js/src/main/scala/refined4s/types/networkCompat.scala
@@ -18,18 +18,14 @@ object networkCompat {
   type Url = Url.Type
   object Url extends InlinedRefined[String], UrlTypeClassInstances {
 
-    override def invalidReason(a: String): String =
-      expectedMessage(inlinedExpectedValue)
+    override def invalidReason(a: String): String = s"Invalid Url value: [$a]."
 
     @SuppressWarnings(Array("org.wartremover.warts.JavaNetURLConstructors"))
-    override def predicate(a: String): Boolean =
-      validate(a) match {
-        case Left(err) =>
-//          println(err)
-          false
-        case Right(_) =>
-          true
-      }
+    override def predicate(a: String): Boolean = validate(a).isRight
+
+    @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
+    override def from(a: String): Either[String, Url] =
+      validate(a).map(_.asInstanceOf[Url]) // scalafix:ok DisableSyntax.asInstanceOf
 
     def validate(url: String): Either[String, String] =
       try {
@@ -57,11 +53,11 @@ object networkCompat {
         then Right(url)
         else
           Left(
-            s"Invalid URL. URL: $url, The following propert${if errors.lengthIs > 1 then "ies are" else "y is"} invalid: ${errors.mkString("[", ", ", "]")}"
+            s"${invalidReason(url)} The following propert${if errors.lengthIs > 1 then "ies are" else "y is"} invalid: ${errors.mkString("[", ", ", "]")}"
           )
       } catch {
         case NonFatal(err) =>
-          Left(s"Invalid URL. URL: $url, Error: ${err.getMessage}")
+          Left(s"${invalidReason(url)} ${err.getMessage}")
       }
 
     override inline val inlinedExpectedValue = "a URL String"
@@ -133,7 +129,7 @@ object networkCompat {
           if validity then Expr(validity)
           else {
             report.error(
-              "Invalid Url value: " +
+              "Invalid Url value: [" + urlStr + "]. " +
                 List(
                   (if isValidSchemas then "" else "invalid schema"),
                   (if isValidAuthority then "" else "invalid authority"),
@@ -147,7 +143,7 @@ object networkCompat {
         } catch {
           case ex: Throwable =>
             report.error(
-              "Invalid Url value: " + ex.getMessage,
+              "Invalid Url value: [" + urlStr + "]. " + ex.getMessage,
               urlExpr,
             )
             Expr(false)

--- a/modules/refined4s-core/shared/src/main/scala/refined4s/types/network.scala
+++ b/modules/refined4s-core/shared/src/main/scala/refined4s/types/network.scala
@@ -51,16 +51,19 @@ object network {
   type Uri = Uri.Type
   object Uri extends InlinedRefined[String], UriTypeClassInstances {
 
-    override def invalidReason(a: String): String =
-      expectedMessage(inlinedExpectedValue)
+    override def invalidReason(a: String): String = s"Invalid Uri value: [$a]."
 
     override def predicate(a: String): Boolean =
+      from(a).isRight
+
+    @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
+    override def from(a: String): Either[String, Uri] =
       try {
         new URI(a)
-        true
+        Right(a.asInstanceOf[Uri]) // scalafix:ok DisableSyntax.asInstanceOf
       } catch {
-        case NonFatal(_) =>
-          false
+        case NonFatal(ex) =>
+          Left(s"${invalidReason(a)} ${ex.getMessage}")
       }
 
     override inline val inlinedExpectedValue = "a URI String"

--- a/modules/test-refined4s-core-without-cats/native/src/test/scala/refined4s/types/networkCompatSpec.scala
+++ b/modules/test-refined4s-core-without-cats/native/src/test/scala/refined4s/types/networkCompatSpec.scala
@@ -19,6 +19,8 @@ trait networkCompatSpec {
     example("test Url(valid URL String)", testUrlApply),
     //    example("test Url(URL)", testUrlApplyURL),
     example("test Url(invalid URL String)", testUrlApplyInvalid),
+    property("test Url.predicate(valid)", testUrlPredicateValid),
+    property("test Url.predicate(invalid)", testUrlPredicateInvalid),
     property("test Url.from(valid)", testUrlFromValid),
     property("test Url.from(invalid)", testUrlFromInvalid),
     property("test Url.unsafeFrom(valid)", testUrlUnsafeFromValid),
@@ -89,8 +91,8 @@ trait networkCompatSpec {
       """
     )
 
-    val expectedErrorMessage1 = """Invalid Url value: Malformed escape pair at index 0: %^<>[]`{}"""
-    val expectedErrorMessage2 = """Invalid Url value: invalid schema"""
+    val expectedErrorMessage1 = """Invalid Url value: [%^<>[]`{}]. Malformed escape pair at index 0: %^<>[]`{}"""
+    val expectedErrorMessage2 = """Invalid Url value: [blah://www.google.com]. invalid schema"""
 
     val shouldNotCompile1ErrorMessage = typeCheckErrors(
       """
@@ -115,6 +117,41 @@ trait networkCompatSpec {
       )
     )
   }
+
+  def testUrlPredicateValid: Property =
+    for {
+      url <- networkGens.genUrlString.log("url")
+    } yield {
+      val expected = true
+      val actual   = Url.predicate(url)
+
+      actual ==== expected
+    }
+
+  def testUrlPredicateInvalid: Property =
+    for {
+      input <- Gen
+                 .frequency1(
+                   30 ->
+                     Gen.string(Gen.element1('%', '^', '<', '>', '[', ']', '`', '{', '}'), Range.linear(1, 5)),
+                   70 -> (for {
+                     scheme    <- Gen.string(Gen.alpha, Range.linear(3, 10)).map {
+                                    case "http" | "https" | "ftp" | "file" => "blah"
+                                    case anythingElse => anythingElse
+                                  }
+                     authority <- Gen
+                                    .string(Gen.alphaNum, Range.linear(3, 10))
+                                    .list(Range.linear(1, 4))
+                                    .map(_.mkString("."))
+                   } yield s"$scheme/$authority"),
+                 )
+                 .log("input")
+    } yield {
+      val expected = false
+      val actual   = Url.predicate(input)
+
+      actual ==== expected
+    }
 
   def testUrlFromValid: Property =
     for {
@@ -150,10 +187,26 @@ trait networkCompatSpec {
                  )
                  .log("input")
     } yield {
-      val expected = s"Invalid value: [$input]. It must be a URL String".asLeft
-      val actual   = Url.from(input)
+      val expected = Url.validate(input)
 
-      actual ==== expected
+      val expectedStartWith = s"Invalid Url value: [$input]"
+
+      val actual = Url.from(input)
+
+      Result.all(
+        List(
+          actual
+            .left
+            .map(err => {
+              Result
+                .assert(err.startsWith(expectedStartWith))
+                .log(s"The error message, $err, doesn't start with '$expectedStartWith'")
+            })
+            .swap
+            .getOrElse(Result.failure.log(s"expected Left(error message) but get $actual instead")),
+          actual ==== expected,
+        )
+      )
     }
 
   def testUrlUnsafeFromValid: Property =
@@ -190,7 +243,7 @@ trait networkCompatSpec {
                  )
                  .log("input")
     } yield {
-      val expected = s"Invalid value: [$input]. It must be a URL String"
+      val expectedMessage = Url.validate(input)
 
       try {
         val _ = Url.unsafeFrom(input)
@@ -201,7 +254,26 @@ trait networkCompatSpec {
           )
       } catch {
         case ex: IllegalArgumentException =>
-          ex.getMessage ==== expected
+          val expectedStartWith = s"Invalid Url value: [$input]"
+
+          val actual = ex.getMessage
+          Result.all(
+            List(
+              Result.assert(ex.getMessage.startsWith(expectedStartWith)).log(s"The error message doesn't start with '$expectedStartWith'"),
+              expectedMessage
+                .left
+                .map(expected => actual ==== expected)
+                .swap
+                .getOrElse(
+                  Result
+                    .failure
+                    .log(
+                      s"""expected error message generation failed. Expected Left(error message) but get $expectedMessage instead.
+                         |  NOTE: It's not the failure of Url.unsafeFrom but Url.validate.""".stripMargin
+                    )
+                ),
+            )
+          )
       }
     }
 
@@ -273,8 +345,8 @@ trait networkCompatSpec {
     val actual1  = typeChecks("""runNetworkIsValidateUrl("%^<>[]`{}")""")
     val actual2  = typeChecks("""runNetworkIsValidateUrl("blah://www.google.com")""")
 
-    val expectedErrorMessage1 = """Invalid Url value: Malformed escape pair at index 0: %^<>[]`{}"""
-    val expectedErrorMessage2 = """Invalid Url value: invalid schema"""
+    val expectedErrorMessage1 = """Invalid Url value: [%^<>[]`{}]. Malformed escape pair at index 0: %^<>[]`{}"""
+    val expectedErrorMessage2 = """Invalid Url value: [blah://www.google.com]. invalid schema"""
 
     val actualErrorMessage1 = typeCheckErrors("""runNetworkIsValidateUrl("%^<>[]`{}")""").map(_.message).mkString
     val actualErrorMessage2 = typeCheckErrors("""runNetworkIsValidateUrl("blah://www.google.com")""").map(_.message).mkString


### PR DESCRIPTION
Close #544: [`refined4s-core`] Add better error messages for `Uri.from`, `Uri.unsafeFrom`, `Url.from` and `Url.unsafeFrom`