### PR TITLE
Close #603: Update `orphan` from `0.5.0` to `0.7.0` and `extras` from `0.52.0` to `0.53.0`

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -364,7 +364,7 @@ lazy val props =
     val HedgehogVersion      = "0.13.0"
     val HedgehogExtraVersion = "0.15.0"
 
-    val ExtrasVersion = "0.52.0"
+    val ExtrasVersion = "0.53.0"
 
     val CatsVersion = "2.13.0"
 
@@ -382,7 +382,7 @@ lazy val props =
 
     val LogbackVersion = "1.5.6"
 
-    val OrphanVersion = "0.5.0"
+    val OrphanVersion = "0.7.0"
 
     val KittensVersion = "3.5.0"
 

--- a/modules/refined4s-core/js/src/main/scala/refined4s/types/networkCompat.scala
+++ b/modules/refined4s-core/js/src/main/scala/refined4s/types/networkCompat.scala
@@ -6,7 +6,6 @@ import refined4s.types.network.Uri
 
 import scala.quoted.*
 import java.net.URI
-import scala.quoted.{Expr, Quotes}
 import scala.util.control.NonFatal
 
 /** @author Kevin Lee

--- a/modules/refined4s-core/jvm/src/main/scala/refined4s/types/networkCompat.scala
+++ b/modules/refined4s-core/jvm/src/main/scala/refined4s/types/networkCompat.scala
@@ -6,7 +6,6 @@ import refined4s.types.network.Uri
 
 import scala.quoted.*
 import java.net.{URI, URL}
-import scala.quoted.{Expr, Quotes}
 import scala.util.control.NonFatal
 
 /** @author Kevin Lee

--- a/modules/refined4s-core/native/src/main/scala/refined4s/types/networkCompat.scala
+++ b/modules/refined4s-core/native/src/main/scala/refined4s/types/networkCompat.scala
@@ -6,7 +6,6 @@ import refined4s.types.network.Uri
 
 import scala.quoted.*
 import java.net.URI
-import scala.quoted.{Expr, Quotes}
 import scala.util.control.NonFatal
 
 /** @author Kevin Lee

--- a/modules/refined4s-core/shared/src/main/scala/refined4s/internal/NumericValidator.scala
+++ b/modules/refined4s-core/shared/src/main/scala/refined4s/internal/NumericValidator.scala
@@ -151,6 +151,7 @@ object NumericValidator {
     }
   }
 
+  @SuppressWarnings(Array("org.wartremover.warts.Equals"))
   def equivImpl[A: Type](
     expr1: Expr[A],
     expr2: Expr[A],

--- a/modules/refined4s-core/shared/src/main/scala/refined4s/internal/UuidV7Macros.scala
+++ b/modules/refined4s-core/shared/src/main/scala/refined4s/internal/UuidV7Macros.scala
@@ -23,6 +23,7 @@ object UuidV7Macros {
       case Inlined(_, _, Literal(StringConstant(uuidStr))) =>
         try {
           val uuid          = java.util.UUID.fromString(uuidStr)
+          @SuppressWarnings(Array("org.wartremover.warts.Equals"))
           val isValidUuidV7 = uuid.version() == 7 && uuid.variant() == 2
           if isValidUuidV7 then ()
           else
@@ -102,6 +103,7 @@ object UuidV7Macros {
       case Literal(StringConstant(uuidStr)) =>
         try {
           val uuid          = java.util.UUID.fromString(uuidStr)
+          @SuppressWarnings(Array("org.wartremover.warts.Equals"))
           val isValidUuidV7 = uuid.version() == 7 && uuid.variant() == 2
           if isValidUuidV7 then ()
           else

--- a/modules/refined4s-core/shared/src/test/scala/refined4s/CanBeOrderedSpec.scala
+++ b/modules/refined4s-core/shared/src/test/scala/refined4s/CanBeOrderedSpec.scala
@@ -12,6 +12,7 @@ object CanBeOrderedSpec extends Properties {
     property("test Ordered from CanBeOrdered", testOrdered),
   )
 
+  @SuppressWarnings(Array("org.wartremover.warts.Equals"))
   def testOrdering: Property =
     for {
       n1 <- Gen.int(Range.linear(Int.MinValue, Int.MaxValue)).log("n1")
@@ -24,6 +25,7 @@ object CanBeOrderedSpec extends Properties {
       Result.diff(input1, input2)(Ordering[MyNum].compare(_, _) == expected)
     }
 
+  @SuppressWarnings(Array("org.wartremover.warts.Equals"))
   def testOrdered: Property =
     for {
       n1 <- Gen.int(Range.linear(Int.MinValue, Int.MaxValue)).log("n1")

--- a/modules/refined4s-doobie-ce2/shared/src/test/scala/refined4s/modules/doobie/derivation/generic/autoSpec.scala
+++ b/modules/refined4s-doobie-ce2/shared/src/test/scala/refined4s/modules/doobie/derivation/generic/autoSpec.scala
@@ -11,7 +11,6 @@ import hedgehog.runner.*
 import refined4s.*
 import refined4s.modules.doobie.derivation.generic.auto.given
 import refined4s.modules.doobie.derivation.{Example, Gens}
-import refined4s.types.all.*
 
 import java.util.concurrent.atomic.AtomicInteger
 

--- a/modules/test-refined4s-core-without-cats/shared/src/test/scala/refined4s/types/stringsSpec.scala
+++ b/modules/test-refined4s-core-without-cats/shared/src/test/scala/refined4s/types/stringsSpec.scala
@@ -111,6 +111,7 @@ object stringsSpec extends Properties {
         actual ==== expected
       }
 
+    @SuppressWarnings(Array("org.wartremover.warts.Equals"))
     def testOrdering: Property =
       for {
         s1 <- Gen.string(Gen.alphaNum, Range.linear(1, 10)).log("s1")
@@ -122,6 +123,7 @@ object stringsSpec extends Properties {
         Result.diff(input1, input2)(Ordering[NonEmptyString].compare(_, _) == expected)
       }
 
+    @SuppressWarnings(Array("org.wartremover.warts.Equals"))
     def testOrdered: Property =
       for {
         s1 <- Gen.string(Gen.alphaNum, Range.linear(1, 10)).log("s1")
@@ -391,6 +393,7 @@ object stringsSpec extends Properties {
         actual ==== expected
       }
 
+    @SuppressWarnings(Array("org.wartremover.warts.Equals"))
     def testOrdering: Property =
       for {
         s1 <- Gen.string(hedgehog.extra.Gens.genNonWhitespaceChar, Range.linear(1, 10)).log("s1")
@@ -402,6 +405,7 @@ object stringsSpec extends Properties {
         Result.diff(input1, input2)(Ordering[NonBlankString].compare(_, _) == expected)
       }
 
+    @SuppressWarnings(Array("org.wartremover.warts.Equals"))
     def testOrdered: Property =
       for {
         s1 <- Gen.string(hedgehog.extra.Gens.genNonWhitespaceChar, Range.linear(1, 10)).log("s1")
@@ -638,6 +642,7 @@ object stringsSpec extends Properties {
         actual ==== expected
       }
 
+    @SuppressWarnings(Array("org.wartremover.warts.Equals"))
     def testOrdering: Property =
       for {
         uuid1 <- Gen.constant(UUID.randomUUID()).log("uuid1")
@@ -651,6 +656,7 @@ object stringsSpec extends Properties {
         Result.diff(input1, input2)(Ordering[Uuid].compare(_, _) == expected)
       }
 
+    @SuppressWarnings(Array("org.wartremover.warts.Equals"))
     def testOrdered: Property =
       for {
         uuid1 <- Gen.constant(UUID.randomUUID()).log("uuid1")


### PR DESCRIPTION
## Close #603: Update `orphan` from `0.5.0` to `0.7.0` and `extras` from `0.52.0` to `0.53.0`

`orphan` `0.7.0` and `extras` `0.53.0` address a deprecation issue in Scala 3.8.4 and potential compilation failures in Scala 3.10 due to inaccessible orphan given instances.

https://github.com/kevin-lee/orphan/issues/96

***
Clean up unused imports and suppress WartRemover `Equals` warnings

- Add `@SuppressWarnings(Array("org.wartremover.warts.Equals"))` to `NumericValidator`, `UuidV7Macros`, `stringsSpec`, and `CanBeOrderedSpec` to resolve WartRemover warnings on equality checks
- Remove unused `scala.quoted.{Expr, Quotes}` imports from `networkCompat.scala` across the `js`, `jvm`, and `native` modules
- Remove unused `refined4s.types.all.*` import from `autoSpec.scala` in the `refined4s-doobie-ce2` module