### PR TITLE
Close #582: [`refined4s-core`] Make `UuidV7Generator` effect-polymorphic with higher-kinded type parameter `F[*]`

### DIFF
--- a/modules/refined4s-core/shared/src/main/scala/refined4s/internal/types.scala
+++ b/modules/refined4s-core/shared/src/main/scala/refined4s/internal/types.scala
@@ -1,0 +1,92 @@
+package refined4s.internal
+
+/** @author Kevin Lee
+  * @since 2026-03-07
+  */
+object types {
+
+  type Identity[A] = A
+
+  trait Bind[F[*]] {
+    def pure[A](a: A): F[A]
+    def map[A, B](fa: F[A])(f: A => B): F[B]
+    def flatMap[A, B](fa: F[A])(f: A => F[B]): F[B]
+  }
+  object Bind {
+    def apply[F[*]](using B: Bind[F]): Bind[F] = B
+
+    given bindIdentity: Bind[Identity] with {
+      def pure[A](a: A): A                   = a
+      def map[A, B](fa: A)(f: A => B): B     = f(fa)
+      def flatMap[A, B](fa: A)(f: A => B): B = f(fa)
+    }
+
+    extension [F[*], A](fa: F[A]) {
+      def map[B](f: A => B)(using bind: Bind[F]): F[B]        = bind.map(fa)(f)
+      def flatMap[B](f: A => F[B])(using bind: Bind[F]): F[B] = bind.flatMap(fa)(f)
+    }
+  }
+
+  trait StateRef[F[*], A] {
+    def get: F[A]
+
+    def set(a: A): F[Unit]
+
+    def updateAndGet(f: A => A): F[A]
+
+    def modify[B](f: A => (A, B)): F[B]
+  }
+  object StateRef {
+    def newAtomicLongStateRef(): StateRef[Identity, Long] = new AtomicLongStateRef()
+
+    final private class AtomicLongStateRef extends StateRef[Identity, Long] {
+      private val ref = new java.util.concurrent.atomic.AtomicLong()
+
+      def get: Long = ref.get()
+
+      def set(a: Long): Unit = ref.set(a)
+
+      @scala.annotation.tailrec
+      def updateAndGet(f: Long => Long): Long = {
+        val current  = ref.get()
+        val newValue = f(current)
+        if (ref.compareAndSet(current, newValue)) newValue else updateAndGet(f)
+      }
+
+      @scala.annotation.tailrec
+      def modify[B](f: Long => (Long, B)): B = {
+        val current            = ref.get()
+        val (newState, result) = f(current)
+        if (ref.compareAndSet(current, newState)) result else modify(f)
+      }
+    }
+  }
+
+  trait RandomSource[F[*]] {
+    def nextLong(): F[Long]
+
+    def nextInt(upperBound: Int): F[Int]
+  }
+  object RandomSource {
+    def newDefaultRandomSource(): RandomSource[Identity] = new DefaultRandomSource
+
+    final private class DefaultRandomSource extends RandomSource[Identity] {
+      private lazy val secureRandom = new java.security.SecureRandom()
+
+      def nextLong(): Long              = secureRandom.nextLong()
+      def nextInt(upperBound: Int): Int = secureRandom.nextInt(upperBound)
+    }
+  }
+
+  trait TimestampSource[F[*]] {
+    def timestamp(): F[Long]
+  }
+  object TimestampSource {
+    def newDefaultTimestampSource(): TimestampSource[Identity] = new DefaultTimestampSource
+
+    final private class DefaultTimestampSource extends TimestampSource[Identity] {
+      def timestamp(): Long = System.currentTimeMillis()
+    }
+  }
+
+}

