### PR TITLE
Close #571: `java.net.URL` constructor is deprecated in newer Java versions (Java `20+`) so it should be updated

### DIFF
--- a/modules/refined4s-core/jvm/src/main/scala/refined4s/types/networkCompat.scala
+++ b/modules/refined4s-core/jvm/src/main/scala/refined4s/types/networkCompat.scala
@@ -29,7 +29,7 @@ object networkCompat {
     @SuppressWarnings(Array("org.wartremover.warts.JavaNetURLConstructors"))
     def validate(url: String): Either[String, String] =
       try {
-        new URL(url)
+        new URI(url).toURL
         Right(url)
       } catch {
         case NonFatal(ex) =>
@@ -45,11 +45,11 @@ object networkCompat {
 
     extension (url: Type) {
       @SuppressWarnings(Array("org.wartremover.warts.JavaNetURLConstructors"))
-      def toURL: URL = new URL(url.value)
+      def toURL: URL = toURI.toURL
 
-      def toUri: Uri = Uri(toURL.toURI)
+      def toUri: Uri = Uri(toURI)
 
-      def toURI: URI = toURL.toURI
+      def toURI: URI = new URI(url.value)
     }
 
   }
@@ -78,7 +78,7 @@ object networkCompat {
     urlExpr.asTerm match {
       case Inlined(_, _, Literal(StringConstant(urlStr))) =>
         try {
-          new java.net.URL(urlStr)
+          new java.net.URI(urlStr).toURL
           Expr(true)
         } catch {
           case ex: Throwable =>

--- a/modules/test-refined4s-core-without-cats/jvm/src/test/scala/refined4s/types/networkCompatSpec.scala
+++ b/modules/test-refined4s-core-without-cats/jvm/src/test/scala/refined4s/types/networkCompatSpec.scala
@@ -95,7 +95,7 @@ trait networkCompatSpec {
       """
     )
 
-    val expectedCompilationErrorMessage1 = """Invalid Url value: [%^<>[]`{}]. no protocol: %^<>[]`{}"""
+    val expectedCompilationErrorMessage1 = """Invalid Url value: [%^<>[]`{}]. Malformed escape pair at index 0: %^<>[]`{}"""
     val shouldNotCompile1ErrorMessage    = typeCheckErrors(
       """
         import network.*
@@ -359,7 +359,7 @@ trait networkCompatSpec {
 
   def testNetworkIsValidateUrlInvalid: Result = {
     import scala.compiletime.testing.typeCheckErrors
-    val expected1 = """Invalid Url value: [%^<>[]`{}]. no protocol: %^<>[]`{}"""
+    val expected1 = """Invalid Url value: [%^<>[]`{}]. Malformed escape pair at index 0: %^<>[]`{}"""
     val expected2 = """Invalid Url value: [blah://www.google.com]. unknown protocol: blah"""
 
     val actual1 = typeCheckErrors("""runNetworkIsValidateUrl("%^<>[]`{}")""").map(_.message).mkString


### PR DESCRIPTION
# Close #571: `java.net.URL` constructor is deprecated in newer Java versions (Java `20+`) so it should be updated

Change `Url` validation to use `URI.toURL` instead of `URL` constructor

The `URL` constructor `new URL(url)` is deprecated in newer Java versions (Java `20+`). To ensure consistent behavior and avoid deprecation warnings, the `Url` validation in the JVM implementation of `networkCompat` now uses `new URI(url).toURL`.

Specifically:
- In `validate(url: String)`, `new URL(url)` has been replaced with `new URI(url).toURL`
- In the `isValidateUrl` macro, `new java.net.URL(urlStr)` has been replaced with `new java.net.URI(urlStr).toURL`
- The `Url` extension methods have been updated to use `URI` as the primary conversion mechanism:
  - `toURI` now uses `new URI(url.value)` instead of `toURL.toURI`
  - `toURL` now uses `toURI.toURL` instead of `new URL(url.value)`
  - `toUri` now uses `Uri(toURI)` instead of `Uri(toURL.toURI)`