### PR TITLE
refined4s v1.17.0

### DIFF
--- a/changelogs/1.17.0.md
+++ b/changelogs/1.17.0.md
@@ -1,0 +1,56 @@
+## [1.17.0](https://github.com/kevin-lee/refined4s/issues?q=is%3Aissue%20is%3Aclosed%20-label%3Ainvalid%20-label%3Awontfix%20milestone%3Am41) - 2026-06-22
+
+## Internal Housekeeping
+
+### Update doobie 1 to `1.0.0-RC11` (#589)
+
+### Update Scala.js to `1.20.2` (#591)
+
+### Update Scala Native to `0.5.10` (#593)
+
+### Update Scala 2 for `refined-compat-scala2` modules (#595)
+
+- `2.12.18` => `2.12.19`
+- `2.13.16` => `2.13.17`
+
+### Hide `UuidV7` until it's ready for use. (#597)
+
+It should include:
+* `UuidV7`
+* `UuidV7Instances`
+* `UuidV7Generator`
+
+### Update `extras` from `0.50.1` to `0.52.0` (#599)
+
+***
+
+## Changes
+
+### `java.net.URL` constructor is deprecated in newer Java versions (Java 20+) so it should be updated (#571)
+
+`java.net.URL` constructor is deprecated in newer Java versions (Java 20+), so it should be updated.
+
+`Url` validation in `networkCompat` uses `new java.net.URL(urlString)`, and it has to be updated.
+
+#### Problem
+The JVM implementation of `Url` in `networkCompat` was using `new URL(url)` for validation and conversion. However, the `java.net.URL` constructor is deprecated in newer Java versions (Java 20+). In addition, using `new URL(url)` directly can lead to inconsistent behavior compared to parsing a `URI` first and then converting it to a `URL`, which is a recommended way to construct a `URL` instance in the newer Java versions.
+
+#### Solution
+Replace the direct usage of the `java.net.URL` constructor with `java.net.URI(url).toURL` (as recommended) across the `networkCompat` for JVM.
+
+Specifically:
+- In `validate(url: String)`: Changed `new URL(url)` to `new URI(url).toURL`.
+- In `isValidateUrl` macro: Changed `new java.net.URL(urlStr)` to `new java.net.URI(urlStr).toURL`.
+- In the `Url` extension methods:
+  - `toURI`: Changed from `toURL.toURI` to `new URI(url.value)`.
+  - `toURL`: Changed from `new URL(url.value)` to `toURI.toURL`.
+  - `toUri`: Changed from `Uri(toURL.toURI)` to `Uri(toURI)`.
+
+This ensures that `Url` parsing and validation are consistent with modern Java best practices by using `URI` as the primary parsing mechanism before converting to `URL`.
+***
+
+## ~~New Features~~
+
+### ~~Add support for `UuidV7` (RFC 9562) (#572)~~
+
+> **NOTE: This feature is temporarily hidden and unusable as it is not ready for production use.**


### PR DESCRIPTION
# refined4s v1.17.0
## [1.17.0](https://github.com/kevin-lee/refined4s/issues?q=is%3Aissue%20is%3Aclosed%20-label%3Ainvalid%20-label%3Awontfix%20milestone%3Am41) - 2026-06-22

## Internal Housekeeping

### Update doobie 1 to `1.0.0-RC11` (#589)

### Update Scala.js to `1.20.2` (#591)

### Update Scala Native to `0.5.10` (#593)

### Update Scala 2 for `refined-compat-scala2` modules (#595)

- `2.12.18` => `2.12.19`
- `2.13.16` => `2.13.17`

### Hide `UuidV7` until it's ready for use. (#597)

It should include:
* `UuidV7`
* `UuidV7Instances`
* `UuidV7Generator`

### Update `extras` from `0.50.1` to `0.52.0` (#599)

***

## Changes

### `java.net.URL` constructor is deprecated in newer Java versions (Java 20+) so it should be updated (#571)

`java.net.URL` constructor is deprecated in newer Java versions (Java 20+), so it should be updated.

`Url` validation in `networkCompat` uses `new java.net.URL(urlString)`, and it has to be updated.

#### Problem
The JVM implementation of `Url` in `networkCompat` was using `new URL(url)` for validation and conversion. However, the `java.net.URL` constructor is deprecated in newer Java versions (Java 20+). In addition, using `new URL(url)` directly can lead to inconsistent behavior compared to parsing a `URI` first and then converting it to a `URL`, which is a recommended way to construct a `URL` instance in the newer Java versions.

#### Solution
Replace the direct usage of the `java.net.URL` constructor with `java.net.URI(url).toURL` (as recommended) across the `networkCompat` for JVM.

Specifically:
- In `validate(url: String)`: Changed `new URL(url)` to `new URI(url).toURL`.
- In `isValidateUrl` macro: Changed `new java.net.URL(urlStr)` to `new java.net.URI(urlStr).toURL`.
- In the `Url` extension methods:
  - `toURI`: Changed from `toURL.toURI` to `new URI(url.value)`.
  - `toURL`: Changed from `new URL(url.value)` to `toURI.toURL`.
  - `toUri`: Changed from `Uri(toURL.toURI)` to `Uri(toURI)`.

This ensures that `Url` parsing and validation are consistent with modern Java best practices by using `URI` as the primary parsing mechanism before converting to `URL`.
***

## ~~New Features~~

### ~~Add support for `UuidV7` (RFC 9562) (#572)~~

> **NOTE: This feature is temporarily hidden and unusable as it is not ready for production use.**
