### PR TITLE
Close #550: [`refined4s-doobie-ce3`] Upgrade doobie for `cats-effect 3` to `1.0.0-RC10`

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -524,7 +524,7 @@ lazy val props =
     val HedgehogVersion      = "0.13.0"
     val HedgehogExtraVersion = "0.15.0"
 
-    val ExtrasVersion = "0.49.0"
+    val ExtrasVersion = "0.50.0"
 
     val CatsVersion = "2.12.0"
 
@@ -533,7 +533,7 @@ lazy val props =
     val PureconfigVersion = "0.17.1"
 
     val DoobieCe2Version = "0.13.4"
-    val DoobieCe3Version = "1.0.0-RC2"
+    val DoobieCe3Version = "1.0.0-RC10"
 
     val EmbeddedPostgresVersion = "2.0.7"
 

--- a/modules/refined4s-doobie-ce3/shared/src/test/scala/extras/doobie/RunWithDb.scala
+++ b/modules/refined4s-doobie-ce3/shared/src/test/scala/extras/doobie/RunWithDb.scala
@@ -60,6 +60,7 @@ trait RunWithDb {
                                 url,
                                 user,
                                 password,
+                                none,
                               )
                             )
 

--- a/modules/refined4s-doobie-ce3/shared/src/test/scala/refined4s/modules/doobie/derivation/ExampleWithDoobieGetPut.scala
+++ b/modules/refined4s-doobie-ce3/shared/src/test/scala/refined4s/modules/doobie/derivation/ExampleWithDoobieGetPut.scala
@@ -1,6 +1,7 @@
 package refined4s.modules.doobie.derivation
 
 import cats.*
+import doobie.*
 import refined4s.*
 import refined4s.modules.cats.derivation.*
 import refined4s.modules.doobie.derivation.generic.auto.given
@@ -11,7 +12,8 @@ final case class ExampleWithDoobieGetPut(
   name: ExampleWithDoobieGetPut.Name,
   note: ExampleWithDoobieGetPut.Note,
   count: ExampleWithDoobieGetPut.Count,
-)
+) derives Read,
+      Write
 object ExampleWithDoobieGetPut {
 
   given eqExampleWithDoobieGetPut: Eq[ExampleWithDoobieGetPut]     = Eq.fromUniversalEquals

--- a/modules/refined4s-doobie-ce3/shared/src/test/scala/refined4s/modules/doobie/derivation/generic/autoSpec.scala
+++ b/modules/refined4s-doobie-ce3/shared/src/test/scala/refined4s/modules/doobie/derivation/generic/autoSpec.scala
@@ -3,7 +3,7 @@ package refined4s.modules.doobie.derivation.generic
 import cats.*
 import cats.effect.*
 import cats.syntax.all.*
-import doobie.syntax.all.*
+import doobie.implicits.*
 import extras.doobie.RunWithDb
 import extras.doobie.ce3.DbTools
 import extras.hedgehog.ce3.CatsEffectRunner


### PR DESCRIPTION
Close #550: [`refined4s-doobie-ce3`] Upgrade doobie for `cats-effect 3` to `1.0.0-RC10`

- Also, update extras to 0.50.0
- Update tests to accommodate changes in Doobie
  - including updating imports to `doobie.implicits.*`,
  - adding `Read` and `Write` derivation to `ExampleWithDoobieGetPut`,
  - and updating method arguments in `RunWithDb`.