### PR TITLE
Close #580: [`refined4s-core`] Make `UuidV7Generator` customisable with `RandomSource` and `TimestampSource`

### DIFF
--- a/modules/refined4s-core/shared/src/main/scala/refined4s/types/strings.scala
+++ b/modules/refined4s-core/shared/src/main/scala/refined4s/types/strings.scala
@@ -246,17 +246,49 @@ object strings {
     def generate(): UuidV7.Type
   }
   object UuidV7Generator {
-    final lazy val global: UuidV7Generator = newGenerator() // scalafix:ok DisableSyntax.noFinalVal
+    final lazy val globalDefaultGenerator: UuidV7Generator = newDefaultGenerator() // scalafix:ok DisableSyntax.noFinalVal
 
-    def newGenerator(): UuidV7Generator = new DefaultUuidV7Generator()
+    def newGenerator(randomSource: RandomSource, timestampSource: TimestampSource): UuidV7Generator =
+      new DefaultUuidV7Generator(randomSource, timestampSource)
 
-    final private class DefaultUuidV7Generator extends UuidV7Generator {
+    def newDefaultGenerator(): UuidV7Generator =
+      newGenerator(RandomSource.newDefaultRandomSource(), TimestampSource.newDefaultTimestampSource())
+
+    trait RandomSource {
+      def nextLong(): Long
+      def nextInt(upperBound: Int): Int
+    }
+    object RandomSource {
+      def newDefaultRandomSource(): RandomSource = new DefaultRandomSource
+
+      final private class DefaultRandomSource extends RandomSource {
+        private lazy val secureRandom = new java.security.SecureRandom()
+
+        def nextLong(): Long              = secureRandom.nextLong()
+        def nextInt(upperBound: Int): Int = secureRandom.nextInt(upperBound)
+      }
+    }
+
+    trait TimestampSource {
+      def timestamp(): Long
+    }
+    object TimestampSource {
+      def newDefaultTimestampSource(): TimestampSource = new DefaultTimestampSource
+
+      final private class DefaultTimestampSource extends TimestampSource {
+        def timestamp(): Long = System.currentTimeMillis()
+      }
+    }
+
+    final private class DefaultUuidV7Generator(
+      randomSource: RandomSource,
+      timestampSource: TimestampSource,
+    ) extends UuidV7Generator {
       private val timestampAndSequence = new java.util.concurrent.atomic.AtomicLong()
-      private lazy val entropy         = new java.security.SecureRandom()
       private val Version              = 7L
       private val Variant              = 2L // RFC 9562 uses 10x for the variant, which is 2 in UUID API
 
-      private def randomSeed(): Long = entropy.nextInt(0x800).toLong // `0` to `0x7ff` = 0 to 2047
+      private def randomSeed(): Long = randomSource.nextInt(0x800).toLong // `0` to `0x7ff` = 0 to 2047
 
       @scala.annotation.tailrec
       private def updateAndGetState(): (Long, Long) = {
@@ -264,7 +296,7 @@ object strings {
         val lastTimestamp = state >>> 16
         val lastSequence  = state & 0xffffL
 
-        val currentTimestamp = System.currentTimeMillis()
+        val currentTimestamp = timestampSource.timestamp()
 
         val (newTimestamp, newSequence) =
           if (currentTimestamp > lastTimestamp) {
@@ -311,7 +343,7 @@ object strings {
          * 2 bits: variant (10)
          * 62 bits: rand_b (random)
          */
-        val randB        = entropy.nextLong() & 0x3fff_ffff_ffff_ffffL // 62 bits
+        val randB        = randomSource.nextLong() & 0x3fff_ffff_ffff_ffffL // 62 bits
         val leastSigBits = (Variant << 62) | randB
 
         val uuid = new UUID(mostSigBits, leastSigBits)

--- a/modules/refined4s-core/shared/src/main/scala/refined4s/types/strings.scala
+++ b/modules/refined4s-core/shared/src/main/scala/refined4s/types/strings.scala
@@ -311,7 +311,7 @@ object strings {
          * 2 bits: variant (10)
          * 62 bits: rand_b (random)
          */
-        val randB        = entropy.nextLong() & 0x3fffffffffffffffL // 62 bits
+        val randB        = entropy.nextLong() & 0x3fff_ffff_ffff_ffffL // 62 bits
         val leastSigBits = (Variant << 62) | randB
 
         val uuid = new UUID(mostSigBits, leastSigBits)

--- a/modules/test-refined4s-core-without-cats/shared/src/test/scala/refined4s/types/stringsSpec.scala
+++ b/modules/test-refined4s-core-without-cats/shared/src/test/scala/refined4s/types/stringsSpec.scala
@@ -688,11 +688,17 @@ object stringsSpec extends Properties {
       property("test UuidV7.toUUID", testToUUID),
       property("test Ordering[UuidV7]", testOrdering),
       property("test Ordered[UuidV7]", testOrdered),
-      property("test UuidV7Generator.global.generate() valid format", testGenerateValidFormat),
-      property("test UuidV7Generator.global.generate() should return unique UUID v7", testGenerateUnique),
-      property("test UuidV7Generator.global.generate() is monotonic", testGenerateMonotonic),
-      property("test UuidV7Generator.global.generate() is monotonic (using UuidV7.compareTo)", testGenerateMonotonicWithUuidV7CompareTo),
-      property("test UuidV7Generator.global.generate() rand_a is randomly seeded per RFC 9562 section 6.2", testGenerateRandARandomlySeeded),
+      property("test UuidV7Generator.globalDefaultGenerator.generate() valid format", testGenerateValidFormat),
+      property("test UuidV7Generator.globalDefaultGenerator.generate() should return unique UUID v7", testGenerateUnique),
+      property("test UuidV7Generator.globalDefaultGenerator.generate() is monotonic", testGenerateMonotonic),
+      property(
+        "test UuidV7Generator.globalDefaultGenerator.generate() is monotonic (using UuidV7.compareTo)",
+        testGenerateMonotonicWithUuidV7CompareTo,
+      ),
+      property(
+        "test UuidV7Generator.globalDefaultGenerator.generate() rand_a is randomly seeded per RFC 9562 section 6.2",
+        testGenerateRandARandomlySeeded,
+      ),
     )
 
     def testApplyValid: Result = {
@@ -951,7 +957,7 @@ object stringsSpec extends Properties {
       }
 
     def testGenerateValidFormat: Property = for {
-      generated <- Gen.constant(UuidV7Generator.global.generate()).log("generated")
+      generated <- Gen.constant(UuidV7Generator.globalDefaultGenerator.generate()).log("generated")
     } yield {
       val uuid = generated.toUUID
       Result.all(
@@ -963,14 +969,14 @@ object stringsSpec extends Properties {
     }
 
     def testGenerateUnique: Property = for {
-      generated <- Gen.constant((1 to 10_000).map(_ => UuidV7Generator.global.generate())).log("generated")
+      generated <- Gen.constant((1 to 10_000).map(_ => UuidV7Generator.globalDefaultGenerator.generate())).log("generated")
     } yield {
       val uuids = generated.distinct
-      Result.diffNamed("UuidV7Generator.global.generate() should return a unique UUID v7", uuids.length, 10_000)(_ == _)
+      Result.diffNamed("UuidV7Generator.globalDefaultGenerator.generate() should return a unique UUID v7", uuids.length, 10_000)(_ == _)
     }
 
     def testGenerateMonotonic: Property = for {
-      generated <- Gen.constant((1 to 10_000).map(_ => UuidV7Generator.global.generate())).log("generated")
+      generated <- Gen.constant((1 to 10_000).map(_ => UuidV7Generator.globalDefaultGenerator.generate())).log("generated")
     } yield {
 
       val nonMonotonicIdPairs = generated.sliding(2).flatMap {
@@ -995,7 +1001,7 @@ object stringsSpec extends Properties {
     }
 
     def testGenerateMonotonicWithUuidV7CompareTo: Property = for {
-      generated <- Gen.constant((1 to 10_000).map(_ => UuidV7Generator.global.generate())).log("generated")
+      generated <- Gen.constant((1 to 10_000).map(_ => UuidV7Generator.globalDefaultGenerator.generate())).log("generated")
     } yield {
 
       val nonMonotonicIdPairs = generated.sliding(2).flatMap {
@@ -1019,7 +1025,7 @@ object stringsSpec extends Properties {
 
     def testGenerateRandARandomlySeeded: Property =
       for {
-        generated <- Gen.constant((1 to 100).map(_ => UuidV7Generator.global.generate())).log("generated")
+        generated <- Gen.constant((1 to 100).map(_ => UuidV7Generator.globalDefaultGenerator.generate())).log("generated")
       } yield {
         val uuidV7AndRandAValues = generated.map(uuidV7 => (uuidV7, uuidV7.toUUID.getMostSignificantBits & 0xfffL))
 


### PR DESCRIPTION
# Close #580: [`refined4s-core`] Make `UuidV7Generator` customisable with `RandomSource` and `TimestampSource`

Extract `RandomSource` and `TimestampSource` `trait`s from `UuidV7Generator`
to allow custom implementations for random number generation and timestamp
retrieval. This makes `UuidV7Generator` more testable and flexible.

- Add `RandomSource` `trait` with `nextLong()` and `nextInt(upperBound)` methods
- Add `TimestampSource` `trait` with `timestamp()` method
- Provide default implementations using `SecureRandom` and `System.currentTimeMillis()`
- Change `newGenerator()` to accept `RandomSource` and `TimestampSource` parameters
- Add `newDefaultGenerator()` convenience method using default sources
- Rename `global` to `globalDefaultGenerator` for clarity
- Update tests to use the renamed `globalDefaultGenerator`