--- a/modules/refined4s-core/shared/src/main/scala/refined4s/types/strings.scala
+++ b/modules/refined4s-core/shared/src/main/scala/refined4s/types/strings.scala
@@ -28,7 +28,7 @@ trait strings {
   final type UuidV7 = strings.UuidV7
   final val UuidV7 = strings.UuidV7
 
-  final type UuidV7Generator = strings.UuidV7Generator
+  final type UuidV7Generator[F[*]] = strings.UuidV7Generator[F]
   final val UuidV7Generator = strings.UuidV7Generator
 
   // scalafix:on
@@ -242,113 +242,86 @@ object strings {
     }.asInstanceOf[F[UuidV7]] // scalafix:ok DisableSyntax.asInstanceOf
   }
 
-  trait UuidV7Generator {
-    def generate(): UuidV7.Type
+  trait UuidV7Generator[F[*]] {
+    def generate(): F[UuidV7]
   }
   object UuidV7Generator {
-    final lazy val globalDefaultGenerator: UuidV7Generator = newDefaultGenerator() // scalafix:ok DisableSyntax.noFinalVal
+    import refined4s.internal.types.{Bind, Identity, RandomSource, StateRef, TimestampSource}
 
-    def newGenerator(randomSource: RandomSource, timestampSource: TimestampSource): UuidV7Generator =
-      new DefaultUuidV7Generator(randomSource, timestampSource)
+    val Version: Long = 7L
+    val Variant: Long = 2L // RFC 9562 uses 10x for the variant, which is 2 in UUID API
 
-    def newDefaultGenerator(): UuidV7Generator =
-      newGenerator(RandomSource.newDefaultRandomSource(), TimestampSource.newDefaultTimestampSource())
+    final lazy val globalDefaultGenerator: UuidV7Generator[Identity] = newDefaultGenerator() // scalafix:ok DisableSyntax.noFinalVal
 
-    trait RandomSource {
-      def nextLong(): Long
-      def nextInt(upperBound: Int): Int
-    }
-    object RandomSource {
-      def newDefaultRandomSource(): RandomSource = new DefaultRandomSource
+    def newGenerator[F[*]: Bind](
+      randomSource: RandomSource[F],
+      timestampSource: TimestampSource[F],
+      stateRef: StateRef[F, Long],
+    ): UuidV7Generator[F] =
+      new DefaultUuidV7Generator[F](randomSource, timestampSource, stateRef)
 
-      final private class DefaultRandomSource extends RandomSource {
-        private lazy val secureRandom = new java.security.SecureRandom()
+    def newDefaultGenerator(): UuidV7Generator[Identity] =
+      newGenerator[Identity](
+        RandomSource.newDefaultRandomSource(),
+        TimestampSource.newDefaultTimestampSource(),
+        StateRef.newAtomicLongStateRef(),
+      )
 
-        def nextLong(): Long              = secureRandom.nextLong()
-        def nextInt(upperBound: Int): Int = secureRandom.nextInt(upperBound)
-      }
-    }
+    final private class DefaultUuidV7Generator[F[*]](
+      randomSource: RandomSource[F],
+      timestampSource: TimestampSource[F],
+      stateRef: StateRef[F, Long],
+    )(using B: Bind[F])
+        extends UuidV7Generator[F] {
+      import refined4s.internal.types.Bind.*
 
-    trait TimestampSource {
-      def timestamp(): Long
-    }
-    object TimestampSource {
-      def newDefaultTimestampSource(): TimestampSource = new DefaultTimestampSource
+      def generate(): F[UuidV7] =
+        for {
+          currentTimestamp <- timestampSource.timestamp()
 
-      final private class DefaultTimestampSource extends TimestampSource {
-        def timestamp(): Long = System.currentTimeMillis()
-      }
-    }
+          seedInt <- randomSource.nextInt(0x800)
 
-    final private class DefaultUuidV7Generator(
-      randomSource: RandomSource,
-      timestampSource: TimestampSource,
-    ) extends UuidV7Generator {
-      private val timestampAndSequence = new java.util.concurrent.atomic.AtomicLong()
-      private val Version              = 7L
-      private val Variant              = 2L // RFC 9562 uses 10x for the variant, which is 2 in UUID API
+          seed = seedInt.toLong
 
-      private def randomSeed(): Long = randomSource.nextInt(0x800).toLong // `0` to `0x7ff` = 0 to 2047
+          newTimestampAndNewSequence <- stateRef.modify({ state =>
+                                          val lastTimestamp = state >>> 16
+                                          val lastSequence  = state & 0xffffL
 
-      @scala.annotation.tailrec
-      private def updateAndGetState(): (Long, Long) = {
-        val state         = timestampAndSequence.get()
-        val lastTimestamp = state >>> 16
-        val lastSequence  = state & 0xffffL
+                                          val (newTimestamp, newSequence) =
+                                            if currentTimestamp > lastTimestamp then {
+                                              (currentTimestamp, seed)
+                                            } else if currentTimestamp == lastTimestamp then {
+                                              val nextSequence = lastSequence + 1
+                                              if nextSequence > 0xfffL // Exceeded 12 bits allocated for rand_a
+                                              then (lastTimestamp + 1, seed)
+                                              else (lastTimestamp, nextSequence)
+                                            } else {
+                                              /* Clock moved backwards. To maintain monotonicity,
+                                               * we use the last timestamp and increment sequence
+                                               */
+                                              val nextSequence = lastSequence + 1
+                                              if nextSequence > 0xfffL
+                                              then (lastTimestamp + 1, seed)
+                                              else (lastTimestamp, nextSequence)
+                                            }
 
-        val currentTimestamp = timestampSource.timestamp()
+                                          val newState = (newTimestamp << 16) | newSequence
+                                          (newState, (newTimestamp, newSequence))
+                                        })
 
-        val (newTimestamp, newSequence) =
-          if (currentTimestamp > lastTimestamp) {
-            (currentTimestamp, randomSeed())
-          } else if (currentTimestamp == lastTimestamp) {
-            val nextSequence = lastSequence + 1
-            if (nextSequence > 0xfffL) { // Exceeded 12 bits allocated for rand_a
-              (lastTimestamp + 1, randomSeed())
-            } else {
-              (lastTimestamp, nextSequence)
-            }
-          } else {
-            /* Clock moved backwards. To maintain monotonicity, we use the last timestamp and increment sequence */
-            val nextSequence = lastSequence + 1
-            if (nextSequence > 0xfffL) {
-              (lastTimestamp + 1, randomSeed())
-            } else {
-              (lastTimestamp, nextSequence)
-            }
-          }
+          (newTimestamp, newSequence) = newTimestampAndNewSequence
 
-        val newState = (newTimestamp << 16) | newSequence
-        if (timestampAndSequence.compareAndSet(state, newState)) {
-          (newTimestamp, newSequence)
-        } else {
-          updateAndGetState()
-        }
-      }
+          randA = newSequence & 0xfffL
 
-      def generate(): UuidV7.Type = {
-        val (newTimestamp, newSequence) = updateAndGetState()
+          mostSigBits = (newTimestamp << 16) | (Version << 12) | randA
 
-        val randA = newSequence & 0xfffL
+          randBRaw <- randomSource.nextLong()
 
-        /* mostSigBits:
-         * 48 bits: timestamp
-         * 4 bits: version (7)
-         * 12 bits: rand_a (sequence)
-         */
-        val mostSigBits = (newTimestamp << 16) | (Version << 12) | randA
+          randB        = randBRaw & 0x3fff_ffff_ffff_ffffL // 62 bits
+          leastSigBits = (Variant << 62) | randB
+          uuid         = new UUID(mostSigBits, leastSigBits)
 
-        /*
-         * leastSigBits:
-         * 2 bits: variant (10)
-         * 62 bits: rand_b (random)
-         */
-        val randB        = randomSource.nextLong() & 0x3fff_ffff_ffff_ffffL // 62 bits
-        val leastSigBits = (Variant << 62) | randB
-
-        val uuid = new UUID(mostSigBits, leastSigBits)
-        UuidV7.unsafeFrom(uuid)
-      }
+        } yield UuidV7.unsafeFrom(uuid)
     }
   }
 

--- a/modules/refined4s-core/shared/src/test/scala/refined4s/internal/typesSpec.scala
+++ b/modules/refined4s-core/shared/src/test/scala/refined4s/internal/typesSpec.scala
@@ -1,0 +1,173 @@
+package refined4s.internal
+
+import hedgehog.*
+import hedgehog.runner.*
+import refined4s.internal.types.*
+import refined4s.internal.types.Bind.*
+import refined4s.internal.types.Bind.given
+
+object typesSpec extends Properties {
+  override def tests: List[Test] = List(
+    property("Bind[Identity].pure(a) returns a", testBindPure),
+    property("Bind[Identity].map(a)(f) returns the mapped value", testBindMap),
+    property("Bind[Identity].flatMap(a)(f) returns the flat-mapped value", testBindFlatMap),
+    property("Identity extension map returns the mapped value", testBindExtensionMap),
+    property("Identity extension flatMap returns the flat-mapped value", testBindExtensionFlatMap),
+    example("StateRef.newAtomicLongStateRef() starts at 0L", testStateRefInitialState),
+    property("StateRef.set(a) updates the stored value", testStateRefSet),
+    property("StateRef.updateAndGet(f) returns and persists the updated state", testStateRefUpdateAndGet),
+    property("StateRef.modify(f) returns the result and persists the updated state", testStateRefModify),
+    example("RandomSource.nextLong() can be called successfully", testRandomSourceNextLong),
+    property("RandomSource.nextInt(upperBound) returns a value in range", testRandomSourceNextInt),
+    example("TimestampSource.timestamp() returns a bounded wall-clock value", testTimestampSourceTimestamp),
+  )
+
+  def testBindPure: Property =
+    for {
+      n <- Gen.int(Range.linear(-1_000, 1_000)).log("n")
+    } yield {
+      val expected = n
+      val actual   = Bind[Identity].pure(n)
+      actual ==== expected
+    }
+
+  def testBindMap: Property =
+    for {
+      n <- Gen.int(Range.linear(-1_000, 1_000)).log("n")
+    } yield {
+      val f = (x: Int) => x + 1
+
+      val actual   = Bind[Identity].map(n)(f)
+      val expected = f(n)
+      actual ==== expected
+    }
+
+  def testBindFlatMap: Property =
+    for {
+      n <- Gen.int(Range.linear(-1_000, 1_000)).log("n")
+    } yield {
+      val f: Int => Identity[String] = value => s"${value}!${value + 1}"
+
+      val actual   = Bind[Identity].flatMap(n)(f)
+      val expected = f(n)
+      actual ==== expected
+    }
+
+  def testBindExtensionMap: Property =
+    for {
+      n <- Gen.int(Range.linear(-1_000, 1_000)).log("n")
+    } yield {
+      val fa: Identity[Int] = n
+
+      val f = (x: Int) => x + 1
+
+      val actual   = fa.map(f)
+      val expected = f(n)
+      actual ==== expected
+    }
+
+  def testBindExtensionFlatMap: Property =
+    for {
+      n <- Gen.int(Range.linear(-1_000, 1_000)).log("n")
+    } yield {
+      val fa: Identity[Int] = n
+
+      val f: Int => Identity[String] = value => s"${value}!${value + 1}"
+
+      val actual   = fa.flatMap(f)
+      val expected = f(n)
+
+      actual ==== expected
+    }
+
+  def testStateRefInitialState: Result = {
+    val stateRef = StateRef.newAtomicLongStateRef()
+    stateRef.get ==== 0L
+  }
+
+  def testStateRefSet: Property =
+    for {
+      n <- Gen.long(Range.linear(-1_000_000L, 1_000_000L)).log("n")
+    } yield {
+      val stateRef = StateRef.newAtomicLongStateRef()
+      stateRef.set(n)
+      stateRef.get ==== n
+    }
+
+  def testStateRefUpdateAndGet: Property =
+    for {
+      initial <- Gen.long(Range.linear(-1_000_000L, 1_000_000L)).log("initial")
+      delta   <- Gen.long(Range.linear(-1_000L, 1_000L)).log("delta")
+    } yield {
+      val stateRef = StateRef.newAtomicLongStateRef()
+      stateRef.set(initial)
+
+      val expectedState = initial + delta
+
+      val actual = stateRef.updateAndGet(_ + delta)
+
+      Result.all(
+        List(
+          actual ==== expectedState,
+          stateRef.get ==== expectedState,
+        )
+      )
+    }
+
+  def testStateRefModify: Property =
+    for {
+      initial <- Gen.long(Range.linear(-1_000_000L, 1_000_000L)).log("initial")
+      delta   <- Gen.long(Range.linear(-1_000L, 1_000L)).log("delta")
+    } yield {
+      val stateRef = StateRef.newAtomicLongStateRef()
+      stateRef.set(initial)
+
+      val expectedState  = initial + delta
+      val expectedResult = s"${initial}->${expectedState}"
+
+      val actual = stateRef.modify(current => (current + delta, s"${current}->${current + delta}"))
+
+      Result.all(
+        List(
+          actual ==== expectedResult,
+          stateRef.get ==== expectedState,
+        )
+      )
+    }
+
+  def testRandomSourceNextLong: Result = {
+    val randomSource = RandomSource.newDefaultRandomSource()
+    val actual       = randomSource.nextLong()
+
+    Result.assert(actual.toString.nonEmpty).log(s"nextLong() returned an empty string representation: $actual")
+  }
+
+  def testRandomSourceNextInt: Property =
+    for {
+      upperBound <- Gen.int(Range.linear(1, 10_000)).log("upperBound")
+    } yield {
+      val randomSource = RandomSource.newDefaultRandomSource()
+      val actual       = randomSource.nextInt(upperBound)
+
+      Result.all(
+        List(
+          Result.assert(actual >= 0).log(s"Expected nextInt($upperBound) >= 0 but got $actual"),
+          Result.assert(actual < upperBound).log(s"Expected nextInt($upperBound) < $upperBound but got $actual"),
+        )
+      )
+    }
+
+  def testTimestampSourceTimestamp: Result = {
+    val timestampSource = TimestampSource.newDefaultTimestampSource()
+    val before          = System.currentTimeMillis()
+    val actual          = timestampSource.timestamp()
+    val after           = System.currentTimeMillis()
+
+    Result.all(
+      List(
+        Result.assert(actual >= before).log(s"Expected timestamp $actual to be >= $before"),
+        Result.assert(actual <= after).log(s"Expected timestamp $actual to be <= $after"),
+      )
+    )
+  }
+}


### PR DESCRIPTION
# Close #582: [`refined4s-core`] Make `UuidV7Generator` effect-polymorphic with higher-kinded type parameter `F[*]`

- Parameterize `UuidV7Generator` with `F[*]` so `generate()` returns `F[UuidV7]` instead of `UuidV7.Type`, enabling use with different effect types (e.g. `Identity` for synchronous, `IO` for cats-effect)
- Extract `RandomSource`, `TimestampSource` from `UuidV7Generator` companion and parameterize them with `F[*]`, moving them to `refined4s.internal.types`
- Add internal abstractions in `refined4s.internal.types`: `Identity` type alias, `Bind[F[*]]` typeclass with `Identity` instance, and `StateRef[F[*], A]` trait with `AtomicLongStateRef` implementation
- `newGenerator` now requires `Bind[F]` context bound and takes an additional `StateRef[F, Long]` parameter
- `DefaultUuidV7Generator` now uses monadic composition (for-comprehension) via `Bind` instead of direct imperative style
- `globalDefaultGenerator` type is now `UuidV7Generator[Identity]`