### PR TITLE
refined4s v1.15.0

### DIFF
--- a/changelogs/1.15.0.md
+++ b/changelogs/1.15.0.md
@@ -1,0 +1,106 @@
+## [1.15.0](https://github.com/kevin-lee/refined4s/issues?q=is%3Aissue%20is%3Aclosed%20-label%3Ainvalid%20-label%3Awontfix%20milestone%3Am39) - 2026-02-06
+
+### New Features
+
+* Add `InlinedNumericMin`, `InlinedNumericMax` and `InlinedNumericMinMax` (#563)
+
+```scala 3
+import refined4s.types.numeric.*
+
+type MyMinInt = MyMinInt.Type
+object MyMinInt extends InlinedNumericMin[Int] {
+
+  override inline def minValue: Int = 10
+
+}
+
+MyMinInt(10)
+// MyMinInt.Type = 10
+
+MyMinInt(9)
+-- Error: ----------------------------------------------------------------------
+   |MyMinInt(9)
+   |^^^^^^^^^^^
+   |Invalid value: [9]. It must be >= 10.
+   |----------------------------------------------------------------------------
+   |Inline stack trace
+   |- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+   |This location contains code that was inlined from rs$line$5:1
+   |    else RefinedMacros.internalError(a, inlinedExpectedValue)
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    ----------------------------------------------------------------------------
+1 error found
+```
+```scala 3
+import refined4s.types.numeric.*
+
+type MyMaxInt = MyMaxInt.Type
+object MyMaxInt extends InlinedNumericMax[Int] {
+
+  override inline def maxValue: Int = 100
+
+}
+
+MyMaxInt(100)
+// MyMaxInt.Type = 100
+
+MyMaxInt(101)
+-- Error: ----------------------------------------------------------------------
+   |MyMaxInt(101)
+   |^^^^^^^^^^^^^
+   |Invalid value: [101]. It must be <= 100.
+   |----------------------------------------------------------------------------
+   |Inline stack trace
+   |- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+   |This location contains code that was inlined from rs$line$6:1
+   |    else RefinedMacros.internalError(a, inlinedExpectedValue)
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    ----------------------------------------------------------------------------
+1 error found
+```
+```scala 3
+import refined4s.types.numeric.*
+
+type MyMinMaxInt = MyMinMaxInt.Type
+object MyMinMaxInt extends InlinedNumericMinMax[Int] {
+
+  override inline def minValue: Int = 10
+  override inline def maxValue: Int = 100
+
+}
+
+MyMinMaxInt(10)
+// MyMinMaxInt.Type = 10
+
+MyMinMaxInt(100)
+// MyMinMaxInt.Type = 100
+
+MyMinMaxInt(9)
+-- Error: ----------------------------------------------------------------------
+   |MyMinMaxInt(9)
+   |^^^^^^^^^^^^^^
+   |Invalid value: [9]. It must be >= 10 && <= 100.
+   |----------------------------------------------------------------------------
+   |Inline stack trace
+   |- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+   |This location contains code that was inlined from rs$line$10:1
+   |    else RefinedMacros.internalError(a, inlinedExpectedValue)
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    ----------------------------------------------------------------------------
+1 error found
+//////
+
+MyMinMaxInt(101)
+-- Error: ----------------------------------------------------------------------
+   |MyMinMaxInt(101)
+   |^^^^^^^^^^^^^^^^
+   |Invalid value: [101]. It must be >= 10 && <= 100.
+   |----------------------------------------------------------------------------
+   |Inline stack trace
+   |- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+   |This location contains code that was inlined from rs$line$10:1
+   |    else RefinedMacros.internalError(a, inlinedExpectedValue)
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    ----------------------------------------------------------------------------
+1 error found
+```


### PR DESCRIPTION
# refined4s v1.15.0
## [1.15.0](https://github.com/kevin-lee/refined4s/issues?q=is%3Aissue%20is%3Aclosed%20-label%3Ainvalid%20-label%3Awontfix%20milestone%3Am39) - 2026-02-06

### New Features

* Add `InlinedNumericMin`, `InlinedNumericMax` and `InlinedNumericMinMax` (#563)

```scala 3
import refined4s.types.numeric.*

type MyMinInt = MyMinInt.Type
object MyMinInt extends InlinedNumericMin[Int] {

  override inline def minValue: Int = 10

}

MyMinInt(10)
// MyMinInt.Type = 10

MyMinInt(9)
-- Error: ----------------------------------------------------------------------
   |MyMinInt(9)
   |^^^^^^^^^^^
   |Invalid value: [9]. It must be >= 10.
   |----------------------------------------------------------------------------
   |Inline stack trace
   |- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
   |This location contains code that was inlined from rs$line$5:1
   |    else RefinedMacros.internalError(a, inlinedExpectedValue)
   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    ----------------------------------------------------------------------------
1 error found
```
```scala 3
import refined4s.types.numeric.*

type MyMaxInt = MyMaxInt.Type
object MyMaxInt extends InlinedNumericMax[Int] {

  override inline def maxValue: Int = 100

}

MyMaxInt(100)
// MyMaxInt.Type = 100

MyMaxInt(101)
-- Error: ----------------------------------------------------------------------
   |MyMaxInt(101)
   |^^^^^^^^^^^^^
   |Invalid value: [101]. It must be <= 100.
   |----------------------------------------------------------------------------
   |Inline stack trace
   |- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
   |This location contains code that was inlined from rs$line$6:1
   |    else RefinedMacros.internalError(a, inlinedExpectedValue)
   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    ----------------------------------------------------------------------------
1 error found
```
```scala 3
import refined4s.types.numeric.*

type MyMinMaxInt = MyMinMaxInt.Type
object MyMinMaxInt extends InlinedNumericMinMax[Int] {

  override inline def minValue: Int = 10
  override inline def maxValue: Int = 100

}

MyMinMaxInt(10)
// MyMinMaxInt.Type = 10

MyMinMaxInt(100)
// MyMinMaxInt.Type = 100

MyMinMaxInt(9)
-- Error: ----------------------------------------------------------------------
   |MyMinMaxInt(9)
   |^^^^^^^^^^^^^^
   |Invalid value: [9]. It must be >= 10 && <= 100.
   |----------------------------------------------------------------------------
   |Inline stack trace
   |- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
   |This location contains code that was inlined from rs$line$10:1
   |    else RefinedMacros.internalError(a, inlinedExpectedValue)
   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    ----------------------------------------------------------------------------
1 error found
//////

MyMinMaxInt(101)
-- Error: ----------------------------------------------------------------------
   |MyMinMaxInt(101)
   |^^^^^^^^^^^^^^^^
   |Invalid value: [101]. It must be >= 10 && <= 100.
   |----------------------------------------------------------------------------
   |Inline stack trace
   |- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
   |This location contains code that was inlined from rs$line$10:1
   |    else RefinedMacros.internalError(a, inlinedExpectedValue)
   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    ----------------------------------------------------------------------------
1 error found
```
