### PR TITLE
refined4s v1.14.2

### DIFF
--- a/changelogs/1.14.2.md
+++ b/changelogs/1.14.2.md
@@ -1,0 +1,9 @@
+## [1.14.2](https://github.com/kevin-lee/refined4s/issues?q=is%3Aissue%20is%3Aclosed%20-label%3Ainvalid%20-label%3Awontfix%20milestone%3Am38) - 2026-02-03
+
+### Bug Fixed
+
+* [`refined4s-core`] `MinValue` and `MaxValue` in `Min`, `Max`, and `MinMax` are incorrectly set if `min` and `max` are declared as `val`s rather than `def`s (#560)
+
+### Internal Housekeeping
+
+* Move doc site to `refined4s-docs` (#558)


### PR DESCRIPTION
# refined4s v1.14.2
## [1.14.2](https://github.com/kevin-lee/refined4s/issues?q=is%3Aissue%20is%3Aclosed%20-label%3Ainvalid%20-label%3Awontfix%20milestone%3Am38) - 2026-02-03

### Bug Fixed

* [`refined4s-core`] `MinValue` and `MaxValue` in `Min`, `Max`, and `MinMax` are incorrectly set if `min` and `max` are declared as `val`s rather than `def`s (#560)

### Internal Housekeeping

* Move doc site to `refined4s-docs` (#558)
