### PR TITLE
refined4s v1.20.0

### DIFF
--- a/changelogs/1.20.0.md
+++ b/changelogs/1.20.0.md
@@ -1,0 +1,7 @@
+## [1.20.0](https://github.com/kevin-lee/refined4s/issues?q=is%3Aissue%20is%3Aclosed%20-label%3Ainvalid%20-label%3Awontfix%20milestone%3Am44) - 2026-07-01
+
+## Internal Housekeeping
+
+### [`refined4s-doobie-ce3`] Update `doobie` `1` from `1.0.0-RC12` to `1.0.0-RC13` (#611)
+
+This release has breaking changes due to [doobie 1.0.0-RC13](https://github.com/typelevel/doobie/releases/tag/v1.0.0-RC13).

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,5 +1,7 @@
 addSbtPlugin("com.github.sbt" % "sbt-ci-release" % "1.11.2")
 
+addSbtPlugin("com.eed3si9n" % "sbt-salad-days" % "0.2.0")
+
 addSbtPlugin("org.wartremover" % "sbt-wartremover" % "3.5.0")
 
 addSbtPlugin("ch.epfl.scala" % "sbt-scalafix"  % "0.14.6")


### PR DESCRIPTION
# refined4s v1.20.0
## [1.20.0](https://github.com/kevin-lee/refined4s/issues?q=is%3Aissue%20is%3Aclosed%20-label%3Ainvalid%20-label%3Awontfix%20milestone%3Am44) - 2026-07-01

## Internal Housekeeping

### [`refined4s-doobie-ce3`] Update `doobie` `1` from `1.0.0-RC12` to `1.0.0-RC13` (#611)

This release has breaking changes due to [doobie 1.0.0-RC13](https://github.com/typelevel/doobie/releases/tag/v1.0.0-RC13).
