### PR TITLE
refined4s v1.19.0

### DIFF
--- a/changelogs/1.19.0.md
+++ b/changelogs/1.19.0.md
@@ -1,0 +1,12 @@
+## [1.19.0](https://github.com/kevin-lee/refined4s/issues?q=is%3Aissue%20is%3Aclosed%20-label%3Ainvalid%20-label%3Awontfix%20milestone%3Am43) - 2026-06-28
+
+## Internal Housekeeping
+
+### Update `doobie` `1` from `1.0.0-RC11` to `1.0.0-RC12` (#606)
+
+### Update libraries (#608)
+
+- `hedgehog`: `0.13.0` => `0.13.1`
+- `hedgehog-extra`: `0.15.0` => `0.21.0`
+- `extras`: `0.53.0` => `0.54.0`
+- `effectie`: `2.3.0` => `2.4.0`


### PR DESCRIPTION
# refined4s v1.19.0
## [1.19.0](https://github.com/kevin-lee/refined4s/issues?q=is%3Aissue%20is%3Aclosed%20-label%3Ainvalid%20-label%3Awontfix%20milestone%3Am43) - 2026-06-28

## Internal Housekeeping

### Update `doobie` `1` from `1.0.0-RC11` to `1.0.0-RC12` (#606)

### Update libraries (#608)

- `hedgehog`: `0.13.0` => `0.13.1`
- `hedgehog-extra`: `0.15.0` => `0.21.0`
- `extras`: `0.53.0` => `0.54.0`
- `effectie`: `2.3.0` => `2.4.0`
