### PR TITLE
Close #595: Update Scala 2 for `refined-compat-scala2` modules

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -264,7 +264,7 @@ lazy val chimneyNative = chimney.native.settings(nativeSettings)
 
 lazy val refinedCompatScala2       = module("refined-compat-scala2", crossProject(JVMPlatform, JSPlatform, NativePlatform))
   .settings(
-    crossScalaVersions := List("2.12.18", "2.13.16")
+    crossScalaVersions := List("2.12.19", "2.13.17")
   )
 lazy val refinedCompatScala2Jvm    = refinedCompatScala2
   .jvm

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,6 +1,6 @@
 addSbtPlugin("com.github.sbt" % "sbt-ci-release" % "1.11.2")
 
-addSbtPlugin("org.wartremover" % "sbt-wartremover" % "3.4.0")
+addSbtPlugin("org.wartremover" % "sbt-wartremover" % "3.5.0")
 
 addSbtPlugin("ch.epfl.scala" % "sbt-scalafix"  % "0.14.3")
 addSbtPlugin("org.scalameta" % "sbt-scalafmt"  % "2.5.5")
@@ -12,7 +12,7 @@ addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject" % "1.3.2")
 addSbtPlugin("org.scala-native"   % "sbt-scala-native"              % "0.5.10")
 addSbtPlugin("org.portable-scala" % "sbt-scala-native-crossproject" % "1.3.2")
 
-val sbtDevOopsVersion = "3.2.1"
+val sbtDevOopsVersion = "3.3.2"
 addSbtPlugin("io.kevinlee" % "sbt-devoops-scala"     % sbtDevOopsVersion)
 addSbtPlugin("io.kevinlee" % "sbt-devoops-sbt-extra" % sbtDevOopsVersion)
 addSbtPlugin("io.kevinlee" % "sbt-devoops-github"    % sbtDevOopsVersion)


### PR DESCRIPTION
## Close #595: Update Scala 2 for `refined-compat-scala2` modules

- `scala` 2: `2.12.18` => `2.12.19`, `2.13.16` => `2.13.17`

Also,
- `sbt-wartremover`: `3.4.0` => `3.5.0`
- `sbt-devoops`: `3.2.1` => `3.3.2`