### PR TITLE
Close #575: [`refined4s-core`] Improve `UuidV7` monotonic counter with random seeding per `RFC 9562` section `6.2`

### DIFF
--- a/modules/refined4s-core/shared/src/main/scala/refined4s/types/strings.scala
+++ b/modules/refined4s-core/shared/src/main/scala/refined4s/types/strings.scala
@@ -221,6 +221,8 @@ object strings {
     private val Version              = 7L
     private val Variant              = 2L // RFC 9562 uses 10x for the variant, which is 2 in UUID API
 
+    private def randomSeed(): Long = entropy.nextInt(0x800).toLong // `0` to `0x7ff` = 0 to 2047
+
     @scala.annotation.tailrec
     private def updateAndGetState(): (Long, Long) = {
       val state         = timestampAndSequence.get()
@@ -231,11 +233,11 @@ object strings {
 
       val (newTimestamp, newSequence) =
         if (currentTimestamp > lastTimestamp) {
-          (currentTimestamp, 0L)
+          (currentTimestamp, randomSeed())
         } else if (currentTimestamp == lastTimestamp) {
           val nextSequence = lastSequence + 1
           if (nextSequence > 0xfffL) { // Exceeded 12 bits allocated for rand_a
-            (lastTimestamp + 1, 0L)
+            (lastTimestamp + 1, randomSeed())
           } else {
             (lastTimestamp, nextSequence)
           }
@@ -243,7 +245,7 @@ object strings {
           /* Clock moved backwards. To maintain monotonicity, we use the last timestamp and increment sequence */
           val nextSequence = lastSequence + 1
           if (nextSequence > 0xfffL) {
-            (lastTimestamp + 1, 0L)
+            (lastTimestamp + 1, randomSeed())
           } else {
             (lastTimestamp, nextSequence)
           }


### PR DESCRIPTION
# Close #575: [`refined4s-core`] Improve `UuidV7` monotonic counter with random seeding per `RFC 9562` section `6.2`

- Seed the `rand_a` field with a random value instead of always starting from `0` when the counter resets. This follows `RFC 9562` section `6.2` (https://www.rfc-editor.org/rfc/rfc9562.html#section-6.2) which recommends using random bits to initialize the counter portion to improve privacy and reduce predictability.
- Add a `randomSeed()` helper that generates a random value within the 12-bit `rand_a` range (`0 to 0x7FF`) using the existing entropy source.
- Replace all three counter-reset paths (new timestamp, sequence overflow, and clock regression) to use `randomSeed()` instead of `0L`.
- Add test to verify `rand_a` values are randomly seeded and unique across 100 consecutive generated `UUID`s.