### PR TITLE
refined4s v1.13.0

### DIFF
--- a/changelogs/1.13.0.md
+++ b/changelogs/1.13.0.md
@@ -1,0 +1,30 @@
+## [1.13.0](https://github.com/kevin-lee/refined4s/issues?q=is%3Aissue%20is%3Aclosed%20-label%3Ainvalid%20-label%3Awontfix%20milestone%3Am35) - 2025-11-04
+
+### Changes
+
+#### [`refined4s-core`] Add better error messages for `Uri.from`, `Uri.unsafeFrom`, `Url.from` and `Url.unsafeFrom` (#544)
+
+* `Uri`
+  ```scala 3
+  Uri.from("%^<>[]`{}")
+  // Either[String, refined4s.types.network.Uri] = Left(Invalid Uri value: [%^<>[]`{}]. Malformed escape pair at index 0: %^<>[]`{})
+  
+  Uri.unsafeFrom("%^<>[]`{}")
+  // java.lang.IllegalArgumentException: Invalid Uri value: [%^<>[]`{}]. Malformed escape pair at index 0: %^<>[]`{}
+  ```
+
+* `Url`
+  ```scala 3
+  Url.from("%^<>[]`{}")
+  // Either[String, refined4s.types.networkCompat.Url] = Left(Invalid Url value: [%^<>[]`{}]. no protocol: %^<>[]`{})
+  
+  Url.unsafeFrom("%^<>[]`{}")
+  // java.lang.IllegalArgumentException: Invalid Url value: [%^<>[]`{}]. no protocol: %^<>[]`{}
+  ```
+  ```scala 3
+  Url.from("blah://www.google.com")
+  // Either[String, refined4s.types.networkCompat.Url] = Left(Invalid Url value: [blah://www.google.com]. unknown protocol: blah)
+  
+  Url.unsafeFrom("blah://www.google.com")
+  // java.lang.IllegalArgumentException: Invalid Url value: [blah://www.google.com]. unknown protocol: blah
+  ```


### PR DESCRIPTION
# refined4s v1.13.0
## [1.13.0](https://github.com/kevin-lee/refined4s/issues?q=is%3Aissue%20is%3Aclosed%20-label%3Ainvalid%20-label%3Awontfix%20milestone%3Am35) - 2025-11-04

### Changes

#### [`refined4s-core`] Add better error messages for `Uri.from`, `Uri.unsafeFrom`, `Url.from` and `Url.unsafeFrom` (#544)

* `Uri`
  ```scala 3
  Uri.from("%^<>[]`{}")
  // Either[String, refined4s.types.network.Uri] = Left(Invalid Uri value: [%^<>[]`{}]. Malformed escape pair at index 0: %^<>[]`{})
  
  Uri.unsafeFrom("%^<>[]`{}")
  // java.lang.IllegalArgumentException: Invalid Uri value: [%^<>[]`{}]. Malformed escape pair at index 0: %^<>[]`{}
  ```

* `Url`
  ```scala 3
  Url.from("%^<>[]`{}")
  // Either[String, refined4s.types.networkCompat.Url] = Left(Invalid Url value: [%^<>[]`{}]. no protocol: %^<>[]`{})
  
  Url.unsafeFrom("%^<>[]`{}")
  // java.lang.IllegalArgumentException: Invalid Url value: [%^<>[]`{}]. no protocol: %^<>[]`{}
  ```
  ```scala 3
  Url.from("blah://www.google.com")
  // Either[String, refined4s.types.networkCompat.Url] = Left(Invalid Url value: [blah://www.google.com]. unknown protocol: blah)
  
  Url.unsafeFrom("blah://www.google.com")
  // java.lang.IllegalArgumentException: Invalid Url value: [blah://www.google.com]. unknown protocol: blah
  ```
