### PR TITLE
refined4s v1.16.0

### DIFF
--- a/changelogs/1.16.0.md
+++ b/changelogs/1.16.0.md
@@ -1,0 +1,18 @@
+## [1.16.0](https://github.com/kevin-lee/refined4s/issues?q=is%3Aissue%20is%3Aclosed%20-label%3Ainvalid%20-label%3Awontfix%20milestone%3Am40) - 2026-02-07
+
+### New Features
+
+* `numeric` `trait`s should be available by importing `refined4s.types.all.*` (#566)
+
+Previously, to use the following `trait`s, `import refined4s.types.numeric.*` was required.
+
+* `Numeric`
+* `InlinedNumeric`
+* `Min`
+* `Max`
+* `MinMax`
+* `InlinedNumericMin`
+* `InlinedNumericMax`
+* `InlinedNumericMinMax`
+
+Now, these are available with `import refined4s.types.all.*` as well.


### PR DESCRIPTION
# refined4s v1.16.0
## [1.16.0](https://github.com/kevin-lee/refined4s/issues?q=is%3Aissue%20is%3Aclosed%20-label%3Ainvalid%20-label%3Awontfix%20milestone%3Am40) - 2026-02-07

### New Features

* `numeric` `trait`s should be available by importing `refined4s.types.all.*` (#566)

Previously, to use the following `trait`s, `import refined4s.types.numeric.*` was required.

* `Numeric`
* `InlinedNumeric`
* `Min`
* `Max`
* `MinMax`
* `InlinedNumericMin`
* `InlinedNumericMax`
* `InlinedNumericMinMax`

Now, these are available with `import refined4s.types.all.*` as well.
