### PR TITLE
refined4s v1.18.0

### DIFF
--- a/changelogs/1.18.0.md
+++ b/changelogs/1.18.0.md
@@ -1,0 +1,8 @@
+## [1.18.0](https://github.com/kevin-lee/refined4s/issues?q=is%3Aissue%20is%3Aclosed%20-label%3Ainvalid%20-label%3Awontfix%20milestone%3Am42) - 2026-06-23
+
+## Internal Housekeeping
+
+* Update `orphan` from `0.5.0` to `0.7.0` and `extras` from `0.52.0` to `0.53.0` (#603)
+  * `orphan` `0.7.0` and `extras` `0.53.0` address a deprecation issue in Scala 3.8.4 and potential compilation failures in Scala 3.10 due to inaccessible orphan given instances.
+
+    kevin-lee/orphan/issues/96


### PR DESCRIPTION
# refined4s v1.18.0
## [1.18.0](https://github.com/kevin-lee/refined4s/issues?q=is%3Aissue%20is%3Aclosed%20-label%3Ainvalid%20-label%3Awontfix%20milestone%3Am42) - 2026-06-23

## Internal Housekeeping

* Update `orphan` from `0.5.0` to `0.7.0` and `extras` from `0.52.0` to `0.53.0` (#603)
  * `orphan` `0.7.0` and `extras` `0.53.0` address a deprecation issue in Scala 3.8.4 and potential compilation failures in Scala 3.10 due to inaccessible orphan given instances.

    kevin-lee/orphan/issues/96
